### PR TITLE
[expo-cryptolib] [backport] [crypto] Randomize sensitive buffers before use.

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -30,6 +30,7 @@ cc_library(
     hdrs = ["aes.h"],
     deps = [
         ":entropy",
+        ":rv_core_ibex",
         "//hw/ip/aes/data:aes_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
@@ -65,6 +66,7 @@ cc_library(
     ],
     deps = [
         ":entropy",
+        ":rv_core_ibex",
         "//hw/ip/keymgr/data:keymgr_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",
@@ -110,6 +112,7 @@ cc_library(
     ],
     deps = [
         ":entropy",
+        ":rv_core_ibex",
         "//hw/ip/kmac/data:kmac_c_regs",
         "//hw/top_earlgrey/sw/autogen:top_earlgrey",
         "//sw/device/lib/base:abs_mmio",

--- a/sw/device/lib/crypto/drivers/keymgr.c
+++ b/sw/device/lib/crypto/drivers/keymgr.c
@@ -161,6 +161,10 @@ status_t keymgr_generate_key_sw(keymgr_diversification_t diversification,
   keymgr_start(diversification);
   HARDENED_TRY(keymgr_wait_until_done());
 
+  // Randomize the destination buffer.
+  hardened_memshred(key->share0, kKeymgrOutputShareNumWords);
+  hardened_memshred(key->share1, kKeymgrOutputShareNumWords);
+
   // Collect output.
   hardened_mmio_read(key->share0,
                      kBaseAddr + KEYMGR_SW_SHARE0_OUTPUT_0_REG_OFFSET,

--- a/sw/device/lib/crypto/drivers/kmac.c
+++ b/sw/device/lib/crypto/drivers/kmac.c
@@ -8,6 +8,7 @@
 #include "sw/device/lib/base/bitfield.h"
 #include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/drivers/entropy.h"
+#include "sw/device/lib/crypto/drivers/rv_core_ibex.h"
 #include "sw/device/lib/crypto/impl/status.h"
 
 #include "hw/top_earlgrey/sw/autogen/top_earlgrey.h"
@@ -524,6 +525,9 @@ static status_t kmac_init(kmac_operation_t operation,
  *
  * If the key is hardware-backed, this is a no-op.
  *
+ * Uses hardening primitives internally that consume entropy; the caller must
+ * ensure the entropy complex is up before calling.
+ *
  * @param key The input key passed as a struct.
  * @return Error code.
  */
@@ -544,6 +548,14 @@ static status_t kmac_write_key_block(kmac_blinded_key_t *key) {
   uint32_t key_len_reg = bitfield_field32_write(
       KMAC_KEY_LEN_REG_RESVAL, KMAC_KEY_LEN_LEN_FIELD, key_len_enum);
   abs_mmio_write32(kKmacBaseAddr + KMAC_KEY_LEN_REG_OFFSET, key_len_reg);
+
+  // Write random words to the key registers.
+  for (size_t i = 0; i * sizeof(uint32_t) < key->len; i++) {
+    abs_mmio_write32(kKmacKeyShare0Addr + i * sizeof(uint32_t),
+                     ibex_rnd32_read());
+    abs_mmio_write32(kKmacKeyShare1Addr + i * sizeof(uint32_t),
+                     ibex_rnd32_read());
+  }
 
   for (size_t i = 0; i * sizeof(uint32_t) < key->len; i++) {
     abs_mmio_write32(kKmacKeyShare0Addr + i * sizeof(uint32_t), key->share0[i]);

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -194,8 +194,10 @@ cc_library(
         ":integrity",
         ":keyblob",
         ":status",
+        "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/base:math",
         "//sw/device/lib/crypto/drivers:kmac",
+        "//sw/device/lib/crypto/drivers:rv_core_ibex",
         "//sw/device/lib/crypto/include:datatypes",
     ],
 )

--- a/sw/device/lib/crypto/impl/aes.c
+++ b/sw/device/lib/crypto/impl/aes.c
@@ -191,6 +191,9 @@ static status_t num_padded_blocks_get(size_t plaintext_len,
 /**
  * Return the block at index i for the given input and padding mode.
  *
+ * Uses hardening primitives internally that consume entropy; check the entropy
+ * complex is up before calling.
+ *
  * @param input Input data buffer.
  * @param padding Padding mode.
  * @param index Block index.
@@ -207,6 +210,9 @@ static status_t get_block(otcrypto_const_byte_buf_t input,
   // The index should never be more than `num_full_blocks` + 1, even including
   // padding.
   HARDENED_CHECK_LE(index, num_full_blocks + 1);
+
+  // Randomize the destination buffer.
+  hardened_memshred(block->data, ARRAYSIZE(block->data));
 
   if (launder32(index) < num_full_blocks) {
     HARDENED_CHECK_LT(index, num_full_blocks);
@@ -346,7 +352,7 @@ otcrypto_status_t otcrypto_aes(const otcrypto_blinded_key_t *key,
   // cipher.
   for (i = 0; launder32(i) < block_offset; ++i) {
     HARDENED_TRY(get_block(cipher_input, aes_padding, i, &block_in));
-    TRY(aes_update(/*dest=*/NULL, &block_in));
+    HARDENED_TRY(aes_update(/*dest=*/NULL, &block_in));
   }
   // Check that the loop ran for the correct number of iterations.
   HARDENED_CHECK_EQ(i, block_offset);
@@ -355,7 +361,8 @@ otcrypto_status_t otcrypto_aes(const otcrypto_blinded_key_t *key,
   // output buffer.
   for (i = block_offset; launder32(i) < input_nblocks; ++i) {
     HARDENED_TRY(get_block(cipher_input, aes_padding, i, &block_in));
-    TRY(aes_update(&block_out, &block_in));
+    hardened_memshred(block_out.data, ARRAYSIZE(block_out.data));
+    HARDENED_TRY(aes_update(&block_out, &block_in));
     // TODO(#17711) Change to `hardened_memcpy`.
     memcpy(&cipher_output.data[(i - block_offset) * kAesBlockNumBytes],
            block_out.data, kAesBlockNumBytes);
@@ -382,10 +389,6 @@ otcrypto_status_t otcrypto_aes(const otcrypto_blinded_key_t *key,
     hardened_memcpy(iv.data, aes_iv.data, kAesBlockNumWords);
   }
 
-  // If the key was sideloaded, clear it.
-  if (key->config.hw_backed == kHardenedBoolTrue) {
-    HARDENED_TRY(keymgr_sideload_clear_aes());
-  }
-
-  return OTCRYPTO_OK;
+  // In case the key was sideloaded, clear it.
+  return keymgr_sideload_clear_aes();
 }

--- a/sw/device/lib/crypto/impl/drbg.c
+++ b/sw/device/lib/crypto/impl/drbg.c
@@ -25,7 +25,7 @@
  * @param[out] seed_material Resulting entropy complex seed.
  * @return OK or error.
  */
-static otcrypto_status_t seed_material_construct(
+static status_t seed_material_construct(
     otcrypto_const_byte_buf_t value, entropy_seed_material_t *seed_material) {
   if (value.len > kEntropySeedBytes) {
     return OTCRYPTO_BAD_ARGS;
@@ -34,16 +34,13 @@ static otcrypto_status_t seed_material_construct(
   size_t nwords = ceil_div(value.len, sizeof(uint32_t));
   seed_material->len = nwords;
 
-  // Initialize the set words to zero.
-  memset(seed_material->data, 0, nwords * sizeof(uint32_t));
-
-  if (value.len == 0) {
-    return OTCRYPTO_OK;
-  }
-
   // Copy seed data.
   // TODO(#17711) Change to `hardened_memcpy`.
   memcpy(seed_material->data, value.data, value.len);
+
+  // Set any unset bytes to zero.
+  size_t unset_bytes = nwords * sizeof(uint32_t) - value.len;
+  memset(((unsigned char *)seed_material->data) + value.len, 0, unset_bytes);
 
   return OTCRYPTO_OK;
 }
@@ -95,6 +92,7 @@ otcrypto_status_t otcrypto_drbg_instantiate(
   HARDENED_TRY(entropy_complex_check());
 
   entropy_seed_material_t seed_material;
+  hardened_memshred(seed_material.data, ARRAYSIZE(seed_material.data));
   seed_material_construct(perso_string, &seed_material);
 
   HARDENED_TRY(entropy_csrng_uninstantiate());
@@ -113,6 +111,7 @@ otcrypto_status_t otcrypto_drbg_reseed(
   HARDENED_TRY(entropy_complex_check());
 
   entropy_seed_material_t seed_material;
+  hardened_memshred(seed_material.data, ARRAYSIZE(seed_material.data));
   seed_material_construct(additional_input, &seed_material);
 
   return entropy_csrng_reseed(/*disable_trng_input=*/kHardenedBoolFalse,
@@ -193,6 +192,12 @@ static otcrypto_status_t generate(hardened_bool_t fips_check,
 otcrypto_status_t otcrypto_drbg_generate(
     otcrypto_const_byte_buf_t additional_input,
     otcrypto_word32_buf_t drbg_output) {
+  // Ensure the entropy complex is initialized.
+  HARDENED_TRY(entropy_complex_check());
+
+  // Randomize destination buffer.
+  hardened_memshred(drbg_output.data, drbg_output.len);
+
   return generate(/*fips_check=*/kHardenedBoolTrue, additional_input,
                   drbg_output);
 }

--- a/sw/device/lib/crypto/impl/hkdf.c
+++ b/sw/device/lib/crypto/impl/hkdf.c
@@ -170,13 +170,9 @@ otcrypto_status_t otcrypto_hkdf_extract(const otcrypto_blinded_key_t *ikm,
   // struct.
 
   // Unmask the input key.
-  uint32_t *ikm_share0;
-  uint32_t *ikm_share1;
-  HARDENED_TRY(keyblob_to_shares(ikm, &ikm_share0, &ikm_share1));
   uint32_t unmasked_ikm_data[keyblob_share_num_words(ikm->config)];
-  for (size_t i = 0; i < ARRAYSIZE(unmasked_ikm_data); i++) {
-    unmasked_ikm_data[i] = ikm_share0[i] ^ ikm_share1[i];
-  }
+  HARDENED_TRY(
+      keyblob_key_unmask(ikm, ARRAYSIZE(unmasked_ikm_data), unmasked_ikm_data));
   otcrypto_const_byte_buf_t unmasked_ikm = {
       .data = (unsigned char *)unmasked_ikm_data,
       .len = ikm->config.key_length,

--- a/sw/device/lib/crypto/impl/key_transport.c
+++ b/sw/device/lib/crypto/impl/key_transport.c
@@ -6,11 +6,11 @@
 
 #include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/aes_kwp/aes_kwp.h"
 #include "sw/device/lib/crypto/impl/integrity.h"
 #include "sw/device/lib/crypto/impl/keyblob.h"
 #include "sw/device/lib/crypto/impl/status.h"
-#include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
 #include "sw/device/lib/crypto/include/drbg.h"
 
@@ -177,6 +177,9 @@ otcrypto_status_t otcrypto_key_wrap(const otcrypto_blinded_key_t *key_to_wrap,
     return OTCRYPTO_BAD_ARGS;
   }
 
+  // Ensure the entropy complex is initialized.
+  HARDENED_TRY(entropy_complex_check());
+
   // Check the integrity of the key material we are wrapping.
   if (launder32(integrity_blinded_key_check(key_to_wrap)) !=
       kHardenedBoolTrue) {
@@ -213,6 +216,7 @@ otcrypto_status_t otcrypto_key_wrap(const otcrypto_blinded_key_t *key_to_wrap,
   uint32_t config_words = sizeof(otcrypto_key_config_t) / sizeof(uint32_t);
   size_t plaintext_num_words = config_words + 2 + keyblob_words;
   uint32_t plaintext[plaintext_num_words];
+  hardened_memshred(plaintext, ARRAYSIZE(plaintext));
   hardened_memcpy(plaintext, (uint32_t *)&key_to_wrap->config, config_words);
   plaintext[config_words] = key_to_wrap->checksum;
   plaintext[config_words + 1] = keyblob_words;
@@ -235,6 +239,9 @@ otcrypto_status_t otcrypto_key_unwrap(otcrypto_const_word32_buf_t wrapped_key,
     return OTCRYPTO_BAD_ARGS;
   }
 
+  // Ensure the entropy complex is initialized.
+  HARDENED_TRY(entropy_complex_check());
+
   // Check the integrity/lengths/mode of the key encryption key, and construct
   // an internal AES key.
   aes_key_t kek;
@@ -247,6 +254,7 @@ otcrypto_status_t otcrypto_key_unwrap(otcrypto_const_word32_buf_t wrapped_key,
 
   // Unwrap the key.
   uint32_t plaintext[wrapped_key.len];
+  hardened_memshred(plaintext, ARRAYSIZE(plaintext));
   HARDENED_TRY(aes_kwp_unwrap(kek, wrapped_key.data,
                               wrapped_key.len * sizeof(uint32_t), success,
                               plaintext));
@@ -331,6 +339,9 @@ otcrypto_status_t otcrypto_export_blinded_key(
     return OTCRYPTO_BAD_ARGS;
   }
 
+  // Ensure the entropy complex is initialized.
+  HARDENED_TRY(entropy_complex_check());
+
   // Check key integrity.
   if (launder32(integrity_blinded_key_check(blinded_key)) !=
       kHardenedBoolTrue) {
@@ -358,6 +369,10 @@ otcrypto_status_t otcrypto_export_blinded_key(
                     keyblob_share_num_words(blinded_key->config));
   HARDENED_CHECK_EQ(key_share1.len,
                     keyblob_share_num_words(blinded_key->config));
+
+  // Randomize the destination buffers.
+  hardened_memshred(key_share0.data, key_share0.len);
+  hardened_memshred(key_share1.data, key_share1.len);
 
   // Check the length of the keyblob.
   size_t keyblob_words = launder32(keyblob_num_words(blinded_key->config));

--- a/sw/device/lib/crypto/impl/keyblob.c
+++ b/sw/device/lib/crypto/impl/keyblob.c
@@ -94,6 +94,9 @@ status_t keyblob_from_shares(const uint32_t *share0, const uint32_t *share1,
   // Entropy complex must be initialized for `hardened_memcpy`.
   HARDENED_TRY(entropy_complex_check());
 
+  // Randomize the keyblob contents before writing shares.
+  hardened_memshred(keyblob, keyblob_num_words(config));
+
   size_t share_words = keyblob_share_num_words(config);
   hardened_memcpy(keyblob, share0, share_words);
   hardened_memcpy(keyblob + share_words, share1, share_words);

--- a/sw/device/lib/crypto/impl/kmac_kdf.c
+++ b/sw/device/lib/crypto/impl/kmac_kdf.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/crypto/include/kmac_kdf.h"
 
+#include "sw/device/lib/base/hardened_memory.h"
 #include "sw/device/lib/base/math.h"
 #include "sw/device/lib/crypto/drivers/kmac.h"
 #include "sw/device/lib/crypto/impl/integrity.h"
@@ -100,6 +101,10 @@ otcrypto_status_t otcrypto_kmac_kdf(
       keyblob_num_words(output_key_material->config) * sizeof(uint32_t)) {
     return OTCRYPTO_BAD_ARGS;
   }
+
+  // Randomize the keyblob memory.
+  hardened_memshred(output_key_material->keyblob,
+                    keyblob_num_words(output_key_material->config));
 
   switch (launder32(key_derivation_key->config.key_mode)) {
     case kOtcryptoKeyModeKdfKmac128: {

--- a/sw/device/lib/crypto/impl/rsa.c
+++ b/sw/device/lib/crypto/impl/rsa.c
@@ -5,6 +5,7 @@
 #include "sw/device/lib/crypto/include/rsa.h"
 
 #include "sw/device/lib/base/hardened_memory.h"
+#include "sw/device/lib/base/math.h"
 #include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/integrity.h"
 #include "sw/device/lib/crypto/impl/rsa/rsa_encryption.h"
@@ -200,6 +201,10 @@ otcrypto_status_t otcrypto_rsa_private_key_from_exponents(
 
   // Check the mode and lengths for the private key.
   HARDENED_TRY(private_key_structural_check(size, private_key));
+
+  // Randomize the keyblob.
+  hardened_memshred(private_key->keyblob,
+                    ceil_div(private_key->keyblob_length, sizeof(uint32_t)));
 
   switch (size) {
     case kOtcryptoRsaSize2048: {
@@ -460,6 +465,10 @@ otcrypto_status_t otcrypto_rsa_keygen_async_finalize(
   // Check the caller-provided private key buffer.
   HARDENED_TRY(private_key_structural_check(size, private_key));
 
+  // Randomize the keyblob memory.
+  hardened_memshred(private_key->keyblob,
+                    ceil_div(private_key->keyblob_length, sizeof(uint32_t)));
+
   // Call the required finalize() operation.
   switch (size) {
     case kOtcryptoRsaSize2048: {
@@ -569,6 +578,10 @@ otcrypto_status_t otcrypto_rsa_keypair_from_cofactor_async_finalize(
 
   // Check the caller-provided private key buffer.
   HARDENED_TRY(private_key_structural_check(size, private_key));
+
+  // Randomize the keyblob memory.
+  hardened_memshred(private_key->keyblob,
+                    ceil_div(private_key->keyblob_length, sizeof(uint32_t)));
 
   // Call the required finalize() operation.
   switch (size) {


### PR DESCRIPTION
Backport to earlgrey_1.0.0 of a PR merged to master: https://github.com/lowRISC/opentitan/pull/27297.

Required for the backport of https://github.com/zerorisc/expo/pull/32.

> Covers most of https://github.com/lowRISC/opentitan/issues/20517 , but leaves AES-GCM and P256/P384 OTBN code untouched for now to avoid conflicts with other in-flight PRs.
> 
> Includes a couple of small fixes I noticed along the way while crawling through the code looking for sensitive buffers to randomize; where applicable, the commit messages explain these.
> 
> Resolves https://github.com/lowRISC/opentitan/issues/20308 as a side effect.