### PR TITLE
[expo-cryptolib] [backport] [crypto] Clean up a few redundant HARDENED_TRYs.

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/p256.c
+++ b/sw/device/lib/crypto/impl/ecc/p256.c
@@ -92,10 +92,8 @@ static status_t p256_masked_scalar_write(const p256_masked_scalar_t *src,
   // cause an error.
   HARDENED_TRY(otbn_dmem_set(kMaskedScalarPaddingWords, 0,
                              share0_addr + kP256MaskedScalarShareBytes));
-  HARDENED_TRY(otbn_dmem_set(kMaskedScalarPaddingWords, 0,
-                             share1_addr + kP256MaskedScalarShareBytes));
-
-  return OTCRYPTO_OK;
+  return otbn_dmem_set(kMaskedScalarPaddingWords, 0,
+                       share1_addr + kP256MaskedScalarShareBytes);
 }
 
 status_t p256_keygen_start(void) {
@@ -138,9 +136,7 @@ status_t p256_keygen_finalize(p256_masked_scalar_t *private_key,
   HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarY, public_key->y));
 
   // Wipe DMEM.
-  HARDENED_TRY(otbn_dmem_sec_wipe());
-
-  return OTCRYPTO_OK;
+  return otbn_dmem_sec_wipe();
 }
 
 status_t p256_sideload_keygen_finalize(p256_point_t *public_key) {
@@ -152,9 +148,7 @@ status_t p256_sideload_keygen_finalize(p256_point_t *public_key) {
   HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarY, public_key->y));
 
   // Wipe DMEM.
-  HARDENED_TRY(otbn_dmem_sec_wipe());
-
-  return OTCRYPTO_OK;
+  return otbn_dmem_sec_wipe();
 }
 
 /**
@@ -227,9 +221,7 @@ status_t p256_ecdsa_sign_finalize(p256_ecdsa_signature_t *result) {
   HARDENED_TRY(otbn_dmem_read(kP256ScalarWords, kOtbnVarS, result->s));
 
   // Wipe DMEM.
-  HARDENED_TRY(otbn_dmem_sec_wipe());
-
-  return OTCRYPTO_OK;
+  return otbn_dmem_sec_wipe();
 }
 
 status_t p256_ecdsa_verify_start(const p256_ecdsa_signature_t *signature,
@@ -282,9 +274,7 @@ status_t p256_ecdsa_verify_finalize(const p256_ecdsa_signature_t *signature,
   *result = hardened_memeq(x_r, signature->r, kP256ScalarWords);
 
   // Wipe DMEM.
-  HARDENED_TRY(otbn_dmem_sec_wipe());
-
-  return OTCRYPTO_OK;
+  return otbn_dmem_sec_wipe();
 }
 
 status_t p256_ecdh_start(const p256_masked_scalar_t *private_key,
@@ -326,9 +316,7 @@ status_t p256_ecdh_finalize(p256_ecdh_shared_key_t *shared_key) {
   HARDENED_TRY(otbn_dmem_read(kP256CoordWords, kOtbnVarY, shared_key->share1));
 
   // Wipe DMEM.
-  HARDENED_TRY(otbn_dmem_sec_wipe());
-
-  return OTCRYPTO_OK;
+  return otbn_dmem_sec_wipe();
 }
 
 status_t p256_sideload_ecdh_start(const p256_point_t *public_key) {

--- a/sw/device/lib/crypto/impl/ecc/p384.c
+++ b/sw/device/lib/crypto/impl/ecc/p384.c
@@ -102,10 +102,8 @@ static status_t p384_masked_scalar_write(const p384_masked_scalar_t *src,
   // cause an error.
   HARDENED_TRY(otbn_dmem_set(kMaskedScalarPaddingWords, 0,
                              share0_addr + kP384MaskedScalarShareBytes));
-  HARDENED_TRY(otbn_dmem_set(kMaskedScalarPaddingWords, 0,
-                             share1_addr + kP384MaskedScalarShareBytes));
-
-  return OTCRYPTO_OK;
+  return otbn_dmem_set(kMaskedScalarPaddingWords, 0,
+                       share1_addr + kP384MaskedScalarShareBytes);
 }
 
 /**
@@ -179,9 +177,7 @@ status_t p384_keygen_finalize(p384_masked_scalar_t *private_key,
   HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarY, public_key->y));
 
   // Wipe DMEM.
-  HARDENED_TRY(otbn_dmem_sec_wipe());
-
-  return OTCRYPTO_OK;
+  return otbn_dmem_sec_wipe();
 }
 
 status_t p384_sideload_keygen_start(void) {
@@ -205,9 +201,7 @@ status_t p384_sideload_keygen_finalize(p384_point_t *public_key) {
   HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarY, public_key->y));
 
   // Wipe DMEM.
-  HARDENED_TRY(otbn_dmem_sec_wipe());
-
-  return OTCRYPTO_OK;
+  return otbn_dmem_sec_wipe();
 }
 
 status_t p384_ecdsa_sign_start(const uint32_t digest[kP384ScalarWords],
@@ -256,9 +250,7 @@ status_t p384_ecdsa_sign_finalize(p384_ecdsa_signature_t *result) {
   HARDENED_TRY(otbn_dmem_read(kP384ScalarWords, kOtbnVarS, result->s));
 
   // Wipe DMEM.
-  HARDENED_TRY(otbn_dmem_sec_wipe());
-
-  return OTCRYPTO_OK;
+  return otbn_dmem_sec_wipe();
 }
 
 status_t p384_ecdsa_verify_start(const p384_ecdsa_signature_t *signature,
@@ -308,9 +300,7 @@ status_t p384_ecdsa_verify_finalize(const p384_ecdsa_signature_t *signature,
   *result = hardened_memeq(x_r, signature->r, kP384ScalarWords);
 
   // Wipe DMEM.
-  HARDENED_TRY(otbn_dmem_sec_wipe());
-
-  return OTCRYPTO_OK;
+  return otbn_dmem_sec_wipe();
 }
 
 status_t p384_ecdh_start(const p384_masked_scalar_t *private_key,
@@ -350,9 +340,7 @@ status_t p384_ecdh_finalize(p384_ecdh_shared_key_t *shared_key) {
   HARDENED_TRY(otbn_dmem_read(kP384CoordWords, kOtbnVarY, shared_key->share1));
 
   // Wipe DMEM.
-  HARDENED_TRY(otbn_dmem_sec_wipe());
-
-  return OTCRYPTO_OK;
+  return otbn_dmem_sec_wipe();
 }
 
 status_t p384_sideload_ecdh_start(const p384_point_t *public_key) {

--- a/sw/device/lib/crypto/impl/hkdf.c
+++ b/sw/device/lib/crypto/impl/hkdf.c
@@ -111,9 +111,7 @@ static status_t hkdf_check_prk(size_t digest_words,
 
   // Ensure that the PRK is a symmetric key masked with XOR and is not supposed
   // to be hardware-backed.
-  HARDENED_TRY(keyblob_ensure_xor_masked(prk->config));
-
-  return OTCRYPTO_OK;
+  return keyblob_ensure_xor_masked(prk->config);
 }
 
 otcrypto_status_t otcrypto_hkdf_extract(const otcrypto_blinded_key_t ikm,

--- a/sw/device/lib/crypto/impl/hmac.c
+++ b/sw/device/lib/crypto/impl/hmac.c
@@ -245,11 +245,8 @@ otcrypto_status_t otcrypto_hmac_update(
     return OTCRYPTO_BAD_ARGS;
   }
 
-  hmac_ctx_t hmac_ctx;
-  hmac_ctx_restore(ctx, &hmac_ctx);
-  HARDENED_TRY(hmac_update(&hmac_ctx, input_message.data, input_message.len));
-  hmac_ctx_save(ctx, &hmac_ctx);
-  return OTCRYPTO_OK;
+  hmac_ctx_t *hmac_ctx = (hmac_ctx_t *)ctx->data;
+  return hmac_update(hmac_ctx, input_message.data, input_message.len);
 }
 
 otcrypto_status_t otcrypto_hmac_final(otcrypto_hmac_context_t *const ctx,


### PR DESCRIPTION
Originally from https://github.com/zerorisc/expo-cryptolib/pull/5.

Backport to earlgrey_1.0.0 of an upstream PR that was merged into master (#27269).

Tested locally with cryptolib_tests.sh from https://github.com/zerorisc/expo-cryptolib/pull/3