### PR TITLE
[expo-cryptolib] [crypto] Harden entropy driver.

### DIFF
--- a/sw/device/lib/crypto/drivers/entropy.h
+++ b/sw/device/lib/crypto/drivers/entropy.h
@@ -52,31 +52,6 @@ typedef struct entropy_seed_material {
 } entropy_seed_material_t;
 
 /**
- * This enum type contains all the different command types for
- * csrng_send_app_cmd().
- */
-typedef enum entropy_csrng_send_app_cmd_type {
-  /**
-   * Command issued directly to CSRNG.
-   */
-  kEntropyCsrngSendAppCmdTypeCsrng,
-  /**
-   * Command issued to CSRNG via the SW_CMD_REQ register of the EDN.
-   */
-  kEntropyCsrngSendAppCmdTypeEdnSw,
-  /**
-   * Command issued to CSRNG via the GENERATE_CMD register of the EDN.
-   * This type of command will be used in the auto mode of the EDN.
-   */
-  kEntropyCsrngSendAppCmdTypeEdnGen,
-  /**
-   * Command issued to CSRNG via the RESEED_CMD register of the EDN.
-   * This type of command will be used in the auto mode of the EDN.
-   */
-  kEntropyCsrngSendAppCmdTypeEdnRes,
-} entropy_csrng_send_app_cmd_type_t;
-
-/**
  * Constant empty seed material for the entropy complex.
  *
  * This is convenient to have available for some implementations.

--- a/sw/device/lib/crypto/impl/drbg.c
+++ b/sw/device/lib/crypto/impl/drbg.c
@@ -185,10 +185,8 @@ static otcrypto_status_t generate(hardened_bool_t fips_check,
 
   entropy_seed_material_t seed_material;
   seed_material_construct(additional_input, &seed_material);
-  HARDENED_TRY(entropy_csrng_generate(&seed_material, drbg_output.data,
-                                      drbg_output.len, fips_check));
-
-  return OTCRYPTO_OK;
+  return entropy_csrng_generate(&seed_material, drbg_output.data,
+                                drbg_output.len, fips_check);
 }
 
 otcrypto_status_t otcrypto_drbg_generate(


### PR DESCRIPTION
Originally from https://github.com/zerorisc/expo-cryptolib/pull/9.

Hardening pass through the entropy driver.

- Give enums high-Hamming weight values instead of the automatically assigned 1, 2, 3...
- In a few highly sensitive functions, construct the "OK" return value gradually throughout the computation so that if a fault attacker were to skip steps, the return value would likely be different.
- Add some `HARDENED_CHECK_*` redundant checks as FI mitigations.

Most of the hardening is FI focused rather than SCA, partially because SCA-hardened code will generally just call the entropy driver multiple times to get independent shares.

I also made a few simplifying changes while I was poking around:

- There's only one default config, so there's no need for a table and an ID enum to select within the table,
- Previously, `send_app_cmd` took a `check_completion` argument that was actually fully determined by the command type; I removed this argument and decide based on the command type when to check.
- Moved the `entropy_csrng_send_app_cmd_type` struct out of the header and into the `.c`, since it's not used anywhere else and clutters the header unnecessarily.

