### PR TITLE
[expo-cryptolib] [crypto] Harden the OTBN driver and wipe DMEM on failures.

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -254,7 +254,9 @@ cc_library(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:crc32",
         "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base:random_order",
         "//sw/device/lib/crypto/impl:status",
     ],
 )

--- a/sw/device/lib/crypto/impl/rsa/rsa_keygen.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_keygen.c
@@ -1,3 +1,7 @@
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
@@ -83,25 +87,23 @@ static status_t keygen_start(uint32_t mode) {
 static status_t keygen_finalize(uint32_t exp_mode, size_t num_words,
                                 uint32_t *n, uint32_t *d) {
   // Spin here waiting for OTBN to complete.
-  HARDENED_TRY(otbn_busy_wait_for_done());
+  OTBN_WIPE_IF_ERROR(otbn_busy_wait_for_done());
 
   // Read the mode from OTBN dmem and panic if it's not as expected.
   uint32_t act_mode = 0;
-  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarRsaMode, &act_mode));
+  OTBN_WIPE_IF_ERROR(otbn_dmem_read(1, kOtbnVarRsaMode, &act_mode));
   if (act_mode != exp_mode) {
     return OTCRYPTO_FATAL_ERR;
   }
 
   // Read the public modulus (n) from OTBN dmem.
-  HARDENED_TRY(otbn_dmem_read(num_words, kOtbnVarRsaN, n));
+  OTBN_WIPE_IF_ERROR(otbn_dmem_read(num_words, kOtbnVarRsaN, n));
 
   // Read the private exponent (d) from OTBN dmem.
-  HARDENED_TRY(otbn_dmem_read(num_words, kOtbnVarRsaD, d));
+  OTBN_WIPE_IF_ERROR(otbn_dmem_read(num_words, kOtbnVarRsaD, d));
 
   // Wipe DMEM.
-  HARDENED_TRY(otbn_dmem_sec_wipe());
-
-  return OTCRYPTO_OK;
+  return otbn_dmem_sec_wipe();
 }
 
 status_t rsa_keygen_2048_start(void) {

--- a/sw/device/lib/crypto/impl/rsa/rsa_modexp.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_modexp.c
@@ -1,3 +1,7 @@
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
@@ -92,15 +96,16 @@ status_t rsa_modexp_wait(size_t *num_words) {
 static status_t rsa_modexp_finalize(const size_t num_words, uint32_t *result) {
   // Wait for OTBN to complete and get the result size.
   size_t num_words_inferred;
-  HARDENED_TRY(rsa_modexp_wait(&num_words_inferred));
+  OTBN_WIPE_IF_ERROR(rsa_modexp_wait(&num_words_inferred));
 
   // Check that the inferred result size matches expectations.
   if (num_words != num_words_inferred) {
+    otbn_dmem_sec_wipe_nofail();
     return OTCRYPTO_FATAL_ERR;
   }
 
   // Read the result.
-  HARDENED_TRY(otbn_dmem_read(num_words, kOtbnVarRsaInOut, result));
+  OTBN_WIPE_IF_ERROR(otbn_dmem_read(num_words, kOtbnVarRsaInOut, result));
 
   // Wipe DMEM.
   return otbn_dmem_sec_wipe();
@@ -119,10 +124,12 @@ status_t rsa_modexp_consttime_2048_start(const rsa_2048_int_t *base,
   // Set the base, the modulus n and private exponent d.
   HARDENED_TRY(otbn_dmem_write(kRsa2048NumWords, base->data, kOtbnVarRsaInOut));
   HARDENED_TRY(otbn_dmem_write(kRsa2048NumWords, modulus->data, kOtbnVarRsaN));
-  HARDENED_TRY(otbn_dmem_write(kRsa2048NumWords, exp->data, kOtbnVarRsaD));
+  OTBN_WIPE_IF_ERROR(
+      otbn_dmem_write(kRsa2048NumWords, exp->data, kOtbnVarRsaD));
 
   // Start OTBN.
-  return otbn_execute();
+  OTBN_WIPE_IF_ERROR(otbn_execute());
+  return OTCRYPTO_OK;
 }
 
 status_t rsa_modexp_vartime_2048_start(const rsa_2048_int_t *base,
@@ -169,10 +176,12 @@ status_t rsa_modexp_consttime_3072_start(const rsa_3072_int_t *base,
   // Set the base, the modulus n and private exponent d.
   HARDENED_TRY(otbn_dmem_write(kRsa3072NumWords, base->data, kOtbnVarRsaInOut));
   HARDENED_TRY(otbn_dmem_write(kRsa3072NumWords, modulus->data, kOtbnVarRsaN));
-  HARDENED_TRY(otbn_dmem_write(kRsa3072NumWords, exp->data, kOtbnVarRsaD));
+  OTBN_WIPE_IF_ERROR(
+      otbn_dmem_write(kRsa3072NumWords, exp->data, kOtbnVarRsaD));
 
   // Start OTBN.
-  return otbn_execute();
+  OTBN_WIPE_IF_ERROR(otbn_execute());
+  return OTCRYPTO_OK;
 }
 
 status_t rsa_modexp_vartime_3072_start(const rsa_3072_int_t *base,
@@ -219,10 +228,12 @@ status_t rsa_modexp_consttime_4096_start(const rsa_4096_int_t *base,
   // Set the base, the modulus n and private exponent d.
   HARDENED_TRY(otbn_dmem_write(kRsa4096NumWords, base->data, kOtbnVarRsaInOut));
   HARDENED_TRY(otbn_dmem_write(kRsa4096NumWords, modulus->data, kOtbnVarRsaN));
-  HARDENED_TRY(otbn_dmem_write(kRsa4096NumWords, exp->data, kOtbnVarRsaD));
+  OTBN_WIPE_IF_ERROR(
+      otbn_dmem_write(kRsa4096NumWords, exp->data, kOtbnVarRsaD));
 
   // Start OTBN.
-  return otbn_execute();
+  OTBN_WIPE_IF_ERROR(otbn_execute());
+  return OTCRYPTO_OK;
 }
 
 status_t rsa_modexp_vartime_4096_start(const rsa_4096_int_t *base,

--- a/sw/device/lib/crypto/impl/sha2/sha256.c
+++ b/sw/device/lib/crypto/impl/sha2/sha256.c
@@ -1,3 +1,7 @@
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
@@ -110,7 +114,7 @@ static status_t process_block(sha256_otbn_ctx_t *ctx,
   otbn_addr_t dst = kOtbnVarSha256Msg + offset;
 
   // Copy the message block into DMEM.
-  otbn_dmem_write(kSha256MessageBlockWords, block->data, dst);
+  HARDENED_TRY(otbn_dmem_write(kSha256MessageBlockWords, block->data, dst));
   ctx->num_blocks += 1;
 
   // If we've reached the maximum number of message chunks for a single run,

--- a/sw/device/sca/otbn_vertical/ecc256_modinv_serial.c
+++ b/sw/device/sca/otbn_vertical/ecc256_modinv_serial.c
@@ -94,7 +94,7 @@ static void p256_run_modinv(uint32_t *k0, uint32_t *k1) {
   pentest_set_trigger_high();
   pentest_call_and_sleep(otbn_manual_trigger, kIbexOtbnSleepCycles, false,
                          false);
-  otbn_busy_wait_for_done();
+  SS_CHECK_STATUS_OK(otbn_busy_wait_for_done());
   pentest_set_trigger_low();
 }
 

--- a/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.c
+++ b/sw/device/tests/penetrationtests/firmware/fi/otbn_fi.c
@@ -157,12 +157,12 @@ status_t handle_otbn_fi_char_beq(ujson_t *uj) {
   const otbn_app_t kOtbnAppCharBeq = OTBN_APP_T_INIT(otbn_char_beq);
   static const otbn_addr_t kOtbnAppCharBeqRes =
       OTBN_ADDR_T_INIT(otbn_char_beq, res);
-  otbn_load_app(kOtbnAppCharBeq);
+  TRY(otbn_load_app(kOtbnAppCharBeq));
 
   // FI code target.
   pentest_set_trigger_high();
-  otbn_execute();
-  otbn_busy_wait_for_done();
+  TRY(otbn_execute());
+  TRY(otbn_busy_wait_for_done());
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -172,7 +172,7 @@ status_t handle_otbn_fi_char_beq(ujson_t *uj) {
   // Read counter (x1) from OTBN data memory.
   otbn_fi_result_cnt_t uj_output;
   uj_output.result = 0;
-  otbn_dmem_read(1, kOtbnAppCharBeqRes, &uj_output.result);
+  TRY(otbn_dmem_read(1, kOtbnAppCharBeqRes, &uj_output.result));
 
   // Read OTBN instruction counter.
   TRY(dif_otbn_get_insn_cnt(&otbn, &uj_output.insn_cnt));
@@ -219,14 +219,14 @@ status_t handle_otbn_fi_char_bn_rshi(ujson_t *uj) {
       OTBN_ADDR_T_INIT(otbn_char_bn_rshi, big_num_out);
 
   // Load app and write received big_num into DMEM.
-  otbn_load_app(kOtbnAppCharBnRshi);
+  TRY(otbn_load_app(kOtbnAppCharBnRshi));
   TRY(dif_otbn_dmem_write(&otbn, kOtbnAppCharBnRshiBigNum, uj_data.big_num,
                           sizeof(uj_data.big_num)));
 
   // FI code target.
   pentest_set_trigger_high();
-  otbn_execute();
-  otbn_busy_wait_for_done();
+  TRY(otbn_execute());
+  TRY(otbn_busy_wait_for_done());
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -284,14 +284,14 @@ status_t handle_otbn_fi_char_bn_sel(ujson_t *uj) {
       OTBN_ADDR_T_INIT(otbn_char_bn_sel, big_num_out);
 
   // Load app and write received big_num into DMEM.
-  otbn_load_app(kOtbnAppCharBnSel);
+  TRY(otbn_load_app(kOtbnAppCharBnSel));
   TRY(dif_otbn_dmem_write(&otbn, kOtbnAppCharBnSelBigNum, uj_data.big_num,
                           sizeof(uj_data.big_num)));
 
   // FI code target.
   pentest_set_trigger_high();
-  otbn_execute();
-  otbn_busy_wait_for_done();
+  TRY(otbn_execute());
+  TRY(otbn_busy_wait_for_done());
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -342,12 +342,12 @@ status_t handle_otbn_fi_char_bn_wsrr(ujson_t *uj) {
       OTBN_ADDR_T_INIT(otbn_char_bn_wsrr, otbn_res_values_wdr);
 
   // Load app and write received big_num into DMEM.
-  otbn_load_app(kOtbnAppCharBnWsrr);
+  TRY(otbn_load_app(kOtbnAppCharBnWsrr));
 
   // FI code target.
   pentest_set_trigger_high();
-  otbn_execute();
-  otbn_busy_wait_for_done();
+  TRY(otbn_execute());
+  TRY(otbn_busy_wait_for_done());
   pentest_set_trigger_low();
 
   // Get registered alerts from alert handler.
@@ -398,12 +398,12 @@ status_t handle_otbn_fi_char_bne(ujson_t *uj) {
   const otbn_app_t kOtbnAppCharBne = OTBN_APP_T_INIT(otbn_char_bne);
   static const otbn_addr_t kOtbnAppCharBneRes =
       OTBN_ADDR_T_INIT(otbn_char_bne, res);
-  otbn_load_app(kOtbnAppCharBne);
+  TRY(otbn_load_app(kOtbnAppCharBne));
 
   // FI code target.
   pentest_set_trigger_high();
-  otbn_execute();
-  otbn_busy_wait_for_done();
+  TRY(otbn_execute());
+  TRY(otbn_busy_wait_for_done());
   pentest_set_trigger_low();
 
   // Get registered alerts from alert handler.
@@ -413,7 +413,7 @@ status_t handle_otbn_fi_char_bne(ujson_t *uj) {
   // Read counter (x1) from OTBN data memory.
   otbn_fi_result_cnt_t uj_output;
   uj_output.result = 0;
-  otbn_dmem_read(1, kOtbnAppCharBneRes, &uj_output.result);
+  TRY(otbn_dmem_read(1, kOtbnAppCharBneRes, &uj_output.result));
 
   // Read OTBN instruction counter.
   TRY(dif_otbn_get_insn_cnt(&otbn, &uj_output.insn_cnt));
@@ -452,12 +452,12 @@ status_t handle_otbn_fi_char_dmem_access(ujson_t *uj) {
   static const otbn_addr_t kOtbnVarCharDmemAccessValues =
       OTBN_ADDR_T_INIT(otbn_char_dmem_access, values);
 
-  otbn_load_app(kOtbnAppCharDmemAccess);
+  TRY(otbn_load_app(kOtbnAppCharDmemAccess));
 
   // FI code target.
   pentest_set_trigger_high();
-  otbn_execute();
-  otbn_busy_wait_for_done();
+  TRY(otbn_execute());
+  TRY(otbn_busy_wait_for_done());
   pentest_set_trigger_low();
 
   // Get registered alerts from alert handler.
@@ -509,7 +509,7 @@ status_t handle_otbn_fi_char_dmem_write(ujson_t *uj) {
       OTBN_ADDR_T_INIT(otbn_char_dmem_write, mem);
 
   // Init application and load reference values into DMEM.
-  otbn_load_app(kOtbnAppCharDmemWrite);
+  TRY(otbn_load_app(kOtbnAppCharDmemWrite));
   // FI code target.
   pentest_set_trigger_high();
   asm volatile(NOP30);
@@ -646,8 +646,8 @@ status_t handle_otbn_fi_char_dmem_write(ujson_t *uj) {
   pentest_set_trigger_low();
 
   // Execute OTBN application.
-  otbn_execute();
-  otbn_busy_wait_for_done();
+  TRY(otbn_execute());
+  TRY(otbn_busy_wait_for_done());
 
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -702,14 +702,14 @@ status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
       OTBN_APP_T_INIT(otbn_char_hardware_dmem_op_loop);
   static const otbn_addr_t kOtbnAppCharHardwareDmemOpLoopLC =
       OTBN_ADDR_T_INIT(otbn_char_hardware_dmem_op_loop, lc);
-  otbn_load_app(kOtbnAppCharHardwareDmemOpLoop);
+  TRY(otbn_load_app(kOtbnAppCharHardwareDmemOpLoop));
 
   uint32_t loop_counter;
 
   // FI code target.
   pentest_set_trigger_high();
-  otbn_execute();
-  otbn_busy_wait_for_done();
+  TRY(otbn_execute());
+  TRY(otbn_busy_wait_for_done());
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -717,7 +717,7 @@ status_t handle_otbn_fi_char_hardware_dmem_op_loop(ujson_t *uj) {
   pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read loop counter from OTBN data memory.
-  otbn_dmem_read(1, kOtbnAppCharHardwareDmemOpLoopLC, &loop_counter);
+  TRY(otbn_dmem_read(1, kOtbnAppCharHardwareDmemOpLoopLC, &loop_counter));
 
   // Read ERR_STATUS register from OTBN.
   dif_otbn_err_bits_t err_otbn;
@@ -755,14 +755,14 @@ status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
       OTBN_APP_T_INIT(otbn_char_hardware_reg_op_loop);
   static const otbn_addr_t kOtbnAppCharHardwareRegOpLoopLC =
       OTBN_ADDR_T_INIT(otbn_char_hardware_reg_op_loop, lc);
-  otbn_load_app(kOtbnAppCharHardwareRegOpLoop);
+  TRY(otbn_load_app(kOtbnAppCharHardwareRegOpLoop));
 
   uint32_t loop_counter;
 
   // FI code target.
   pentest_set_trigger_high();
-  otbn_execute();
-  otbn_busy_wait_for_done();
+  TRY(otbn_execute());
+  TRY(otbn_busy_wait_for_done());
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -770,7 +770,7 @@ status_t handle_otbn_fi_char_hardware_reg_op_loop(ujson_t *uj) {
   pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read loop counter from OTBN data memory.
-  otbn_dmem_read(1, kOtbnAppCharHardwareRegOpLoopLC, &loop_counter);
+  TRY(otbn_dmem_read(1, kOtbnAppCharHardwareRegOpLoopLC, &loop_counter));
 
   // Read ERR_STATUS register from OTBN.
   dif_otbn_err_bits_t err_otbn;
@@ -807,12 +807,12 @@ status_t handle_otbn_fi_char_jal(ujson_t *uj) {
   const otbn_app_t kOtbnAppCharJal = OTBN_APP_T_INIT(otbn_char_jal);
   static const otbn_addr_t kOtbnAppCharJalRes =
       OTBN_ADDR_T_INIT(otbn_char_jal, res);
-  otbn_load_app(kOtbnAppCharJal);
+  TRY(otbn_load_app(kOtbnAppCharJal));
 
   // FI code target.
   pentest_set_trigger_high();
-  otbn_execute();
-  otbn_busy_wait_for_done();
+  TRY(otbn_execute());
+  TRY(otbn_busy_wait_for_done());
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -822,7 +822,7 @@ status_t handle_otbn_fi_char_jal(ujson_t *uj) {
   // Read counter (x1) from OTBN data memory.
   otbn_fi_result_cnt_t uj_output;
   uj_output.result = 0;
-  otbn_dmem_read(1, kOtbnAppCharJalRes, &uj_output.result);
+  TRY(otbn_dmem_read(1, kOtbnAppCharJalRes, &uj_output.result));
 
   // Read OTBN instruction counter.
   TRY(dif_otbn_get_insn_cnt(&otbn, &uj_output.insn_cnt));
@@ -864,13 +864,13 @@ status_t handle_otbn_fi_char_lw(ujson_t *uj) {
       OTBN_ADDR_T_INIT(otbn_char_lw, mem_out);
 
   // Load app and write reference values into mem_in DMEM.
-  otbn_load_app(kOtbnAppCharLw);
+  TRY(otbn_load_app(kOtbnAppCharLw));
   TRY(dif_otbn_dmem_write(&otbn, kOtbnMemIn, ref_values, sizeof(ref_values)));
 
   // FI code target.
   pentest_set_trigger_high();
-  otbn_execute();
-  otbn_busy_wait_for_done();
+  TRY(otbn_execute());
+  TRY(otbn_busy_wait_for_done());
   pentest_set_trigger_low();
 
   // Get registered alerts from alert handler.
@@ -1049,13 +1049,13 @@ status_t handle_otbn_fi_char_register_file(ujson_t *uj) {
       OTBN_ADDR_T_INIT(otbn_char_rf, otbn_res_values_wdr);
 
   // Init application and load reference values into DMEM.
-  otbn_load_app(kOtbnAppCharRF);
+  TRY(otbn_load_app(kOtbnAppCharRF));
   TRY(dif_otbn_dmem_write(&otbn, kOtbnVarCharRFRefValues, ref_values,
                           sizeof(ref_values)));
 
   pentest_set_trigger_high();
-  otbn_execute();
-  otbn_busy_wait_for_done();
+  TRY(otbn_execute());
+  TRY(otbn_busy_wait_for_done());
   pentest_set_trigger_low();
 
   // Get registered alerts from alert handler.
@@ -1131,14 +1131,14 @@ status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
       OTBN_APP_T_INIT(otbn_char_unrolled_dmem_op_loop);
   static const otbn_addr_t kOtbnAppCharUnrolledDmemOpLoopLC =
       OTBN_ADDR_T_INIT(otbn_char_unrolled_dmem_op_loop, lc);
-  otbn_load_app(kOtbnAppCharUnrolledDmemOpLoop);
+  TRY(otbn_load_app(kOtbnAppCharUnrolledDmemOpLoop));
 
   uint32_t loop_counter;
 
   // FI code target.
   pentest_set_trigger_high();
-  otbn_execute();
-  otbn_busy_wait_for_done();
+  TRY(otbn_execute());
+  TRY(otbn_busy_wait_for_done());
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -1146,7 +1146,7 @@ status_t handle_otbn_fi_char_unrolled_dmem_op_loop(ujson_t *uj) {
   pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read loop counter from OTBN data memory.
-  otbn_dmem_read(1, kOtbnAppCharUnrolledDmemOpLoopLC, &loop_counter);
+  TRY(otbn_dmem_read(1, kOtbnAppCharUnrolledDmemOpLoopLC, &loop_counter));
 
   // Read ERR_STATUS register from OTBN.
   dif_otbn_err_bits_t err_otbn;
@@ -1184,14 +1184,14 @@ status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
       OTBN_APP_T_INIT(otbn_char_unrolled_reg_op_loop);
   static const otbn_addr_t kOtbnAppCharUnrolledRegOpLoopLC =
       OTBN_ADDR_T_INIT(otbn_char_unrolled_reg_op_loop, lc);
-  otbn_load_app(kOtbnAppCharUnrolledRegOpLoop);
+  TRY(otbn_load_app(kOtbnAppCharUnrolledRegOpLoop));
 
   uint32_t loop_counter;
 
   // FI code target.
   pentest_set_trigger_high();
-  otbn_execute();
-  otbn_busy_wait_for_done();
+  TRY(otbn_execute());
+  TRY(otbn_busy_wait_for_done());
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -1199,7 +1199,7 @@ status_t handle_otbn_fi_char_unrolled_reg_op_loop(ujson_t *uj) {
   pentest_sensor_alerts_t sensor_alerts = pentest_get_sensor_alerts();
 
   // Read loop counter from OTBN data memory.
-  otbn_dmem_read(1, kOtbnAppCharUnrolledRegOpLoopLC, &loop_counter);
+  TRY(otbn_dmem_read(1, kOtbnAppCharUnrolledRegOpLoopLC, &loop_counter));
 
   // Read ERR_STATUS register from OTBN.
   dif_otbn_err_bits_t err_otbn;
@@ -1318,23 +1318,23 @@ status_t handle_otbn_fi_key_sideload(ujson_t *uj) {
 
   if (!key_sideloading_init) {
     // Setup keymanager for sideloading key into OTBN.
-    otbn_load_app(kOtbnAppKeySideload);
+    TRY(otbn_load_app(kOtbnAppKeySideload));
     // Get reference keys.
-    otbn_execute();
-    otbn_busy_wait_for_done();
+    TRY(otbn_execute());
+    TRY(otbn_busy_wait_for_done());
 
-    otbn_dmem_read(1, kOtbnAppKeySideloadks0l, &key_share_0_l_ref);
-    otbn_dmem_read(1, kOtbnAppKeySideloadks0h, &key_share_0_h_ref);
-    otbn_dmem_read(1, kOtbnAppKeySideloadks1l, &key_share_1_l_ref);
-    otbn_dmem_read(1, kOtbnAppKeySideloadks1h, &key_share_1_h_ref);
+    TRY(otbn_dmem_read(1, kOtbnAppKeySideloadks0l, &key_share_0_l_ref));
+    TRY(otbn_dmem_read(1, kOtbnAppKeySideloadks0h, &key_share_0_h_ref));
+    TRY(otbn_dmem_read(1, kOtbnAppKeySideloadks1l, &key_share_1_l_ref));
+    TRY(otbn_dmem_read(1, kOtbnAppKeySideloadks1h, &key_share_1_h_ref));
 
     key_sideloading_init = true;
   }
 
   // FI code target.
   pentest_set_trigger_high();
-  otbn_execute();
-  otbn_busy_wait_for_done();
+  TRY(otbn_execute());
+  TRY(otbn_busy_wait_for_done());
   pentest_set_trigger_low();
 
   // Get registered alerts from alert handler.
@@ -1345,10 +1345,10 @@ status_t handle_otbn_fi_key_sideload(ujson_t *uj) {
   // Read loop counter from OTBN data memory.
   uint32_t key_share_0_l, key_share_0_h;
   uint32_t key_share_1_l, key_share_1_h;
-  otbn_dmem_read(1, kOtbnAppKeySideloadks0l, &key_share_0_l);
-  otbn_dmem_read(1, kOtbnAppKeySideloadks0h, &key_share_0_h);
-  otbn_dmem_read(1, kOtbnAppKeySideloadks1l, &key_share_1_l);
-  otbn_dmem_read(1, kOtbnAppKeySideloadks1h, &key_share_1_h);
+  TRY(otbn_dmem_read(1, kOtbnAppKeySideloadks0l, &key_share_0_l));
+  TRY(otbn_dmem_read(1, kOtbnAppKeySideloadks0h, &key_share_0_h));
+  TRY(otbn_dmem_read(1, kOtbnAppKeySideloadks1l, &key_share_1_l));
+  TRY(otbn_dmem_read(1, kOtbnAppKeySideloadks1h, &key_share_1_h));
 
   // Read ERR_STATUS register from OTBN.
   dif_otbn_err_bits_t err_otbn;
@@ -1392,7 +1392,7 @@ status_t handle_otbn_fi_load_integrity(ujson_t *uj) {
     // Load the OTBN app and read the load checksum without FI to retrieve
     // reference value.
     clear_otbn_load_checksum();
-    otbn_load_app(kOtbnAppLoadIntegrity);
+    TRY(otbn_load_app(kOtbnAppLoadIntegrity));
     read_otbn_load_checksum(&load_checksum_ref);
     clear_otbn_load_checksum();
 
@@ -1401,7 +1401,7 @@ status_t handle_otbn_fi_load_integrity(ujson_t *uj) {
 
   // FI code target.
   pentest_set_trigger_high();
-  otbn_load_app(kOtbnAppLoadIntegrity);
+  TRY(otbn_load_app(kOtbnAppLoadIntegrity));
   pentest_set_trigger_low();
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
@@ -1415,9 +1415,9 @@ status_t handle_otbn_fi_load_integrity(ujson_t *uj) {
 
   // Read loop counter from OTBN data memory.
   uint32_t ref_val1, ref_val2, ref_val3;
-  otbn_dmem_read(1, kOtbnAppLoadIntegrityRefVal1, &ref_val1);
-  otbn_dmem_read(1, kOtbnAppLoadIntegrityRefVal2, &ref_val2);
-  otbn_dmem_read(1, kOtbnAppLoadIntegrityRefVal3, &ref_val3);
+  TRY(otbn_dmem_read(1, kOtbnAppLoadIntegrityRefVal1, &ref_val1));
+  TRY(otbn_dmem_read(1, kOtbnAppLoadIntegrityRefVal2, &ref_val2));
+  TRY(otbn_dmem_read(1, kOtbnAppLoadIntegrityRefVal3, &ref_val3));
 
   // Check if DMEM is corrupted.
   bool dmem_corrupted = false;
@@ -1476,12 +1476,12 @@ status_t handle_otbn_fi_pc(ujson_t *uj) {
   dif_otbn_status_t otbn_status;
 
   // Load app.
-  otbn_load_app(kOtbnAppPc);
+  TRY(otbn_load_app(kOtbnAppPc));
 
   // FI code target.
   pentest_set_trigger_high();
   TRY(dif_otbn_dmem_write(&otbn, kOtbnPc, &uj_data.pc, sizeof(uj_data.pc)));
-  otbn_execute();
+  TRY(otbn_execute());
   // Wait until is started before deasserting the trigger.
   bool is_running = false;
   while (!is_running) {
@@ -1491,7 +1491,7 @@ status_t handle_otbn_fi_pc(ujson_t *uj) {
     }
   }
   pentest_set_trigger_low();
-  otbn_busy_wait_for_done();
+  TRY(otbn_busy_wait_for_done());
   // Get registered alerts from alert handler.
   reg_alerts = pentest_get_triggered_alerts();
   // Get fatal and recoverable AST alerts from sensor controller.

--- a/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.c
+++ b/sw/device/tests/penetrationtests/firmware/lib/pentest_lib.c
@@ -921,7 +921,7 @@ void pentest_call_and_sleep(sca_callee callee, uint32_t sleep_cycles,
 
 #if !OT_IS_ENGLISH_BREAKFAST
   if (otbn) {
-    otbn_busy_wait_for_done();
+    OT_DISCARD((otbn_busy_wait_for_done()).value);
   }
 #endif
 

--- a/sw/device/tests/penetrationtests/firmware/sca/ecc256_keygen_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/ecc256_keygen_sca.c
@@ -148,7 +148,7 @@ static void add_arrays(uint8_t *dest, uint8_t *source, size_t dest_len,
 /**
  * Callback wrapper for OTBN manual trigger function.
  */
-static void otbn_manual_trigger(void) { otbn_execute(); }
+static void otbn_manual_trigger(void) { OT_DISCARD(otbn_execute().value); }
 
 /**
  * Runs the OTBN key generation program.

--- a/sw/device/tests/penetrationtests/firmware/sca/otbn_sca.c
+++ b/sw/device/tests/penetrationtests/firmware/sca/otbn_sca.c
@@ -203,8 +203,8 @@ static status_t p256_ecdsa_sign(const uint32_t *msg,
   pentest_set_trigger_high();
   // Give the trigger time to rise.
   asm volatile(NOP30);
-  otbn_execute();
-  otbn_busy_wait_for_done();
+  TRY(otbn_execute());
+  TRY(otbn_busy_wait_for_done());
   pentest_set_trigger_low();
 
   // Read the results back (sig_r, sig_s)
@@ -259,7 +259,7 @@ status_t handle_otbn_sca_ecdsa_p256_sign(ujson_t *uj) {
   memcpy(ecc256_secret_k + kEcc256NumWords, ecc256_secret_k1,
          sizeof(ecc256_secret_k1));
 
-  otbn_load_app(kOtbnAppP256Ecdsa);
+  TRY(otbn_load_app(kOtbnAppP256Ecdsa));
 
   // Signature output.
   uint32_t ecc256_signature_r[kEcc256NumWords];
@@ -347,7 +347,7 @@ status_t handle_otbn_sca_ecdsa_p256_sign_batch(ujson_t *uj) {
   uint32_t ecc256_signature_s[kEcc256NumWords];
   // Run num_traces ECDSA operations.
   for (size_t i = 0; i < uj_data_num_traces.num_traces; ++i) {
-    otbn_load_app(kOtbnAppP256Ecdsa);
+    TRY(otbn_load_app(kOtbnAppP256Ecdsa));
 
     // Start the operation.
     p256_ecdsa_sign(ecc256_message_batch[i], ecc256_private_key_d_batch[i],
@@ -448,7 +448,7 @@ status_t handle_otbn_sca_ecdsa_p256_sign_fvsr_batch(ujson_t *uj) {
   uint32_t ecc256_signature_s[kEcc256NumWords];
   // Run num_traces ECDSA operations.
   for (size_t i = 0; i < uj_data_num_traces.num_traces; ++i) {
-    otbn_load_app(kOtbnAppP256Ecdsa);
+    TRY(otbn_load_app(kOtbnAppP256Ecdsa));
 
     // Start the operation.
     p256_ecdsa_sign(uj_data.msg, ecc256_private_key_d_batch[i],
@@ -553,13 +553,13 @@ status_t handle_otbn_sca_insn_carry_flag(ujson_t *uj) {
       OTBN_ADDR_T_INIT(otbn_insn_carry_flag, big_num_out);
 
   // Load app and write received big_num into DMEM.
-  otbn_load_app(kOtbnAppInsnCarryFlag);
+  TRY(otbn_load_app(kOtbnAppInsnCarryFlag));
   TRY(dif_otbn_dmem_write(&otbn, kOtbnVarInsnCarryFlagBigNum, uj_data.big_num,
                           sizeof(uj_data.big_num)));
 
   pentest_set_trigger_high();
-  otbn_execute();
-  otbn_busy_wait_for_done();
+  TRY(otbn_execute());
+  TRY(otbn_busy_wait_for_done());
   pentest_set_trigger_low();
 
   penetrationtest_otbn_sca_big_num_t uj_output;
@@ -594,7 +594,7 @@ status_t handle_otbn_sca_key_sideload_fvsr(ujson_t *uj) {
     sample_fixed = prng_rand_uint32() & 0x1;
   }
 
-  otbn_load_app(kOtbnAppKeySideloadSca);
+  TRY(otbn_load_app(kOtbnAppKeySideloadSca));
 
   uint32_t key_share_0_l[kKeySideloadNumIt], key_share_0_h[kKeySideloadNumIt];
   uint32_t key_share_1_l[16], key_share_1_h[kKeySideloadNumIt];
@@ -609,17 +609,17 @@ status_t handle_otbn_sca_key_sideload_fvsr(ujson_t *uj) {
     pentest_set_trigger_high();
     // Give the trigger time to rise.
     asm volatile(NOP30);
-    otbn_execute();
-    otbn_busy_wait_for_done();
+    TRY(otbn_execute());
+    TRY(otbn_busy_wait_for_done());
     pentest_set_trigger_low();
     asm volatile(NOP30);
 
-    otbn_dmem_read(1, kOtbnAppKeySideloadks0l, &key_share_0_l[it]);
-    otbn_dmem_read(1, kOtbnAppKeySideloadks0h, &key_share_0_h[it]);
-    otbn_dmem_read(1, kOtbnAppKeySideloadks1l, &key_share_1_l[it]);
-    otbn_dmem_read(1, kOtbnAppKeySideloadks1h, &key_share_1_h[it]);
-    otbn_dmem_read(1, kOtbnAppKeySideloadkl, &key_l[it]);
-    otbn_dmem_read(1, kOtbnAppKeySideloadkh, &key_h[it]);
+    TRY(otbn_dmem_read(1, kOtbnAppKeySideloadks0l, &key_share_0_l[it]));
+    TRY(otbn_dmem_read(1, kOtbnAppKeySideloadks0h, &key_share_0_h[it]));
+    TRY(otbn_dmem_read(1, kOtbnAppKeySideloadks1l, &key_share_1_l[it]));
+    TRY(otbn_dmem_read(1, kOtbnAppKeySideloadks1h, &key_share_1_h[it]));
+    TRY(otbn_dmem_read(1, kOtbnAppKeySideloadkl, &key_l[it]));
+    TRY(otbn_dmem_read(1, kOtbnAppKeySideloadkh, &key_h[it]));
   }
 
   // Write back shares and keys to host.
@@ -641,7 +641,7 @@ status_t handle_otbn_sca_rsa512_decrypt(ujson_t *uj) {
   // Get RSA256 parameters.
   penetrationtest_otbn_sca_rsa512_dec_t uj_data;
   TRY(ujson_deserialize_penetrationtest_otbn_sca_rsa512_dec_t(uj, &uj_data));
-  otbn_load_app(kOtbnAppRsa);
+  TRY(otbn_load_app(kOtbnAppRsa));
 
   uint32_t mode = 2;  // Decrypt.
   // RSA512 configuration.
@@ -660,8 +660,8 @@ status_t handle_otbn_sca_rsa512_decrypt(ujson_t *uj) {
   pentest_set_trigger_high();
   // Give the trigger time to rise.
   asm volatile(NOP30);
-  otbn_execute();
-  otbn_busy_wait_for_done();
+  TRY(otbn_execute());
+  TRY(otbn_busy_wait_for_done());
   pentest_set_trigger_low();
 
   // Send back decryption result to host.


### PR DESCRIPTION
Use OTBN's hardware CRC32 checksum register to double-check that values written to or read from OTBN were correct.

Also, add a macro that makes it easier to wipe DMEM on failure cases, and use the macro in cryptolib code that writes or reads secrets to/from OTBN.

Also adds some missing `OT_WARN_UNUSED_RESULT` tags on OTBN functions and fixes a bunch of places in the penetration test lib that were silently discarding errors and then started failing to build after the tag was added.