### PR TITLE
Tweaks for more runtime environments

### DIFF
--- a/util/ipgen/renderer.py
+++ b/util/ipgen/renderer.py
@@ -276,12 +276,17 @@ class IpBlockRenderer(IpTemplateRendererBase):
                        f'{output_dir_existing_bak}.')
                 raise TemplateRenderError(msg).with_traceback(e.__traceback__)
 
-        try:
-            os.rename(staging_dir, output_dir)
-        except OSError as e:
-            msg = (f'Cannot move staging directory {staging_dir} to '
-                   f'{output_dir}.')
-            raise TemplateRenderError(msg).with_traceback(e.__traceback__)
+        for _ in range(5):
+            try:
+                os.rename(staging_dir, output_dir)
+                break
+            except PermissionError:
+                # give time for windows antivirus to run so the directory isn't locked
+                time.sleep(0.2)
+            except OSError as e:
+                msg = (f'Cannot move staging directory {staging_dir} to '
+                    f'{output_dir}.')
+                raise TemplateRenderError(msg).with_traceback(e.__traceback__)
 
         if do_overwrite:
             try:

--- a/util/topgen.py
+++ b/util/topgen.py
@@ -1521,12 +1521,27 @@ def main():
                         default=False,
                         action="store_true",
                         help="Only return the list of blocks and exit.")
+    parser.add_argument("--clear-cache",
+                        default=False,
+                        action="store_true",
+                        help = "Clear any temporary files")
 
     args = parser.parse_args()
 
     # check combinations
     if args.top_ral:
         args.no_top = True
+
+    if args.clear_cache:
+        for path in Path.cwd().rglob('*'):
+            if path.name.startswith('.~'):
+                try:
+                    if path.is_file() or path.is_symlink():
+                        path.unlink()
+                    elif path.is_dir():
+                        shutil.rmtree(path)
+                except Exception as e:
+                    print(f"Failed to remove {path}: {e}")
 
     if (args.no_top or args.no_xbar or
             args.no_plic) and (args.top_only or args.xbar_only or


### PR DESCRIPTION
This PR introduces two features

1. Adds a convenience argument `--clear-caches ` that removes all the staging files starting with .~. This is helpful when debugging partially aborted runs.
2. Adds a retry on the portion of the script that moves the staging directories into output directories. On Windows, the antivirus will lock the directories shortly after they are populated, which can cause them to be inaccessible. This patch catches failures due to this and retries the move with a short pause to allow the AV to finish checking the directory so that it can me moved to its final location.
