### PR TITLE
[expo-cryptolib] [crypto] Fix hardened memory dependency in key manager driver

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -69,6 +69,7 @@ cc_library(
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
+        "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/crypto/impl:status",
         "//sw/device/lib/runtime:hart",


### PR DESCRIPTION
This small PR simply fixes a missing dependency in the key manager driver left by #40.