### PR TITLE
[expo-cryptolib] [backport] [crypto] Modify p384_{sign,scalar_mult}.s to comply with OTBN SCA guidelines in docs

### DIFF
--- a/sw/otbn/crypto/p384_scalar_mult.s
+++ b/sw/otbn/crypto/p384_scalar_mult.s
@@ -124,6 +124,7 @@ p384_scalar_mult:
   bn.subb   w1, w26, w19
   bn.sel    w25, w6, w8, FG0.C
   bn.sel    w26, w7, w9, FG0.C
+  bn.sub    w31, w31, w31  /* dummy instruction to clear flags */
 
   /* Store mask to dmem for later use.
      y coordinate is not required afterwards and therefore can be used

--- a/sw/otbn/crypto/p384_sign.s
+++ b/sw/otbn/crypto/p384_sign.s
@@ -119,8 +119,15 @@ p384_sign:
   bn.rshi   w4, w31, w4 >> 129
 
   /* Add 1 to get a 128-bit nonzero scalar for masking.
-     w4 <= w4 + 1 = alpha */
+     w4 <= w4 + 1 = alpha
+
+     N.B. The dummy instruction below serves to clear flags revealing
+     information regarding the masking value in w4, as well as to separate
+     accesses of the multiplicative masking value in w4 from accesses below to
+     the value it masks. */
   bn.addi   w4, w4, 1
+  bn.mov    w16, w4      /* prepare for p384_mulmod488x128_n call below */
+  bn.addi   w31, w31, 0  /* dummy instruction to clear flags */
 
   /* load 1st share k0 from dmem
      [w11,w10] <= k0 = dmem[dptr_k0] */
@@ -128,46 +135,49 @@ p384_sign:
   bn.lid    x2++, 0(x17)
   bn.lid    x2++, 32(x17)
 
-  /* [w26,w25] <= ([w11,w10] * w4) mod n = (k0 * alpha) mod n */
-  bn.mov    w16, w4
+  /*  [w26,w25] <= ([w11,w10] * w4) mod n = (k0 * alpha) mod n */
   jal       x1, p384_mulmod448x128_n
   bn.mov    w25, w16
   bn.mov    w26, w17
 
   /* load 2nd share k1 from dmem
+
+     N.B. We intentionally separate the accesses to w4 and [w11,w10] below so as
+     to prevent transient side channel leakage.
+
+     The same pattern repeats below.
+
      [w11,w10] <= k1 = dmem[dptr_k1] */
+  bn.mov    w16, w4      /* prepare for next p384_mulmod488x128_n call below */
   li        x2, 10
   bn.lid    x2++, 0(x19)
   bn.lid    x2++, 32(x19)
 
   /* [w28,w27] <= ([w11,w10] * w4) mod n = (k1 * alpha) mod n */
-  bn.mov    w16, w4
   jal       x1, p384_mulmod448x128_n
   bn.mov    w27, w16
   bn.mov    w28, w17
 
-  /* Multiplicative masking of shares d0 and d1 */
-
   /* load 1st share d0 from dmem
      [w11,w10] <= d0 = dmem[dptr_d0] */
+  bn.mov    w16, w4      /* prepare for next p384_mulmod488x128_n call below */
   li        x2, 10
   bn.lid    x2++, 0(x4)
   bn.lid    x2++, 32(x4)
 
   /* [w7,w6] <= ([w11,w10] * w4) mod n = (d0 * alpha) mod n */
-  bn.mov    w16, w4
   jal       x1, p384_mulmod448x128_n
   bn.mov    w6, w16
   bn.mov    w7, w17
 
   /* load 2nd share d1 from dmem
      [w11,w10] <= d1 = dmem[dptr_d1] */
+  bn.mov    w16, w4      /* prepare for next p384_mulmod488x128_n call below */
   li        x2, 10
   bn.lid    x2++, 0(x5)
   bn.lid    x2++, 32(x5)
 
   /* [w9,w8] <= ([w11,w10] * w4) mod n = (d1 * alpha) mod n */
-  bn.mov    w16, w4
   jal       x1, p384_mulmod448x128_n
   bn.mov    w8, w16
   bn.mov    w9, w17
@@ -176,12 +186,12 @@ p384_sign:
 
   /* load message from dmem
      [w11, w10] <= msg = dmem[dptr_msg] */
+  bn.mov    w16, w4      /* prepare for next p384_mulmod488x128_n call below */
   li        x2, 10
   bn.lid    x2++, 0(x6)
   bn.lid    x2++, 32(x6)
 
   /* [w1,w0] <= ([w11,w10] * w4) mod n = (msg * alpha) mod n */
-  bn.mov    w16, w4
   jal       x1, p384_mulmod448x128_n
   bn.mov    w0, w16
   bn.mov    w1, w17
@@ -235,15 +245,21 @@ p384_sign:
   bn.mov    w17, w3
   jal       x1, p384_mulmod_n
 
-  /* [w28, w27] <= s' = k^(-1)*msg + k^(-1)*r*d  = [w17, w16] + [w5, w4]*/
-  bn.add    w27, w16, w4
-  bn.addc   w28, w17, w5
+  /* [w26, w25] <= s' = k^(-1)*msg + k^(-1)*r*d  = [w17, w16] + [w5, w4]
+
+     N.B. These values are intentionally stored away from [w28,w27] in order
+     to prevent the bn.sel instructions below from sharing a source with its
+     destination, as the carry bit used in the reduction could leak information
+     about d given msg and r. */
+  bn.add    w25, w16, w4
+  bn.addc   w26, w17, w5
 
   /* reduce s: [w28, w27] <= s <= s' mod n = [w28, w27] mod [w13, w12] */
-  bn.sub    w10, w27, w12
-  bn.subb   w11, w28, w13
-  bn.sel    w27, w27, w10, C
-  bn.sel    w28, w28, w11, C
+  bn.sub    w10, w25, w12
+  bn.subb   w11, w26, w13
+  bn.sel    w27, w25, w10, C
+  bn.sel    w28, w26, w11, C
+  bn.sub    w31, w31, w31  /* dummy instruction to clear flags */
 
   /* store s of signature in dmem: dmem[dptr_s] <= s = [w28, w27] */
   li        x2, 27


### PR DESCRIPTION
Originally from https://github.com/zerorisc/expo-cryptolib/pull/7.

Backport to earlgrey_1.0.0 of an upstream PR that was merged into master (#27319).

Tested locally with cryptolib_tests.sh from https://github.com/zerorisc/expo-cryptolib/pull/3