### PR TITLE
[expo-cryptolib] [crypto] Harden the KMAC driver.

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -118,6 +118,7 @@ cc_library(
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/crypto/impl:status",
     ],


### PR DESCRIPTION
Pass through and add hardened enums, control flow redundancy checks, and hardened MMIO reads/writes to the KMAC driver.