### PR TITLE
[expo-cryptolib] [crypto] Add sc_ prefix to hmac_hmac_sha256 call in silicon_creator HMAC functest

### DIFF
--- a/sw/device/silicon_creator/lib/drivers/hmac_functest.c
+++ b/sw/device/silicon_creator/lib/drivers/hmac_functest.c
@@ -122,9 +122,9 @@ rom_error_t hmac_hmac_sha256_test(void) {
 
 rom_error_t hmac_hmac_sha256_unaligned_test(void) {
   hmac_digest_t digest;
-  hmac_hmac_sha256(kGettysburgPreludeUnaligned.payload,
-                   sizeof(kGettysburgPreludeUnaligned.payload) - 1, kHmacKey,
-                   /*big_endian_digest=*/false, &digest);
+  sc_hmac_hmac_sha256(kGettysburgPreludeUnaligned.payload,
+                      sizeof(kGettysburgPreludeUnaligned.payload) - 1, kHmacKey,
+                      /*big_endian_digest=*/false, &digest);
   const size_t len = ARRAYSIZE(digest.digest);
   for (int i = 0; i < len; ++i) {
     LOG_INFO("word %d = 0x%08x", i, digest.digest[i]);


### PR DESCRIPTION
This PR simply adds the necessary `sc_` prefix as introduced in commit `c94f802e4b740c041dcf13697f1941d2bc98780d` to the call to `hmac_hmac_sha256` in `hmac_hmac_sha256_unaligned_test` from commit `7e07c8b769aa71d7781637feccd0dee99baa3fd8`, fixing the corresponding test build.