### PR TITLE
[expo-cryptolib] [backport] [crypto] Harden the KMAC driver.

### DIFF
--- a/sw/device/lib/crypto/drivers/BUILD
+++ b/sw/device/lib/crypto/drivers/BUILD
@@ -123,6 +123,7 @@ cc_library(
         "//sw/device/lib/base:abs_mmio",
         "//sw/device/lib/base:bitfield",
         "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base:hardened_memory",
         "//sw/device/lib/base:macros",
         "//sw/device/lib/crypto/impl:status",
     ],


### PR DESCRIPTION
Backport to earlgrey_1.0.0 of a PR that was previously merged to master, #33.

> Pass through and add hardened enums, control flow redundancy checks, and hardened MMIO reads/writes to the KMAC driver.