### PR TITLE
[expo-cryptolib] [crypto] Remove stale dependency in KDF KMAC sideload test

### DIFF
--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -518,7 +518,6 @@ opentitan_test(
     deps = [
         "//sw/device/lib/base:macros",
         "//sw/device/lib/crypto/drivers:kmac",
-        "//sw/device/lib/crypto/impl:hash",
         "//sw/device/lib/crypto/impl:key_transport",
         "//sw/device/lib/crypto/impl:kmac_kdf",
         "//sw/device/lib/crypto/impl:sha3",


### PR DESCRIPTION
This PR removes a dependency leftover intended to be removed in #25 which was missed, fixing an error during cryptolib test builds.