### PR TITLE
[expo-cryptolib] [backport] [crypto] Always pass keys by reference.

### DIFF
--- a/sw/device/lib/crypto/impl/hkdf.c
+++ b/sw/device/lib/crypto/impl/hkdf.c
@@ -45,20 +45,20 @@ static status_t digest_num_words_from_key_mode(otcrypto_key_mode_t key_mode,
   return OTCRYPTO_OK;
 }
 
-otcrypto_status_t otcrypto_hkdf(const otcrypto_blinded_key_t ikm,
+otcrypto_status_t otcrypto_hkdf(const otcrypto_blinded_key_t *ikm,
                                 otcrypto_const_byte_buf_t salt,
                                 otcrypto_const_byte_buf_t info,
                                 otcrypto_blinded_key_t *okm) {
   // Infer the digest length.
   size_t digest_wordlen;
   HARDENED_TRY(
-      digest_num_words_from_key_mode(ikm.config.key_mode, &digest_wordlen));
+      digest_num_words_from_key_mode(ikm->config.key_mode, &digest_wordlen));
   size_t digest_bytelen = digest_wordlen * sizeof(uint32_t);
 
   // Construct a blinded key struct for the intermediate key.
   otcrypto_key_config_t prk_config = {
       .version = kOtcryptoLibVersion1,
-      .key_mode = ikm.config.key_mode,
+      .key_mode = ikm->config.key_mode,
       .key_length = digest_bytelen,
       .hw_backed = kHardenedBoolFalse,
       .exportable = kHardenedBoolFalse,
@@ -74,7 +74,7 @@ otcrypto_status_t otcrypto_hkdf(const otcrypto_blinded_key_t ikm,
 
   // Call extract and expand.
   HARDENED_TRY(otcrypto_hkdf_extract(ikm, salt, &prk));
-  return otcrypto_hkdf_expand(prk, info, okm);
+  return otcrypto_hkdf_expand(&prk, info, okm);
 }
 
 /**
@@ -115,11 +115,11 @@ static status_t hkdf_check_prk(size_t digest_words,
   return keyblob_ensure_xor_masked(prk->config);
 }
 
-otcrypto_status_t otcrypto_hkdf_extract(const otcrypto_blinded_key_t ikm,
+otcrypto_status_t otcrypto_hkdf_extract(const otcrypto_blinded_key_t *ikm,
                                         otcrypto_const_byte_buf_t salt,
                                         otcrypto_blinded_key_t *prk) {
   // Check for null pointers.
-  if (ikm.keyblob == NULL || prk == NULL || prk->keyblob == NULL) {
+  if (ikm->keyblob == NULL || prk == NULL || prk->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
   if (salt.data == NULL && salt.len != 0) {
@@ -127,29 +127,29 @@ otcrypto_status_t otcrypto_hkdf_extract(const otcrypto_blinded_key_t ikm,
   }
 
   // Check the private key checksum.
-  if (integrity_blinded_key_check(&ikm) != kHardenedBoolTrue) {
+  if (integrity_blinded_key_check(ikm) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
 
-  if (launder32(ikm.config.security_level) != kOtcryptoKeySecurityLevelLow ||
+  if (launder32(ikm->config.security_level) != kOtcryptoKeySecurityLevelLow ||
       launder32(prk->config.security_level) != kOtcryptoKeySecurityLevelLow) {
     // The underlying HMAC implementation is not currently hardened.
     return OTCRYPTO_NOT_IMPLEMENTED;
   }
-  HARDENED_CHECK_EQ(ikm.config.security_level, kOtcryptoKeySecurityLevelLow);
+  HARDENED_CHECK_EQ(ikm->config.security_level, kOtcryptoKeySecurityLevelLow);
   HARDENED_CHECK_EQ(prk->config.security_level, kOtcryptoKeySecurityLevelLow);
 
   // Ensure the key modes match.
-  if (launder32(prk->config.key_mode) != launder32(ikm.config.key_mode)) {
+  if (launder32(prk->config.key_mode) != launder32(ikm->config.key_mode)) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(prk->config.key_mode, ikm.config.key_mode);
+  HARDENED_CHECK_EQ(prk->config.key_mode, ikm->config.key_mode);
 
   // Infer the digest size. This step also ensures that the key mode is
   // supported.
   size_t digest_words = 0;
   HARDENED_TRY(
-      digest_num_words_from_key_mode(ikm.config.key_mode, &digest_words));
+      digest_num_words_from_key_mode(ikm->config.key_mode, &digest_words));
 
   // Validate the PRK configuration.
   HARDENED_TRY(hkdf_check_prk(digest_words, prk));
@@ -172,14 +172,14 @@ otcrypto_status_t otcrypto_hkdf_extract(const otcrypto_blinded_key_t ikm,
   // Unmask the input key.
   uint32_t *ikm_share0;
   uint32_t *ikm_share1;
-  HARDENED_TRY(keyblob_to_shares(&ikm, &ikm_share0, &ikm_share1));
-  uint32_t unmasked_ikm_data[keyblob_share_num_words(ikm.config)];
+  HARDENED_TRY(keyblob_to_shares(ikm, &ikm_share0, &ikm_share1));
+  uint32_t unmasked_ikm_data[keyblob_share_num_words(ikm->config)];
   for (size_t i = 0; i < ARRAYSIZE(unmasked_ikm_data); i++) {
     unmasked_ikm_data[i] = ikm_share0[i] ^ ikm_share1[i];
   }
   otcrypto_const_byte_buf_t unmasked_ikm = {
       .data = (unsigned char *)unmasked_ikm_data,
-      .len = ikm.config.key_length,
+      .len = ikm->config.key_length,
   };
 
   // Package the salt value in a blinded key, using an all-zero mask because
@@ -188,7 +188,7 @@ otcrypto_status_t otcrypto_hkdf_extract(const otcrypto_blinded_key_t ikm,
   memset(salt_mask, 0, sizeof(salt_mask));
   otcrypto_key_config_t salt_key_config = {
       .version = kOtcryptoLibVersion1,
-      .key_mode = ikm.config.key_mode,
+      .key_mode = ikm->config.key_mode,
       .key_length = salt_bytelen,
       .hw_backed = kHardenedBoolFalse,
       .exportable = kHardenedBoolFalse,
@@ -218,10 +218,10 @@ otcrypto_status_t otcrypto_hkdf_extract(const otcrypto_blinded_key_t ikm,
   return OTCRYPTO_OK;
 }
 
-otcrypto_status_t otcrypto_hkdf_expand(const otcrypto_blinded_key_t prk,
+otcrypto_status_t otcrypto_hkdf_expand(const otcrypto_blinded_key_t *prk,
                                        otcrypto_const_byte_buf_t info,
                                        otcrypto_blinded_key_t *okm) {
-  if (okm == NULL || okm->keyblob == NULL || prk.keyblob == NULL) {
+  if (okm == NULL || okm->keyblob == NULL || prk->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
   if (info.data == NULL && info.len != 0) {
@@ -229,7 +229,7 @@ otcrypto_status_t otcrypto_hkdf_expand(const otcrypto_blinded_key_t prk,
   }
 
   if (launder32(okm->config.security_level) != kOtcryptoKeySecurityLevelLow ||
-      launder32(prk.config.security_level) != kOtcryptoKeySecurityLevelLow) {
+      launder32(prk->config.security_level) != kOtcryptoKeySecurityLevelLow) {
     // The underlying HMAC implementation is not currently hardened.
     return OTCRYPTO_NOT_IMPLEMENTED;
   }
@@ -237,10 +237,10 @@ otcrypto_status_t otcrypto_hkdf_expand(const otcrypto_blinded_key_t prk,
   // Infer the digest size.
   size_t digest_words = 0;
   HARDENED_TRY(
-      digest_num_words_from_key_mode(prk.config.key_mode, &digest_words));
+      digest_num_words_from_key_mode(prk->config.key_mode, &digest_words));
 
   // Check the PRK configuration.
-  HARDENED_TRY(hkdf_check_prk(digest_words, &prk));
+  HARDENED_TRY(hkdf_check_prk(digest_words, prk));
 
   // Ensure that the derived key is a symmetric key masked with XOR and is not
   // supposed to be hardware-backed.
@@ -279,7 +279,7 @@ otcrypto_status_t otcrypto_hkdf_expand(const otcrypto_blinded_key_t prk,
   for (uint8_t i = 0; i < num_iterations; i++) {
     info_and_counter_data[info.len] = i + 1;
     otcrypto_hmac_context_t ctx;
-    HARDENED_TRY(otcrypto_hmac_init(&ctx, &prk));
+    HARDENED_TRY(otcrypto_hmac_init(&ctx, prk));
     if (launder32(i) != 0) {
       otcrypto_const_byte_buf_t t_bytes = {
           .data = (unsigned char *)t_data,

--- a/sw/device/lib/crypto/impl/key_transport.c
+++ b/sw/device/lib/crypto/impl/key_transport.c
@@ -316,55 +316,55 @@ otcrypto_status_t otcrypto_import_blinded_key(
 }
 
 otcrypto_status_t otcrypto_export_blinded_key(
-    const otcrypto_blinded_key_t blinded_key, otcrypto_word32_buf_t key_share0,
+    const otcrypto_blinded_key_t *blinded_key, otcrypto_word32_buf_t key_share0,
     otcrypto_word32_buf_t key_share1) {
-  if (blinded_key.keyblob == NULL || key_share0.data == NULL ||
+  if (blinded_key->keyblob == NULL || key_share0.data == NULL ||
       key_share1.data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
 
   // Check key integrity.
-  if (launder32(integrity_blinded_key_check(&blinded_key)) !=
+  if (launder32(integrity_blinded_key_check(blinded_key)) !=
       kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(integrity_blinded_key_check(&blinded_key),
+  HARDENED_CHECK_EQ(integrity_blinded_key_check(blinded_key),
                     kHardenedBoolTrue);
 
   // Ensure the key is symmetric and not hardware-backed.
-  HARDENED_TRY(keyblob_ensure_xor_masked(blinded_key.config));
+  HARDENED_TRY(keyblob_ensure_xor_masked(blinded_key->config));
 
   // Check that key is exportable.
-  if (launder32(blinded_key.config.exportable) != kHardenedBoolTrue) {
+  if (launder32(blinded_key->config.exportable) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(blinded_key.config.exportable, kHardenedBoolTrue);
+  HARDENED_CHECK_EQ(blinded_key->config.exportable, kHardenedBoolTrue);
 
   // Check the lengths of the shares.
-  size_t share_words = launder32(keyblob_share_num_words(blinded_key.config));
+  size_t share_words = launder32(keyblob_share_num_words(blinded_key->config));
   if (launder32(key_share0.len) != share_words ||
       launder32(key_share1.len) != share_words) {
     return OTCRYPTO_BAD_ARGS;
   }
   HARDENED_CHECK_EQ(key_share0.len,
-                    keyblob_share_num_words(blinded_key.config));
+                    keyblob_share_num_words(blinded_key->config));
   HARDENED_CHECK_EQ(key_share1.len,
-                    keyblob_share_num_words(blinded_key.config));
+                    keyblob_share_num_words(blinded_key->config));
 
   // Check the length of the keyblob.
-  size_t keyblob_words = launder32(keyblob_num_words(blinded_key.config));
-  if ((blinded_key.keyblob_length % sizeof(uint32_t) != 0) ||
-      (blinded_key.keyblob_length / sizeof(uint32_t) != keyblob_words)) {
+  size_t keyblob_words = launder32(keyblob_num_words(blinded_key->config));
+  if ((blinded_key->keyblob_length % sizeof(uint32_t) != 0) ||
+      (blinded_key->keyblob_length / sizeof(uint32_t) != keyblob_words)) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(blinded_key.keyblob_length,
+  HARDENED_CHECK_EQ(blinded_key->keyblob_length,
                     keyblob_words * sizeof(uint32_t));
 
   // Get pointers to the internal shares and copy them into output buffers.
   uint32_t *keyblob_share0;
   uint32_t *keyblob_share1;
   HARDENED_TRY(
-      keyblob_to_shares(&blinded_key, &keyblob_share0, &keyblob_share1));
+      keyblob_to_shares(blinded_key, &keyblob_share0, &keyblob_share1));
   hardened_memcpy(key_share0.data, keyblob_share0, key_share0.len);
   hardened_memcpy(key_share1.data, keyblob_share1, key_share1.len);
   return OTCRYPTO_OK;

--- a/sw/device/lib/crypto/impl/key_transport_unittest.cc
+++ b/sw/device/lib/crypto/impl/key_transport_unittest.cc
@@ -152,7 +152,7 @@ TEST(KeyTransport, BlindedKeyImportExport) {
       .data = share1.data(),
       .len = share1.size(),
   };
-  EXPECT_EQ(status_ok(otcrypto_export_blinded_key(blinded_key, share0_buf,
+  EXPECT_EQ(status_ok(otcrypto_export_blinded_key(&blinded_key, share0_buf,
                                                   share1_buf)),
             true);
 
@@ -259,12 +259,12 @@ TEST(KeyTransport, BlindedKeyExportBadLengths) {
 
   // Set a bad length for share 0 and expect the import to fail.
   EXPECT_EQ(status_ok(otcrypto_export_blinded_key(
-                blinded_key, share_with_bad_length, share_with_good_length)),
+                &blinded_key, share_with_bad_length, share_with_good_length)),
             false);
 
   // Set a bad length for share 1 and expect the import to fail.
   EXPECT_EQ(status_ok(otcrypto_export_blinded_key(
-                blinded_key, share_with_good_length, share_with_bad_length)),
+                &blinded_key, share_with_good_length, share_with_bad_length)),
             false);
 
   // Set a bad length for the keyblob and expect the export to fail.
@@ -275,7 +275,7 @@ TEST(KeyTransport, BlindedKeyExportBadLengths) {
   };
   EXPECT_EQ(
       status_ok(otcrypto_export_blinded_key(
-          bad_blinded_key, share_with_good_length, share_with_good_length)),
+          &bad_blinded_key, share_with_good_length, share_with_good_length)),
       false);
 }
 
@@ -315,7 +315,7 @@ TEST(KeyTransport, BlindedKeyExportNotExportable) {
       .data = share1.data(),
       .len = share1.size(),
   };
-  EXPECT_EQ(status_ok(otcrypto_export_blinded_key(blinded_key, share0_buf,
+  EXPECT_EQ(status_ok(otcrypto_export_blinded_key(&blinded_key, share0_buf,
                                                   share1_buf)),
             false);
 }

--- a/sw/device/lib/crypto/impl/kmac_kdf.c
+++ b/sw/device/lib/crypto/impl/kmac_kdf.c
@@ -15,12 +15,12 @@
 #define MODULE_ID MAKE_MODULE_ID('k', 'k', 'd')
 
 otcrypto_status_t otcrypto_kmac_kdf(
-    const otcrypto_blinded_key_t key_derivation_key,
+    otcrypto_blinded_key_t *key_derivation_key,
     const otcrypto_const_byte_buf_t label,
     const otcrypto_const_byte_buf_t context,
     otcrypto_blinded_key_t *output_key_material) {
   // Check NULL pointers.
-  if (key_derivation_key.keyblob == NULL || output_key_material == NULL ||
+  if (key_derivation_key->keyblob == NULL || output_key_material == NULL ||
       output_key_material->keyblob == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -41,43 +41,44 @@ otcrypto_status_t otcrypto_kmac_kdf(
   }
 
   // Check the private key checksum.
-  if (integrity_blinded_key_check(&key_derivation_key) != kHardenedBoolTrue) {
+  if (integrity_blinded_key_check(key_derivation_key) != kHardenedBoolTrue) {
     return OTCRYPTO_BAD_ARGS;
   }
 
   // Check `key_len` is supported by KMAC HWIP.
   // The set of supported key sizes is {128, 192, 256, 384, 512}.
-  HARDENED_TRY(kmac_key_length_check(key_derivation_key.config.key_length));
+  HARDENED_TRY(kmac_key_length_check(key_derivation_key->config.key_length));
 
   kmac_blinded_key_t kmac_key = {
       .share0 = NULL,
       .share1 = NULL,
-      .hw_backed = key_derivation_key.config.hw_backed,
-      .len = key_derivation_key.config.key_length,
+      .hw_backed = key_derivation_key->config.hw_backed,
+      .len = key_derivation_key->config.key_length,
   };
 
   // Validate key length of `key_derivation_key`.
-  if (key_derivation_key.config.hw_backed == kHardenedBoolTrue) {
+  if (key_derivation_key->config.hw_backed == kHardenedBoolTrue) {
     // Check that 1) key size matches sideload port size, 2) keyblob length
     // matches diversification length.
-    if (keyblob_share_num_words(key_derivation_key.config) * sizeof(uint32_t) !=
+    if (keyblob_share_num_words(key_derivation_key->config) *
+            sizeof(uint32_t) !=
         kKmacSideloadKeyLength / 8) {
       return OTCRYPTO_BAD_ARGS;
     }
     // Configure keymgr with diversification input and then generate the
     // sideload key.
     keymgr_diversification_t diversification;
-    // Diversification call also checks that `key_derivation_key.keyblob_length`
-    // is 8 words long.
-    HARDENED_TRY(keyblob_to_keymgr_diversification(&key_derivation_key,
+    // Diversification call also checks that
+    // `key_derivation_key->keyblob_length` is 8 words long.
+    HARDENED_TRY(keyblob_to_keymgr_diversification(key_derivation_key,
                                                    &diversification));
     HARDENED_TRY(keymgr_generate_key_kmac(diversification));
-  } else if (key_derivation_key.config.hw_backed == kHardenedBoolFalse) {
-    if (key_derivation_key.keyblob_length !=
-        keyblob_num_words(key_derivation_key.config) * sizeof(uint32_t)) {
+  } else if (key_derivation_key->config.hw_backed == kHardenedBoolFalse) {
+    if (key_derivation_key->keyblob_length !=
+        keyblob_num_words(key_derivation_key->config) * sizeof(uint32_t)) {
       return OTCRYPTO_BAD_ARGS;
     }
-    HARDENED_TRY(keyblob_to_shares(&key_derivation_key, &kmac_key.share0,
+    HARDENED_TRY(keyblob_to_shares(key_derivation_key, &kmac_key.share0,
                                    &kmac_key.share1));
   } else {
     return OTCRYPTO_BAD_ARGS;
@@ -100,9 +101,9 @@ otcrypto_status_t otcrypto_kmac_kdf(
     return OTCRYPTO_BAD_ARGS;
   }
 
-  switch (launder32(key_derivation_key.config.key_mode)) {
+  switch (launder32(key_derivation_key->config.key_mode)) {
     case kOtcryptoKeyModeKdfKmac128: {
-      HARDENED_CHECK_EQ(key_derivation_key.config.key_mode,
+      HARDENED_CHECK_EQ(key_derivation_key->config.key_mode,
                         kOtcryptoKeyModeKdfKmac128);
       // No need to further check key size against security level because
       // `kmac_key_length_check` ensures that the key is at least 128-bit.
@@ -113,11 +114,11 @@ otcrypto_status_t otcrypto_kmac_kdf(
       break;
     }
     case kOtcryptoKeyModeKdfKmac256: {
-      HARDENED_CHECK_EQ(key_derivation_key.config.key_mode,
+      HARDENED_CHECK_EQ(key_derivation_key->config.key_mode,
                         kOtcryptoKeyModeKdfKmac256);
       // Check that key size matches the security strength. It should be at
       // least 256-bit.
-      if (key_derivation_key.config.key_length < 256 / 8) {
+      if (key_derivation_key->config.key_length < 256 / 8) {
         return OTCRYPTO_BAD_ARGS;
       }
       HARDENED_TRY(kmac_kmac_256(

--- a/sw/device/lib/crypto/include/hkdf.h
+++ b/sw/device/lib/crypto/include/hkdf.h
@@ -42,7 +42,7 @@ extern "C" {
  * @param[out] okm Blinded output keying material.
  * @return Result of the key derivation operation.
  */
-otcrypto_status_t otcrypto_hkdf(const otcrypto_blinded_key_t ikm,
+otcrypto_status_t otcrypto_hkdf(const otcrypto_blinded_key_t *ikm,
                                 otcrypto_const_byte_buf_t salt,
                                 otcrypto_const_byte_buf_t info,
                                 otcrypto_blinded_key_t *okm);
@@ -66,7 +66,7 @@ otcrypto_status_t otcrypto_hkdf(const otcrypto_blinded_key_t ikm,
  * @param[out] prk Extracted pseudo-random key.
  * @return Result of the key derivation operation.
  */
-otcrypto_status_t otcrypto_hkdf_extract(const otcrypto_blinded_key_t ikm,
+otcrypto_status_t otcrypto_hkdf_extract(const otcrypto_blinded_key_t *ikm,
                                         otcrypto_const_byte_buf_t salt,
                                         otcrypto_blinded_key_t *prk);
 
@@ -84,7 +84,7 @@ otcrypto_status_t otcrypto_hkdf_extract(const otcrypto_blinded_key_t ikm,
  * @param[out] okm Blinded output key material.
  * @return Result of the key derivation operation.
  */
-otcrypto_status_t otcrypto_hkdf_expand(const otcrypto_blinded_key_t prk,
+otcrypto_status_t otcrypto_hkdf_expand(const otcrypto_blinded_key_t *prk,
                                        otcrypto_const_byte_buf_t info,
                                        otcrypto_blinded_key_t *okm);
 

--- a/sw/device/lib/crypto/include/kdf_ctr.h
+++ b/sw/device/lib/crypto/include/kdf_ctr.h
@@ -35,7 +35,7 @@ extern "C" {
  * @return Result of the key derivation operation.
  */
 otcrypto_status_t otcrypto_kdf_ctr_hmac(
-    const otcrypto_blinded_key_t key_derivation_key,
+    const otcrypto_blinded_key_t *key_derivation_key,
     const otcrypto_const_byte_buf_t label,
     const otcrypto_const_byte_buf_t context,
     otcrypto_blinded_key_t *output_key_material);

--- a/sw/device/lib/crypto/include/key_transport.h
+++ b/sw/device/lib/crypto/include/key_transport.h
@@ -187,7 +187,7 @@ otcrypto_status_t otcrypto_import_blinded_key(
  */
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_export_blinded_key(
-    const otcrypto_blinded_key_t blinded_key, otcrypto_word32_buf_t key_share0,
+    const otcrypto_blinded_key_t *blinded_key, otcrypto_word32_buf_t key_share0,
     otcrypto_word32_buf_t key_share1);
 
 #ifdef __cplusplus

--- a/sw/device/lib/crypto/include/kmac_kdf.h
+++ b/sw/device/lib/crypto/include/kmac_kdf.h
@@ -42,7 +42,7 @@ extern "C" {
  * @return Result of the key derivation operation.
  */
 otcrypto_status_t otcrypto_kmac_kdf(
-    const otcrypto_blinded_key_t key_derivation_key,
+    otcrypto_blinded_key_t *key_derivation_key,
     const otcrypto_const_byte_buf_t label,
     const otcrypto_const_byte_buf_t context,
     otcrypto_blinded_key_t *output_key_material);

--- a/sw/device/tests/crypto/cryptotest/firmware/ecdh.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/ecdh.c
@@ -174,7 +174,7 @@ static status_t ecdh_p256(cryptotest_ecdh_private_key_t d,
   uint32_t share0[shared_secret_words];
   uint32_t share1[shared_secret_words];
   TRY(otcrypto_export_blinded_key(
-      shared_secret,
+      &shared_secret,
       (otcrypto_word32_buf_t){.data = share0, .len = ARRAYSIZE(share0)},
       (otcrypto_word32_buf_t){.data = share1, .len = ARRAYSIZE(share1)}));
   for (size_t i = 0; i < shared_secret_words; i++) {
@@ -295,7 +295,7 @@ static status_t ecdh_p384(cryptotest_ecdh_private_key_t d,
   uint32_t share0[shared_secret_words];
   uint32_t share1[shared_secret_words];
   TRY(otcrypto_export_blinded_key(
-      shared_secret,
+      &shared_secret,
       (otcrypto_word32_buf_t){.data = share0, .len = ARRAYSIZE(share0)},
       (otcrypto_word32_buf_t){.data = share1, .len = ARRAYSIZE(share1)}));
   for (size_t i = 0; i < shared_secret_words; i++) {

--- a/sw/device/tests/crypto/hkdf_functest.c
+++ b/sw/device/tests/crypto/hkdf_functest.c
@@ -156,7 +156,7 @@ static status_t run_test(hkdf_test_vector_t *test) {
   };
 
   // Run the "extract" stage of HKDF.
-  TRY(otcrypto_hkdf_extract(ikm, salt, &prk));
+  TRY(otcrypto_hkdf_extract(&ikm, salt, &prk));
 
   // If the test includes an expected value of PRK, then check the value.
   if (test->prk != NULL) {
@@ -171,7 +171,7 @@ static status_t run_test(hkdf_test_vector_t *test) {
   }
 
   // Run the "expand" stage of HKDF.
-  TRY(otcrypto_hkdf_expand(prk, info, &okm));
+  TRY(otcrypto_hkdf_expand(&prk, info, &okm));
 
   // Unmask the output key value and compare to the expected value.
   uint32_t *okm_share0;

--- a/sw/device/tests/crypto/kdf_hmac_ctr_functest.c
+++ b/sw/device/tests/crypto/kdf_hmac_ctr_functest.c
@@ -133,7 +133,7 @@ static status_t run_test(kdf_test_vector_t *test) {
     case kOtcryptoKeyModeHmacSha256:
     case kOtcryptoKeyModeHmacSha384:
     case kOtcryptoKeyModeHmacSha512:
-      TRY(otcrypto_kdf_ctr_hmac(kdk, label, context, &km));
+      TRY(otcrypto_kdf_ctr_hmac(&kdk, label, context, &km));
       break;
     default:
       LOG_INFO("Should never end up here.");

--- a/sw/device/tests/crypto/kdf_kmac_functest.c
+++ b/sw/device/tests/crypto/kdf_kmac_functest.c
@@ -60,7 +60,7 @@ static status_t run_test_vector(void) {
   uint32_t km_share0[km_num_words];
   uint32_t km_share1[km_num_words];
   TRY(otcrypto_export_blinded_key(
-      output_key_material,
+      &output_key_material,
       (otcrypto_word32_buf_t){.data = km_share0, .len = ARRAYSIZE(km_share0)},
       (otcrypto_word32_buf_t){.data = km_share1, .len = ARRAYSIZE(km_share1)}));
 

--- a/sw/device/tests/crypto/kdf_kmac_functest.c
+++ b/sw/device/tests/crypto/kdf_kmac_functest.c
@@ -49,7 +49,7 @@ static status_t run_test_vector(void) {
   current_test_vector->key_derivation_key.checksum =
       integrity_blinded_checksum(&current_test_vector->key_derivation_key);
 
-  TRY(otcrypto_kmac_kdf(current_test_vector->key_derivation_key,
+  TRY(otcrypto_kmac_kdf(&current_test_vector->key_derivation_key,
                         current_test_vector->label,
                         current_test_vector->context, &output_key_material));
 

--- a/sw/device/tests/crypto/kdf_kmac_sideload_functest.c
+++ b/sw/device/tests/crypto/kdf_kmac_sideload_functest.c
@@ -353,7 +353,7 @@ static status_t run_test_vector(void) {
   };
 
   LOG_INFO("Running the first KDF-KMAC sideload operation.");
-  TRY(otcrypto_kmac_kdf(current_test_vector->key_derivation_key,
+  TRY(otcrypto_kmac_kdf(&current_test_vector->key_derivation_key,
                         current_test_vector->label,
                         current_test_vector->context, &keying_material1));
 
@@ -393,7 +393,7 @@ static status_t run_test_vector(void) {
   }
 
   LOG_INFO("Running the second KDF-KMAC sideload operation for comparison.");
-  TRY(otcrypto_kmac_kdf(current_test_vector->key_derivation_key,
+  TRY(otcrypto_kmac_kdf(&current_test_vector->key_derivation_key,
                         current_test_vector->label,
                         current_test_vector->context, &keying_material2));
 


### PR DESCRIPTION
Backport to earlgrey_1.0.0 of a PR merged to master: https://github.com/lowRISC/opentitan/pull/27244.

Required for the backport of https://github.com/lowRISC/opentitan/pull/27247, which in turn is needed for the backport of #32.

> Most of the cryptolib already accepted keys by reference, not value, but the KDFs and export function didn't for some reason (likely simple carelessness on my part). This would make it difficult to re-mask the key and update the checksum, so this PR brings those trailing functions in line with their friends and passes the key by reference.
> 
> Groundwork for https://github.com/lowRISC/opentitan/issues/27243