### PR TITLE
[expo-cryptolib] [crypto] Remove duplicate deps in HMAC driver rule

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -208,8 +208,6 @@ cc_library(
         "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/base:memory",
-        "//sw/device/lib/crypto/drivers:entropy",
-        "//sw/device/lib/crypto/drivers:rv_core_ibex",
         "//sw/device/lib/crypto/impl:status",
     ],
 )


### PR DESCRIPTION
This PR is a quick fix to remove duplicate dependencies in the HMAC cryptolib driver. These resulted from merges which referred to the dependencies in two ways.

Tested with the `cryptolib_tests.sh` script from `expo-cryptolib`. 