### PR TITLE
[expo-cryptolib] [crypto] Lay some groundwork for cryptolib driver hardening.

### DIFF
--- a/sw/device/lib/base/hardened_memory.h
+++ b/sw/device/lib/base/hardened_memory.h
@@ -1,3 +1,7 @@
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
@@ -89,6 +93,28 @@ void hardened_memshred(uint32_t *dest, size_t word_len);
  */
 hardened_bool_t hardened_memeq(const uint32_t *lhs, const uint32_t *rhs,
                                size_t word_len);
+
+/**
+ * Writes 32-bit words into an MMIO location.
+ *
+ * Similar to `hardened_memcpy`, but treats the destination as volatile.
+ *
+ * @param dest The destination of the copy (MMIO address).
+ * @param src The source of the copy.
+ * @param word_len The number of words to copy.
+ */
+void hardened_mmio_write(uint32_t dest, const uint32_t *src, size_t word_len);
+
+/**
+ * Reads 32-bit words from an MMIO location.
+ *
+ * Similar to `hardened_memcpy`, but treats the destination as volatile.
+ *
+ * @param dest The destination of the copy.
+ * @param src The source of the copy (MMIO address).
+ * @param word_len The number of words to copy.
+ */
+void hardened_mmio_read(uint32_t *dest, uint32_t src, size_t word_len);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/sw/device/lib/crypto/impl/status.h
+++ b/sw/device/lib/crypto/impl/status.h
@@ -66,7 +66,6 @@ extern "C" {
  * not match the expected hardened value.
  *
  * @param expr_ An expression that evaluates to a `status_t`.
- * @return The enclosed OK value.
  */
 #define HARDENED_TRY(expr_)                                             \
   do {                                                                  \
@@ -76,7 +75,6 @@ extern "C" {
           .value = (int32_t)(OT_UNSIGNED(status_.value) | 0x80000000)}; \
     }                                                                   \
     HARDENED_CHECK_EQ(status_.value, kHardenedBoolTrue);                \
-    status_.value;                                                      \
   } while (false)
 
 #else  // OT_DISABLE_HARDENING
@@ -88,7 +86,6 @@ extern "C" {
  * control-flow countermeasures.
  *
  * @param expr_ An expression that evaluates to a `status_t`.
- * @return The enclosed OK value.
  */
 #define HARDENED_TRY(expr_)                                             \
   do {                                                                  \
@@ -97,7 +94,6 @@ extern "C" {
       return (status_t){                                                \
           .value = (int32_t)(OT_UNSIGNED(status_.value) | 0x80000000)}; \
     }                                                                   \
-    status_.value;                                                      \
   } while (false)
 
 #endif  // OT_DISABLE_HARDENING


### PR DESCRIPTION
Originally from https://github.com/zerorisc/expo-cryptolib/pull/8.

The first commit adds variants of `hardened_memcpy` that are specialized to the case where either the destination or the source is MMIO. This makes it easier to do heavily obfuscated writes for e.g. key registers. It's not heavily commented because it's based on `hardened_memcpy` in the same file, which has a note saying all the functions have a similar structure and the verbose comments there apply to all of them.

The second commit is a really minor cleanup that removes the ability to use `HARDENED_TRY` as an expression, just to silence some warnings at zero cost. There was some discussion upstream about doing this and renaming it to `HARDENED_RETURN_IF_ERROR` like in the ROM, but from my time working on the ROM code I found this super-long name really hurt readability, so I chose to just leave it as `HARDENED_TRY`.