### PR TITLE
[expo-cryptolib] [crypto] Modify p384_{keygen,keygen_from_seed}.s to comply with OTBN SCA guidelines in docs

### DIFF
--- a/sw/otbn/crypto/p384_keygen.s
+++ b/sw/otbn/crypto/p384_keygen.s
@@ -125,8 +125,8 @@ p384_random_scalar:
   bn.mov    w10, w6
   bn.mov    w11, w7
   jal       x1, p384_mulmod448x128_n
-  bn.mov    w16, w4      /* prepare for next p384_mulmod488x128_n call below */
   bn.mov    w25, w16
+  bn.mov    w16, w4      /* prepare for next p384_mulmod488x128_n call below */
   bn.mov    w26, w17
 
   /* [w28,w27] <= ([w9,w8] * w4) mod n = (seed1 * x) mod n */

--- a/sw/otbn/crypto/p384_keygen.s
+++ b/sw/otbn/crypto/p384_keygen.s
@@ -1,6 +1,11 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
 /* Copyright lowRISC contributors (OpenTitan project). */
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
+
 /*
  *   This library contains:
  *   - P-384 specific routines to generate random values for keys and scalars
@@ -75,17 +80,24 @@ p384_random_scalar:
   bn.wsrr   w5, URND
   bn.xor    w9, w9, w5
 
-  /* Shift bits to get 448-bit seeds.
-     seed0 = [w7,w6], seed1 = [w9,w8]
+  /* Shift seed0 bits to get 448-bit seeds.
+     seed0 = [w7,w6]
      w7 <= w7[192:0]
-     w9 <= w9[192:0] */
+
+     N.B. This has been intentionally separated from the shift of the seed1
+     bits below in order to avoid transient side channel leakage from w7 and w9
+     interacting in the ALU datapath. */
   bn.rshi   w7, w31, w7 >> 64
-  bn.rshi   w9, w31, w9 >> 64
 
   /* Compute Solinas constant k for modulus n (we know it is only 191 bits, so
      no need to compute the high part):
      w14 <= 2^256 - n[255:0] = (2^384 - n) mod (2^256) = 2^384 - n */
   bn.sub    w14, w31, w12
+
+  /* Shift seed1 bits to get 448-bit seeds.
+     seed1 = [w9,w8]
+     w9 <= w9[192:0] */
+  bn.rshi   w9, w31, w9 >> 64
 
   /* Generate a random 127-bit number.
      w4 <= URND()[255:129] */
@@ -93,19 +105,31 @@ p384_random_scalar:
   bn.rshi   w4, w31, w4 >> 129
 
   /* Add 1 to get a 128-bit nonzero scalar for masking.
-     w4 <= w4 + 1 = x */
-  bn.addi   w4, w4, 1
 
-  /* [w26,w25] <= ([w7,w6] * w4) mod n = (seed0 * x) mod n */
-  bn.mov    w16, w4
+     N.B. The dummy instruction below serves to clear flags revealing
+     information regarding the masking value in w4, as well as to separate
+     accesses of the multiplicative masking value in w4 from accesses below to
+     the value it masks.
+
+     w4 <= w4 + 1 = x
+     w16 <= w4 */
+  bn.addi   w4, w4, 1
+  bn.mov    w16, w4      /* prepare for p384_mulmod488x128_n call below */
+  bn.addi   w31, w31, 0  /* dummy instruction to clear flags */
+
+  /* N.B. After the call to p384_mulmod488x128_n below, we immediately move
+     the masking value in w4 back into the (clobbered) w16 so as to separate
+     accesses to w4 from the value it masks ([w9,w8]) below.
+
+     [w26,w25] <= ([w7,w6] * w4) mod n = (seed0 * x) mod n */
   bn.mov    w10, w6
   bn.mov    w11, w7
   jal       x1, p384_mulmod448x128_n
+  bn.mov    w16, w4      /* prepare for next p384_mulmod488x128_n call below */
   bn.mov    w25, w16
   bn.mov    w26, w17
 
   /* [w28,w27] <= ([w9,w8] * w4) mod n = (seed1 * x) mod n */
-  bn.mov    w16, w4
   bn.mov    w10, w8
   bn.mov    w11, w9
   jal       x1, p384_mulmod448x128_n

--- a/sw/otbn/crypto/p384_keygen.s
+++ b/sw/otbn/crypto/p384_keygen.s
@@ -114,8 +114,8 @@ p384_random_scalar:
      w4 <= w4 + 1 = x
      w16 <= w4 */
   bn.addi   w4, w4, 1
-  bn.mov    w16, w4      /* prepare for p384_mulmod488x128_n call below */
-  bn.addi   w31, w31, 0  /* dummy instruction to clear flags */
+  bn.mov    w16, w4        /* prepare for p384_mulmod488x128_n call below */
+  bn.add    w31, w31, w31  /* dummy instruction to clear flags */
 
   /* N.B. After the call to p384_mulmod488x128_n below, we immediately move
      the masking value in w4 back into the (clobbered) w16 so as to separate

--- a/sw/otbn/crypto/p384_keygen_from_seed.s
+++ b/sw/otbn/crypto/p384_keygen_from_seed.s
@@ -1,6 +1,11 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
 /* Copyright lowRISC contributors (OpenTitan project). */
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
+
 /*
  *   This library contains:
  *   - P-384 specific routines to generate a random private key from
@@ -101,9 +106,17 @@ p384_key_from_seed:
   /* Compute d1. Because 2^384 < 2 * n, a conditional subtraction is
      sufficient to reduce. Similarly to the carry bit, the conditional bit here
      is not very sensitive because the shares are large relative to n.
+
+     N.B. Even though the conditional bit isn't sensitive here, other flags set
+     by the above subtraction (i.e. the LSB flag) may be; the dummy instruction
+     below serves both to clear these flags as well as to separate instructions
+     accessing w11 and w21 respectively, as these form the upper words of a pair
+     of secret shares.
+
        [w6,w5] <= x1 mod n = d1 */
   bn.sel    w5, w10, w24, FG0.C
   bn.sel    w6, w11, w25, FG0.C
+  bn.sub    w31, w31, w31  /* dummy instruction to clear flags */
 
   /* Isolate the carry bit and shift it back into position.
        w25 <= x0[384] << 128 */
@@ -130,7 +143,11 @@ p384_key_from_seed:
 
   /* Compute d0 with a modular subtraction. First we add n to protect
      against underflow, then conditionally subtract it again if needed.
-       [w23,w22] <= ([w21, w20] - [w25,w24]) mod n = d0 */
+       [w23,w22] <= ([w21, w20] - [w25,w24]) mod n = d0
+
+     N.B. We also insert a dummy instruction after this step, as the flags set
+     will reveal information regarding d0 in the case that the final conditional
+     subtraction is performed. */
   bn.add    w20, w20, w16
   bn.addc   w21, w21, w17
   bn.sub    w20, w20, w24
@@ -139,6 +156,7 @@ p384_key_from_seed:
   bn.subb   w27, w21, w17
   bn.sel    w22, w20, w26, FG0.C
   bn.sel    w23, w21, w27, FG0.C
+  bn.sub    w31, w31, w31  /* dummy instruction to clear flags */
 
   /* Get 63 bits of randomness from RND, multiply it with n,
      and add it to the key share to get a 448-bit share. */
@@ -151,9 +169,13 @@ p384_key_from_seed:
   bn.mov    w1, w18
   bn.mov    w2, w19
 
-  /* [w6,w5] <= [w6,w5] + [w2,w1] = d1 + (RND >> 193) * n = d1' */
-  bn.add    w5, w5, w1
-  bn.addc   w6, w6, w2
+  /* N.B. We clear flags after this step to prevent the flags from leaking
+     information about d1'.
+
+      [w6,w5] <= [w6,w5] + [w2,w1] = d1 + (RND >> 193) * n = d1' */
+  bn.add    w5,  w5,  w1
+  bn.addc   w6,  w6,  w2
+  bn.add    w31, w31, w31  /* dummy instruction to clear flags */
 
   /* [w4,w3] <= (RND >> 193) * n */
   bn.wsrr   w10, RND
@@ -163,9 +185,13 @@ p384_key_from_seed:
   bn.mov    w3, w18
   bn.mov    w4, w19
 
-  /* [w23,w22] <= [w23,w22] + [w4,w3] = d0 + (RND >> 193) * n = d0' */
+  /* N.B. We clear flags after this step to prevent the flags from leaking
+     information about d0'.
+
+     [w23,w22] <= [w23,w22] + [w4,w3] = d0 + (RND >> 193) * n = d0' */
   bn.add    w22, w22, w3
   bn.addc   w23, w23, w4
+  bn.add    w31, w31, w31  /* dummy instruction to clear flags */
 
   /* Write first 448-bit share to DMEM.
      dmem[d0] <= [w23,w22] = d0' */


### PR DESCRIPTION
Originally from https://github.com/zerorisc/expo-cryptolib/pull/11.

This is the second of a handful of PRs to make the P-384 implementation compliant with the SCA guidelines as listed in the OpenTitan OTBN Style Guide docs.

This PR just addresses `p384_{keygen,keygen_from_seed}.s. Following PRs will address the remainder of the P-384 implementation.

Care has been taken to mirror the SCA adjustments as implemented for P-256 wherever the implementations closely align.

Tested locally with cryptolib_tests.sh from https://github.com/zerorisc/expo-cryptolib/pull/3.