### PR TITLE
[expo-cryptolib] [backport] [crypto] Backport remaining commit from #27297

### DIFF
--- a/sw/device/lib/crypto/drivers/kmac.c
+++ b/sw/device/lib/crypto/drivers/kmac.c
@@ -549,16 +549,19 @@ static status_t kmac_write_key_block(kmac_blinded_key_t *key) {
       KMAC_KEY_LEN_REG_RESVAL, KMAC_KEY_LEN_LEN_FIELD, key_len_enum);
   abs_mmio_write32(kKmacBaseAddr + KMAC_KEY_LEN_REG_OFFSET, key_len_reg);
 
-  // Write random words to the key registers.
+  // Write random words to the key registers first for SCA defense.
   for (size_t i = 0; i * sizeof(uint32_t) < key->len; i++) {
     abs_mmio_write32(kKmacKeyShare0Addr + i * sizeof(uint32_t),
                      ibex_rnd32_read());
+  }
+  for (size_t i = 0; i * sizeof(uint32_t) < key->len; i++) {
+    abs_mmio_write32(kKmacKeyShare0Addr + i * sizeof(uint32_t), key->share0[i]);
+  }
+  for (size_t i = 0; i * sizeof(uint32_t) < key->len; i++) {
     abs_mmio_write32(kKmacKeyShare1Addr + i * sizeof(uint32_t),
                      ibex_rnd32_read());
   }
-
   for (size_t i = 0; i * sizeof(uint32_t) < key->len; i++) {
-    abs_mmio_write32(kKmacKeyShare0Addr + i * sizeof(uint32_t), key->share0[i]);
     abs_mmio_write32(kKmacKeyShare1Addr + i * sizeof(uint32_t), key->share1[i]);
   }
 


### PR DESCRIPTION
The backport of https://github.com/lowRISC/opentitan/pull/27297/ in #47 was missing the last commit decoupling two loops randomizing key buffers in the KMAC implementation.

This PR simply backports that remaining commit.

Required for backport of #33. 