### PR TITLE
[expo-cryptolib] [crypto] Add Ed25519 C implementation code and testing.

### DIFF
--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -1,3 +1,7 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
@@ -94,7 +98,12 @@ cc_library(
     hdrs = ["//sw/device/lib/crypto/include:ed25519.h"],
     target_compatible_with = [OPENTITAN_CPU],
     deps = [
+        ":integrity",
+        ":sha2",
         ":status",
+        "//sw/device/lib/base:math",
+        "//sw/device/lib/crypto/drivers:entropy",
+        "//sw/device/lib/crypto/impl/ecc:ed25519",
         "//sw/device/lib/crypto/include:datatypes",
     ],
 )

--- a/sw/device/lib/crypto/impl/ecc/BUILD
+++ b/sw/device/lib/crypto/impl/ecc/BUILD
@@ -1,3 +1,7 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
@@ -33,5 +37,20 @@ cc_library(
         "//sw/device/lib/crypto/drivers:rv_core_ibex",
         "//sw/device/lib/crypto/impl:status",
         "//sw/otbn/crypto:run_p384",
+    ],
+)
+
+cc_library(
+    name = "ed25519",
+    srcs = ["ed25519.c"],
+    hdrs = ["ed25519.h"],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        "//sw/device/lib/base:hardened",
+        "//sw/device/lib/base:hardened_memory",
+        "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/crypto/drivers:rv_core_ibex",
+        "//sw/device/lib/crypto/impl:status",
+        "//sw/otbn/crypto:run_ed25519",
     ],
 )

--- a/sw/device/lib/crypto/impl/ecc/ed25519.c
+++ b/sw/device/lib/crypto/impl/ecc/ed25519.c
@@ -1,0 +1,193 @@
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/impl/ecc/ed25519.h"
+
+// Module ID for status codes.
+#define MODULE_ID MAKE_MODULE_ID('e', '2', 'r')
+
+// Declare the OTBN app.
+OTBN_DECLARE_APP_SYMBOLS(run_ed25519);  // The OTBN Ed25519 app.
+static const otbn_app_t kOtbnAppEd25519 = OTBN_APP_T_INIT(run_ed25519);
+
+// Declare offsets for input and output buffers.
+OTBN_DECLARE_SYMBOL_ADDR(run_ed25519, ed25519_mode);     // Mode of operation..
+OTBN_DECLARE_SYMBOL_ADDR(run_ed25519, ed25519_message);  // Message.
+OTBN_DECLARE_SYMBOL_ADDR(run_ed25519, ed25519_sig_R);    // R signature point.
+OTBN_DECLARE_SYMBOL_ADDR(run_ed25519, ed25519_sig_S);    // S signature scalar.
+OTBN_DECLARE_SYMBOL_ADDR(run_ed25519, ed25519_hash_h);   // Secret key hash h.
+OTBN_DECLARE_SYMBOL_ADDR(run_ed25519, ed25519_hash_k);   // Pre-computed hash k.
+OTBN_DECLARE_SYMBOL_ADDR(run_ed25519, ed25519_ctx);      // Context string.
+OTBN_DECLARE_SYMBOL_ADDR(run_ed25519, ed25519_ctx_len);  // Context length.
+OTBN_DECLARE_SYMBOL_ADDR(run_ed25519, ed25519_public_key);     // Public key.
+OTBN_DECLARE_SYMBOL_ADDR(run_ed25519, ed25519_verify_result);  // Verify result.
+
+static const otbn_addr_t kOtbnVarEd25519Mode =
+    OTBN_ADDR_T_INIT(run_ed25519, ed25519_mode);
+static const otbn_addr_t kOtbnVarEd25519Message =
+    OTBN_ADDR_T_INIT(run_ed25519, ed25519_message);
+static const otbn_addr_t kOtbnVarEd25519SigR =
+    OTBN_ADDR_T_INIT(run_ed25519, ed25519_sig_R);
+static const otbn_addr_t kOtbnVarEd25519SigS =
+    OTBN_ADDR_T_INIT(run_ed25519, ed25519_sig_S);
+static const otbn_addr_t kOtbnVarEd25519HashH =
+    OTBN_ADDR_T_INIT(run_ed25519, ed25519_hash_h);
+static const otbn_addr_t kOtbnVarEd25519HashK =
+    OTBN_ADDR_T_INIT(run_ed25519, ed25519_hash_k);
+static const otbn_addr_t kOtbnVarEd25519Ctx =
+    OTBN_ADDR_T_INIT(run_ed25519, ed25519_ctx);
+static const otbn_addr_t kOtbnVarEd25519CtxLen =
+    OTBN_ADDR_T_INIT(run_ed25519, ed25519_ctx_len);
+static const otbn_addr_t kOtbnVarEd25519PublicKey =
+    OTBN_ADDR_T_INIT(run_ed25519, ed25519_public_key);
+static const otbn_addr_t kOtbnVarEd25519VerifyResult =
+    OTBN_ADDR_T_INIT(run_ed25519, ed25519_verify_result);
+
+// Declare mode constants.
+OTBN_DECLARE_SYMBOL_ADDR(run_ed25519, ED25519_MODE_SIGN);  // Ed25519 signing.
+OTBN_DECLARE_SYMBOL_ADDR(run_ed25519,
+                         ED25519_MODE_VERIFY);  // Ed25519 verification.
+
+static const uint32_t kOtbnEd25519ModeSign =
+    OTBN_ADDR_T_INIT(run_ed25519, ED25519_MODE_SIGN);
+static const uint32_t kOtbnEd25519ModeVerify =
+    OTBN_ADDR_T_INIT(run_ed25519, ED25519_MODE_VERIFY);
+
+enum {
+  /*
+   * Mode is represented by a single word.
+   */
+  kOtbnEd25519ModeWords = 1,
+};
+
+/**
+ * Set the context for signature generation or verification.
+ *
+ * @param context Context to set (little-endian).
+ * @return OK or error.
+ */
+static status_t set_context(const uint32_t context[kEd25519ContextWords],
+                            const uint32_t context_length) {
+  // Ensure that our context length is valid; if not, fail early.
+  if (context_length > kEd25519ContextWords) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_LE(context_length, kEd25519ContextWords);
+
+  // Write the full context string.
+  HARDENED_TRY(otbn_dmem_write(context_length, context, kOtbnVarEd25519Ctx));
+
+  // Set the context length.
+  return otbn_dmem_write(1, &context_length, kOtbnVarEd25519CtxLen);
+}
+
+status_t ed25519_sign_start(
+    const uint32_t prehashed_message[kEd25519PreHashWords],
+    const uint32_t hash_h[kEd25519HashWords],
+    const uint32_t context[kEd25519ContextWords],
+    const uint32_t context_length) {
+  // Load the Ed25519 app. Fails if OTBN is non-idle.
+  HARDENED_TRY(otbn_load_app(kOtbnAppEd25519));
+
+  // Set mode so start() will jump into signing.
+  uint32_t mode = kOtbnEd25519ModeSign;
+  HARDENED_TRY(
+      otbn_dmem_write(kOtbnEd25519ModeWords, &mode, kOtbnVarEd25519Mode));
+
+  // Set the precomputed private key hash h.
+  HARDENED_TRY(
+      otbn_dmem_write(kEd25519PreHashWords, hash_h, kOtbnVarEd25519HashH));
+
+  // Set the context string.
+  HARDENED_TRY(set_context(context, context_length));
+
+  // Set the pre-hashed message.
+  HARDENED_TRY(otbn_dmem_write(kEd25519HashWords, prehashed_message,
+                               kOtbnVarEd25519Message));
+
+  // Start the OTBN routine.
+  return otbn_execute();
+}
+
+status_t ed25519_sign_finalize(ed25519_signature_t *result) {
+  // Spin here waiting for OTBN to complete.
+  HARDENED_TRY(otbn_busy_wait_for_done());
+
+  // Read signature R out of OTBN dmem.
+  HARDENED_TRY(otbn_dmem_read(8, kOtbnVarEd25519SigR, result->r));
+
+  // Read signature S out of OTBN dmem.
+  HARDENED_TRY(otbn_dmem_read(8, kOtbnVarEd25519SigS, result->s));
+
+  // Wipe DMEM.
+  return otbn_dmem_sec_wipe();
+}
+
+status_t ed25519_verify_start(
+    const ed25519_signature_t *signature,
+    const uint32_t prehashed_message[kEd25519PreHashWords],
+    const uint32_t hash_k[kEd25519HashWords], const ed25519_point_t *public_key,
+    const uint32_t context[kEd25519ContextWords],
+    const uint32_t context_length) {
+  // Load the P-256 app and set up data pointers
+  HARDENED_TRY(otbn_load_app(kOtbnAppEd25519));
+
+  // Set mode so start() will jump into verifying.
+  uint32_t mode = kOtbnEd25519ModeVerify;
+  HARDENED_TRY(
+      otbn_dmem_write(kOtbnEd25519ModeWords, &mode, kOtbnVarEd25519Mode));
+
+  // Set the pre-hashed message to the provided digest.
+  HARDENED_TRY(otbn_dmem_write(kEd25519HashWords, prehashed_message,
+                               kOtbnVarEd25519Message));
+
+  // Set the precomputed hash value k.
+  HARDENED_TRY(
+      otbn_dmem_write(kEd25519HashWords, hash_k, kOtbnVarEd25519HashK));
+
+  // Set the context string.
+  HARDENED_TRY(set_context(context, context_length));
+
+  // Set the signature R.
+  HARDENED_TRY(
+      otbn_dmem_write(kEd25519PointWords, signature->r, kOtbnVarEd25519SigR));
+
+  // Set the signature S.
+  HARDENED_TRY(
+      otbn_dmem_write(kEd25519ScalarWords, signature->s, kOtbnVarEd25519SigS));
+
+  // Set the public key.
+  HARDENED_TRY(otbn_dmem_write(kEd25519PointWords, public_key->data,
+                               kOtbnVarEd25519PublicKey));
+
+  // Start the OTBN routine.
+  return otbn_execute();
+}
+
+status_t ed25519_verify_finalize(const ed25519_signature_t *signature,
+                                 hardened_bool_t *result) {
+  // Spin here waiting for OTBN to complete.
+  HARDENED_TRY(otbn_busy_wait_for_done());
+
+  // Read verification result out of OTBN dmem.
+  uint32_t verify_result;
+  HARDENED_TRY(otbn_dmem_read(1, kOtbnVarEd25519VerifyResult, &verify_result));
+
+  // Wipe DMEM.
+  HARDENED_TRY(otbn_dmem_sec_wipe());
+
+  // Return a result based on the read value.
+  *result = kHardenedBoolFalse;
+  if (launder32(verify_result) == kEd25519VerifySuccess) {
+    HARDENED_CHECK_EQ(verify_result, kEd25519VerifySuccess);
+    *result = kHardenedBoolTrue;
+  } else if (launder32(verify_result) == kEd25519VerifyFailure) {
+    HARDENED_CHECK_EQ(verify_result, kEd25519VerifyFailure);
+  } else {
+    // If we're here, we've read an invalid result.
+    return OTCRYPTO_FATAL_ERR;
+  }
+
+  return OTCRYPTO_OK;
+}

--- a/sw/device/lib/crypto/impl/ecc/ed25519.h
+++ b/sw/device/lib/crypto/impl/ecc/ed25519.h
@@ -1,0 +1,205 @@
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_ED25519_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_ED25519_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "sw/device/lib/base/hardened.h"
+#include "sw/device/lib/crypto/drivers/otbn.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+enum {
+  /**
+   * Length of a Ed25519 curve point coordinate in bits (modulo p).
+   */
+  kEd25519SecretBits = 256,
+  /**
+   * Length of a Ed25519 curve point coordinate in bytes.
+   */
+  kEd25519SecretBytes = kEd25519SecretBits / 8,
+  /**
+   * Length of a Ed25519 curve point coordinate in words.
+   */
+  kEd25519SecretWords = kEd25519SecretBytes / sizeof(uint32_t),
+  /**
+   * Length of a Ed25519 curve point coordinate in bits (modulo p).
+   */
+  kEd25519HashBits = 512,
+  /**
+   * Length of a Ed25519 curve point coordinate in bytes.
+   */
+  kEd25519HashBytes = kEd25519HashBits / 8,
+  /**
+   * Length of a Ed25519 curve point coordinate in words.
+   */
+  kEd25519HashWords = kEd25519HashBytes / sizeof(uint32_t),
+  /**
+   * Length of a Ed25519 curve point coordinate in bits (modulo p).
+   */
+  kEd25519PreHashBits = 512,
+  /**
+   * Length of a Ed25519 curve point coordinate in bytes.
+   */
+  kEd25519PreHashBytes = kEd25519PreHashBits / 8,
+  /**
+   * Length of a Ed25519 curve point coordinate in words.
+   */
+  kEd25519PreHashWords = kEd25519PreHashBytes / sizeof(uint32_t),
+  /**
+   * Length of a Ed25519 curve point coordinate in bits (modulo p).
+   */
+  kEd25519ScalarBits = 256,
+  /**
+   * Length of a Ed25519 curve point coordinate in bytes.
+   */
+  kEd25519ScalarBytes = kEd25519ScalarBits / 8,
+  /**
+   * Length of a Ed25519 curve point coordinate in words.
+   */
+  kEd25519ScalarWords = kEd25519ScalarBytes / sizeof(uint32_t),
+  /**
+   * Length of a element in the Ed25519 scalar field.
+   */
+  kEd25519PointBits = 256,
+  /**
+   * Length of a secret scalar in bytes.
+   */
+  kEd25519PointBytes = kEd25519PointBits / 8,
+  /**
+   * Length of secret scalar in words.
+   */
+  kEd25519PointWords = kEd25519PointBytes / sizeof(uint32_t),
+  /**
+   * Length of Ed25519 context in bits, including the flag.
+   */
+  kEd25519ContextBits = 2048,
+  /**
+   * Length of Ed25519 context in bytes, including the flag.
+   */
+  kEd25519ContextBytes = kEd25519ContextBits / 8,
+  /**
+   * Length of Ed25519 context in words, including the flag.
+   */
+  kEd25519ContextWords = kEd25519ContextBytes / sizeof(uint32_t),
+  /**
+   * A successful Ed25519 signature verification result.
+   */
+  kEd25519VerifySuccess = 0xf77fe650,
+  /**
+   * A failed Ed25519 signature verification result.
+   */
+  kEd25519VerifyFailure = 0xeda2bfaf,
+};
+
+/**
+ * A type that holds an Ed25519 private key.
+ */
+typedef struct ed25519_secret {
+  uint32_t data[kEd25519SecretWords];
+} ed25519_secret_t;
+
+/**
+ * A type that holds an encoded Ed25519 point.
+ *
+ * The point stored in the data field should be encoded as described in RFC 8032
+ * section 5.2.2.
+ */
+typedef struct ed25519_point {
+  uint32_t data[kEd25519SecretWords];
+} ed25519_point_t;
+
+/**
+ * A type that holds a Ed25519 signature.
+ *
+ * The signature stored here should be encoded as described in RFC 8032 section
+ * 5.2.6. Specifically, r should be encoded as described in section 5.2.2, and s
+ * should be encoded as a reduced little-endian scalar.
+ */
+typedef struct ed25519_signature {
+  /**
+   * First part of the Ed25519 signature, the point R.
+   */
+  uint32_t r[kEd25519PointWords];
+  /**
+   * First part of the Ed25519 signature, the scalar S.
+   */
+  uint32_t s[kEd25519ScalarWords];
+} ed25519_signature_t;
+;
+
+/**
+ * Start an async Ed25519ph signature generation operation on OTBN.
+ * 
+ * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if OTBN is busy.
+ *
+ * @param prehashed_message Prehashed (SHA-512) message to sign.
+ * @param hash_h SHA-512 hash of the Ed25519 private key to sign with. 
+ * @param context Context to use for signing.
+ * @param context_length Length of the provided context.
+ * @return Result of the operation (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+status_t ed25519_sign_start(
+    const uint32_t prehashed_message[kEd25519PreHashWords],
+    const uint32_t hash_h[kEd25519HashWords],
+    const uint32_t context[kEd25519ContextWords],
+    const uint32_t context_length);
+
+/**
+ * Finish an async Ed25519 signature generation operation on OTBN.
+ *
+ * See the documentation of `p256_ecdsa_sign` for details.
+ *
+ * Blocks until OTBN is idle.
+ *
+ * @param[out] result Buffer in which to store the generated signature.
+ * @return Result of the operation (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+status_t ed25519_sign_finalize(ed25519_signature_t *result);
+
+/**
+ * Start an async Ed25519 signature verification operation on OTBN.
+ *
+ * This function expects the scalar value k as computed in RFC 8032 section
+ * 5.2.6 step 2 to be pre-computed and provided as a little-endian value to this
+ * function; see that section of the RFC for details.
+ * 
+ * @param signature Signature to verify.
+ * @param prehashed_message Prehashed (SHA-512) message to sign.
+ * @param hash_k Pre-computed scalar value k for verification.
+ * @param context Context to use for signing.
+ * @param context_length Length of the provided context.
+ * @return Result of the operation (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+status_t ed25519_verify_start(
+    const ed25519_signature_t *signature,
+    const uint32_t prehashed_message[kEd25519PreHashWords],
+    const uint32_t hash_k[kEd25519HashWords], const ed25519_point_t *public_key,
+    const uint32_t context[kEd25519ContextWords],
+    const uint32_t context_length);
+
+/**
+ * Finish an async Ed25519 signature verification operation on OTBN.
+ * 
+ * @param signature Signature to be verified.
+ * @param[out] result Result of verification.
+ * @return Result of the operation (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+status_t ed25519_verify_finalize(const ed25519_signature_t *signature,
+                                 hardened_bool_t *result);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_ECC_ED25519_H_

--- a/sw/device/lib/crypto/impl/ed25519.c
+++ b/sw/device/lib/crypto/impl/ed25519.c
@@ -1,75 +1,349 @@
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
-#include "sw/device/lib/crypto/include/ed25519.h"
-
+#include "sw/device/lib/base/math.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
+#include "sw/device/lib/crypto/impl/ecc/ed25519.h"
+#include "sw/device/lib/crypto/impl/integrity.h"
 #include "sw/device/lib/crypto/impl/status.h"
 #include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/ed25519.h"
+#include "sw/device/lib/crypto/include/sha2.h"
 
 // Module ID for status codes.
 #define MODULE_ID MAKE_MODULE_ID('e', '2', '5')
 
 otcrypto_status_t otcrypto_ed25519_keygen(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key) {
-  // TODO: Ed25519 is not yet implemented.
   return OTCRYPTO_NOT_IMPLEMENTED;
 }
 
 otcrypto_status_t otcrypto_ed25519_sign(
     const otcrypto_blinded_key_t *private_key,
-    otcrypto_const_byte_buf_t input_message,
+    otcrypto_const_byte_buf_t input_message, otcrypto_const_byte_buf_t context,
     otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t signature) {
-  // TODO: Ed25519 is not yet implemented.
-  return OTCRYPTO_NOT_IMPLEMENTED;
+  HARDENED_TRY(otcrypto_ed25519_sign_async_start(
+      private_key, input_message, context, sign_mode, signature));
+  return otcrypto_ed25519_sign_async_finalize(signature);
 }
 
 otcrypto_status_t otcrypto_ed25519_verify(
     const otcrypto_unblinded_key_t *public_key,
-    otcrypto_const_byte_buf_t input_message,
+    otcrypto_const_byte_buf_t input_message, otcrypto_const_byte_buf_t context,
     otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_const_word32_buf_t signature,
     hardened_bool_t *verification_result) {
-  // TODO: Ed25519 is not yet implemented.
-  return OTCRYPTO_NOT_IMPLEMENTED;
+  HARDENED_TRY(otcrypto_ed25519_verify_async_start(
+      public_key, input_message, context, sign_mode, signature));
+  return otcrypto_ed25519_verify_async_finalize(signature, verification_result);
 }
 
 otcrypto_status_t otcrypto_ed25519_keygen_async_start(
     const otcrypto_blinded_key_t *private_key) {
-  // TODO: Ed25519 is not yet implemented.
   return OTCRYPTO_NOT_IMPLEMENTED;
 }
 
 otcrypto_status_t otcrypto_ed25519_keygen_async_finalize(
     otcrypto_blinded_key_t *private_key, otcrypto_unblinded_key_t *public_key) {
-  // TODO: Ed25519 is not yet implemented.
   return OTCRYPTO_NOT_IMPLEMENTED;
+}
+
+OT_WARN_UNUSED_RESULT
+static status_t ed25519_private_key_length_check(
+    const otcrypto_blinded_key_t *private_key) {
+  if (private_key->keyblob == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  // Ensure the key isn't hardware backed (we don't support these yet).
+  if (launder32(private_key->config.hw_backed) != kHardenedBoolFalse) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(private_key->config.hw_backed, kHardenedBoolFalse);
+
+  // Check the (unmasked) length.
+  if (launder32(private_key->config.key_length) != kEd25519SecretBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(private_key->config.key_length, kEd25519SecretBytes);
+
+  // Check the keyblob length.
+  if (launder32(private_key->keyblob_length) != sizeof(ed25519_secret_t)) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(private_key->keyblob_length, sizeof(ed25519_secret_t));
+
+  return OTCRYPTO_OK;
+}
+
+OT_WARN_UNUSED_RESULT
+static status_t ed25519_signature_length_check(size_t len) {
+  if (launder32(len) > UINT32_MAX / sizeof(uint32_t) ||
+      launder32(len) * sizeof(uint32_t) != sizeof(ed25519_signature_t)) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(len * sizeof(uint32_t), sizeof(ed25519_signature_t));
+
+  return OTCRYPTO_OK;
+}
+
+OT_WARN_UNUSED_RESULT
+static status_t construct_hash_h(uint32_t hash_h[kEd25519HashWords],
+                                 const otcrypto_blinded_key_t *private_key) {
+  // Copy the private key into a byte buffer.
+  uint8_t private_key_data_buf[kEd25519SecretBytes];
+  otcrypto_const_byte_buf_t private_key_buf = {
+      .data = private_key_data_buf,
+      .len = kEd25519SecretBytes,
+  };
+
+  // TODO(#17711) Change to `hardened_memcpy`.
+  memcpy(private_key_data_buf, private_key->keyblob, kEd25519SecretBytes);
+
+  // Prepare a struct for the hashed private key.
+  uint32_t hash_h_buf[kEd25519HashWords];
+  otcrypto_hash_digest_t hash_h_digest = {
+      .data = hash_h_buf,
+      .len = kEd25519HashWords,
+  };
+
+  HARDENED_TRY(otcrypto_sha2_512(private_key_buf, &hash_h_digest));
+
+  // Copy the hashed private key into the provided buffer.
+  // TODO(#17711) Change to `hardened_memcpy`.
+  memcpy(hash_h, hash_h_buf, kEd25519HashBytes);
+
+  return OTCRYPTO_OK;
 }
 
 otcrypto_status_t otcrypto_ed25519_sign_async_start(
     const otcrypto_blinded_key_t *private_key,
-    otcrypto_const_byte_buf_t input_message,
+    otcrypto_const_byte_buf_t input_message, otcrypto_const_byte_buf_t context,
     otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t signature) {
-  // TODO: Ed25519 is not yet implemented.
-  return OTCRYPTO_NOT_IMPLEMENTED;
+  if (private_key == NULL || private_key->keyblob == NULL ||
+      input_message.data == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  // Check that the entropy complex is initialized.
+  HARDENED_TRY(entropy_complex_check());
+
+  // Check the mode; currently, only HashEd25519 is allowed.
+  if (launder32(sign_mode) != kOtcryptoEddsaSignModeHashEddsa) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(sign_mode, kOtcryptoEddsaSignModeHashEddsa);
+
+  // Check the input message size: since only HashEd25519 is allowed presently,
+  // this must be the full size of the prehash output.
+  if (launder32(input_message.len) != kEd25519PreHashBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(input_message.len, kEd25519PreHashBytes);
+
+  // TODO: how will we check context size? should we?
+
+  // Check the integrity of the private key.
+  if (launder32(integrity_blinded_key_check(private_key)) !=
+      kHardenedBoolTrue) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(integrity_blinded_key_check(private_key),
+                    kHardenedBoolTrue);
+
+  // Ensure that the key mode is correct.
+  if (launder32(private_key->config.key_mode) != kOtcryptoKeyModeEd25519) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(private_key->config.key_mode, kOtcryptoKeyModeEd25519);
+
+  // Check the private key length.
+  HARDENED_TRY(ed25519_private_key_length_check(private_key));
+
+  // Hash the private key.
+  uint32_t hash_h[kEd25519HashWords];
+  HARDENED_TRY(construct_hash_h(hash_h, private_key));
+
+  // Copy the input message into a 32-bit aligned buffer.
+  size_t input_message_wordlen = ceil_div(input_message.len, sizeof(uint32_t));
+  uint32_t input_message_aligned[input_message_wordlen];
+  // TODO(#17711) Change to `hardened_memcpy`.
+  memcpy(input_message_aligned, input_message.data, input_message.len);
+  memset(input_message_aligned, 0,
+         sizeof(input_message_aligned) - input_message.len);
+
+  // Copy the context into a 32-bit aligned buffer.
+  size_t context_wordlen = ceil_div(context.len, sizeof(uint32_t));
+  uint32_t context_aligned[context_wordlen];
+  // TODO(#17711) Change to `hardened_memcpy`.
+  memcpy(context_aligned, context.data, context.len);
+  memset(context_aligned, 0, sizeof(context_aligned) - context.len);
+
+  // Start the asynchronous signature-generation routine.
+  return ed25519_sign_start(input_message_aligned, hash_h, context_aligned,
+                            context.len);
 }
 
 otcrypto_status_t otcrypto_ed25519_sign_async_finalize(
     otcrypto_word32_buf_t signature) {
-  // TODO: Ed25519 is not yet implemented.
-  return OTCRYPTO_NOT_IMPLEMENTED;
+  if (signature.data == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  // Ensure the entropy complex is initialized.
+  HARDENED_TRY(entropy_complex_check());
+
+  // Check the signature length.
+  HARDENED_TRY(ed25519_signature_length_check(signature.len));
+  ed25519_signature_t *sig_ed25519 = (ed25519_signature_t *)signature.data;
+
+  // Note: This operation wipes DMEM, so if an error occurs after this
+  // point then the signature would be unrecoverable. This should be the
+  // last potentially error-causing line before returning to the caller.
+  return ed25519_sign_finalize(sig_ed25519);
+}
+
+OT_WARN_UNUSED_RESULT
+static status_t ed25519_public_key_length_check(
+    const otcrypto_unblinded_key_t *public_key) {
+  if (launder32(public_key->key_length) != sizeof(ed25519_point_t)) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(public_key->key_length, sizeof(ed25519_point_t));
+  return OTCRYPTO_OK;
+}
+
+OT_WARN_UNUSED_RESULT
+static status_t construct_hash_k(uint32_t hash_k[kEd25519HashWords],
+                                 otcrypto_const_word32_buf_t signature,
+                                 otcrypto_const_byte_buf_t context,
+                                 const otcrypto_unblinded_key_t *public_key,
+                                 otcrypto_const_byte_buf_t input_message) {
+  // Initialize the SHA-512 computation.
+  otcrypto_sha2_context_t ctx;
+  HARDENED_TRY(otcrypto_sha2_init(kOtcryptoHashModeSha512, &ctx));
+
+  // Update with the domain separation string, pre-hash flag, and context
+  // length all together.
+  uint8_t domain_sep_data[34] = {'S', 'i', 'g', 'E', 'd', '2',  '5', '5', '1',
+                                 '9', ' ', 'n', 'o', ' ', 'E',  'd', '2', '5',
+                                 '5', '1', '9', ' ', 'c', 'o',  'l', 'l', 'i',
+                                 's', 'i', 'o', 'n', 's', 0x01, 0x00};
+  domain_sep_data[33] = (uint8_t)context.len;
+  otcrypto_const_byte_buf_t domain_sep_buf = {
+      .data = domain_sep_data,
+      .len = sizeof(domain_sep_data),
+  };
+  HARDENED_TRY(otcrypto_sha2_update(&ctx, domain_sep_buf));
+
+  // Update with the context.
+  HARDENED_TRY(otcrypto_sha2_update(&ctx, context));
+
+  // Update with the first half of the signature, R.
+  otcrypto_const_byte_buf_t signature_point_buf = {
+      .data = (uint8_t *)signature.data,
+      .len = kEd25519PointBytes,
+  };
+  HARDENED_TRY(otcrypto_sha2_update(&ctx, signature_point_buf));
+
+  // Update with the public key, A.
+  otcrypto_const_byte_buf_t public_key_buf = {
+      .data = (uint8_t *)public_key->key,
+      .len = kEd25519PointBytes,
+  };
+  HARDENED_TRY(otcrypto_sha2_update(&ctx, public_key_buf));
+
+  // Update with the pre-hashed message, PH(M).
+  HARDENED_TRY(otcrypto_sha2_update(&ctx, input_message));
+
+  // Finalize the computed digest.
+  otcrypto_hash_digest_t hash_k_digest = {
+      .data = hash_k,
+      .len = kEd25519HashWords,
+  };
+  HARDENED_TRY(otcrypto_sha2_final(&ctx, &hash_k_digest));
+
+  return OTCRYPTO_OK;
 }
 
 otcrypto_status_t otcrypto_ed25519_verify_async_start(
     const otcrypto_unblinded_key_t *public_key,
-    otcrypto_const_byte_buf_t input_message,
+    otcrypto_const_byte_buf_t input_message, otcrypto_const_byte_buf_t context,
     otcrypto_eddsa_sign_mode_t sign_mode,
     otcrypto_const_word32_buf_t signature) {
-  // TODO: Ed25519 is not yet implemented.
-  return OTCRYPTO_NOT_IMPLEMENTED;
+  if (public_key == NULL || signature.data == NULL ||
+      input_message.data == NULL || public_key->key == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  // Ensure the entropy complex is initialized.
+  HARDENED_TRY(entropy_complex_check());
+
+  // Check the integrity of the public key.
+  if (launder32(integrity_unblinded_key_check(public_key)) !=
+      kHardenedBoolTrue) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(integrity_unblinded_key_check(public_key),
+                    kHardenedBoolTrue);
+
+  // Check the public key mode.
+  if (launder32(public_key->key_mode) != kOtcryptoKeyModeEd25519) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(public_key->key_mode, kOtcryptoKeyModeEd25519);
+
+  // Check the public key size.
+  HARDENED_TRY(ed25519_public_key_length_check(public_key));
+  ed25519_point_t *pk = (ed25519_point_t *)public_key->key;
+
+  // Check the digest length.
+  if (launder32(input_message.len) != kEd25519PreHashBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  HARDENED_CHECK_EQ(input_message.len, kEd25519PreHashBytes);
+
+  // Check the signature lengths.
+  HARDENED_TRY(ed25519_signature_length_check(signature.len));
+  ed25519_signature_t *sig = (ed25519_signature_t *)signature.data;
+
+  // Copy the input message into a 32-bit aligned buffer.
+  size_t input_message_wordlen = ceil_div(input_message.len, sizeof(uint32_t));
+  uint32_t input_message_aligned[input_message_wordlen];
+  memset(input_message_aligned, 0, sizeof(input_message_aligned));
+  memcpy(input_message_aligned, input_message.data, input_message.len);
+
+  // Compute the pre-computed hash k
+  uint32_t hash_k[kEd25519HashWords];
+  HARDENED_TRY(
+      construct_hash_k(hash_k, signature, context, public_key, input_message));
+
+  size_t context_wordlen = ceil_div(context.len, sizeof(uint32_t));
+  uint32_t context_aligned[context_wordlen];
+  // TODO(#17711) Change to `hardened_memcpy`.
+  memcpy(context_aligned, context.data, context.len);
+  memset(context_aligned, 0, sizeof(context_aligned) - context.len);
+
+  // Start the asynchronous signature-verification routine.
+  return ed25519_verify_start(sig, input_message_aligned, hash_k, pk,
+                              context_aligned, context.len);
 }
 
 otcrypto_status_t otcrypto_ed25519_verify_async_finalize(
+    otcrypto_const_word32_buf_t signature,
     hardened_bool_t *verification_result) {
-  // TODO: Ed25519 is not yet implemented.
-  return OTCRYPTO_NOT_IMPLEMENTED;
+  if (verification_result == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  // Ensure the entropy complex is initialized.
+  HARDENED_TRY(entropy_complex_check());
+
+  HARDENED_TRY(ed25519_signature_length_check(signature.len));
+  ed25519_signature_t *sig_ed25519 = (ed25519_signature_t *)signature.data;
+  return ed25519_verify_finalize(sig_ed25519, verification_result);
 }

--- a/sw/device/lib/crypto/include/ed25519.h
+++ b/sw/device/lib/crypto/include/ed25519.h
@@ -1,3 +1,7 @@
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
 // Copyright lowRISC contributors (OpenTitan project).
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
@@ -51,6 +55,7 @@ otcrypto_status_t otcrypto_ed25519_keygen(otcrypto_blinded_key_t *private_key,
  *
  * @param private_key Pointer to the blinded private key struct.
  * @param input_message Input message to be signed.
+ * @param context Context for signing.
  * @param sign_mode EdDSA signature hashing mode.
  * @param[out] signature Pointer to the EdDSA signature with (r,s) values.
  * @return Result of the Ed25519 signature generation.
@@ -58,7 +63,7 @@ otcrypto_status_t otcrypto_ed25519_keygen(otcrypto_blinded_key_t *private_key,
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ed25519_sign(
     const otcrypto_blinded_key_t *private_key,
-    otcrypto_const_byte_buf_t input_message,
+    otcrypto_const_byte_buf_t input_message, otcrypto_const_byte_buf_t context,
     otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t signature);
 
 /**
@@ -71,6 +76,7 @@ otcrypto_status_t otcrypto_ed25519_sign(
  *
  * @param public_key Pointer to the unblinded public key struct.
  * @param input_message Input message to be signed for verification.
+ * @param context Context for signing.
  * @param sign_mode EdDSA signature hashing mode.
  * @param signature Pointer to the signature to be verified.
  * @param[out] verification_result Whether the signature passed verification.
@@ -79,7 +85,7 @@ otcrypto_status_t otcrypto_ed25519_sign(
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ed25519_verify(
     const otcrypto_unblinded_key_t *public_key,
-    otcrypto_const_byte_buf_t input_message,
+    otcrypto_const_byte_buf_t input_message, otcrypto_const_byte_buf_t context,
     otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_const_word32_buf_t signature,
     hardened_bool_t *verification_result);
 
@@ -120,6 +126,7 @@ otcrypto_status_t otcrypto_ed25519_keygen_async_finalize(
  *
  * @param private_key Pointer to the blinded private key struct.
  * @param input_message Input message to be signed.
+ * @param context Context for signing.
  * @param sign_mode EdDSA signature hashing mode.
  * @param[out] signature Pointer to the EdDSA signature to get (r) value.
  * @return Result of async Ed25519 start operation.
@@ -127,7 +134,7 @@ otcrypto_status_t otcrypto_ed25519_keygen_async_finalize(
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ed25519_sign_async_start(
     const otcrypto_blinded_key_t *private_key,
-    otcrypto_const_byte_buf_t input_message,
+    otcrypto_const_byte_buf_t input_message, otcrypto_const_byte_buf_t context,
     otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t signature);
 
 /**
@@ -151,6 +158,7 @@ otcrypto_status_t otcrypto_ed25519_sign_async_finalize(
  *
  * @param public_key Pointer to the unblinded public key struct.
  * @param input_message Input message to be signed for verification.
+ * @param context Context for signing.
  * @param sign_mode EdDSA signature hashing mode.
  * @param signature Pointer to the signature to be verified.
  * @return Result of async Ed25519 verification start operation.
@@ -158,7 +166,7 @@ otcrypto_status_t otcrypto_ed25519_sign_async_finalize(
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ed25519_verify_async_start(
     const otcrypto_unblinded_key_t *public_key,
-    otcrypto_const_byte_buf_t input_message,
+    otcrypto_const_byte_buf_t input_message, otcrypto_const_byte_buf_t context,
     otcrypto_eddsa_sign_mode_t sign_mode,
     otcrypto_const_word32_buf_t signature);
 
@@ -174,11 +182,13 @@ otcrypto_status_t otcrypto_ed25519_verify_async_start(
  * status code, as for other operations, only indicates whether errors were
  * encountered, and may return OK even when the signature is invalid.
  *
+ * @param signature Pointer to the signature being verified.
  * @param[out] verification_result Whether the signature passed verification.
  * @return Result of async Ed25519 verification finalize operation.
  */
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ed25519_verify_async_finalize(
+    otcrypto_const_word32_buf_t signature,
     hardened_bool_t *verification_result);
 
 #ifdef __cplusplus

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -1,3 +1,7 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
 # Copyright lowRISC contributors (OpenTitan project).
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
@@ -413,6 +417,27 @@ autogen_cryptotest_header(
     hjson = "//sw/device/tests/crypto/testvectors:ecdsa_p256_verify_testvectors_hardcoded",
     template = ":ecdsa_p256_verify_testvectors.h.tpl",
     tool = "//sw/device/tests/crypto:ecdsa_p256_verify_set_testvectors",
+)
+
+opentitan_test(
+    name = "ed25519_functest",
+    srcs = ["ed25519_functest.c"],
+    exec_env = CRYPTOTEST_EXEC_ENVS,
+    verilator = verilator_params(
+        timeout = "long",
+    ),
+    deps = [
+        "//sw/device/lib/crypto/drivers:entropy",
+        "//sw/device/lib/crypto/drivers:otbn",
+        "//sw/device/lib/crypto/impl:ed25519",
+        "//sw/device/lib/crypto/impl:integrity",
+        "//sw/device/lib/crypto/impl:sha2",
+        "//sw/device/lib/crypto/impl:status",
+        "//sw/device/lib/crypto/include:datatypes",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:entropy_testutils",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
 )
 
 autogen_cryptotest_header(

--- a/sw/device/tests/crypto/ed25519_functest.c
+++ b/sw/device/tests/crypto/ed25519_functest.c
@@ -1,0 +1,139 @@
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/drivers/entropy.h"
+#include "sw/device/lib/crypto/drivers/otbn.h"
+#include "sw/device/lib/crypto/impl/integrity.h"
+#include "sw/device/lib/crypto/impl/status.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/ed25519.h"
+#include "sw/device/lib/crypto/include/sha2.h"
+#include "sw/device/lib/testing/entropy_testutils.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+// Module for status messages.
+#define MODULE_ID MAKE_MODULE_ID('t', 's', 't')
+
+enum {
+  /* Number of 32-bit words in a Ed25519 public key. */
+  kEd25519PublicKeyWords = 256 / 32,
+  /* Number of 32-bit words in a Ed25519 signtaure. */
+  kEd25519SignatureWords = 512 / 32,
+  /* Number of 32-bit words in a Ed25519 private key. */
+  kEd25519PrivateKeyWords = 256 / 32,
+  /* Number of bytes in a Ed25519 private key. */
+  kEd25519PrivateKeyBytes = 256 / 8,
+};
+
+// Message
+static const char kMessage[] = "abc";
+
+// Public key
+static uint32_t public_key_fixed[kEd25519PublicKeyWords] = {
+    0x932b17ec, 0x3b565ead, 0x702c93f4, 0x345024e1,
+    0xef6754c3, 0x644dfd2e, 0x6819f8eb, 0xbfe26734,
+};
+
+// Private key
+static uint32_t private_key_fixed[kEd25519PrivateKeyWords] = {
+    0x24e63f83, 0x9d7b2309, 0x5877ec62, 0x1e912075,
+    0xec9c759a, 0x5b75191d, 0xb901a97d, 0x423dca6d,
+};
+
+static const otcrypto_key_config_t kPrivateKeyConfig = {
+    .version = kOtcryptoLibVersion1,
+    .key_mode = kOtcryptoKeyModeEd25519,
+    .key_length = kEd25519PrivateKeyBytes,
+    .hw_backed = kHardenedBoolFalse,
+    .security_level = kOtcryptoKeySecurityLevelLow,
+};
+
+status_t sign_then_verify_test(hardened_bool_t *verification_result) {
+  // Set up private key.
+  otcrypto_blinded_key_t private_key = {
+      .config = kPrivateKeyConfig,
+      .keyblob_length = sizeof(private_key_fixed),
+      .keyblob = private_key_fixed,
+  };
+
+  // Set up public key.
+  otcrypto_unblinded_key_t public_key = {
+      .key_mode = kOtcryptoKeyModeEd25519,
+      .key_length = sizeof(public_key_fixed),
+      .key = public_key_fixed,
+  };
+
+  // Compute the checksums for each.
+  private_key.checksum = integrity_blinded_checksum(&private_key);
+  public_key.checksum = integrity_unblinded_checksum(&public_key);
+
+  // Hash the message.
+  otcrypto_const_byte_buf_t msg = {
+      .data = (unsigned char *)&kMessage,
+      .len = sizeof(kMessage) - 1,
+  };
+  uint32_t msg_digest_data[512 / 32];
+  otcrypto_hash_digest_t msg_digest = {
+      .data = msg_digest_data,
+      .len = ARRAYSIZE(msg_digest_data),
+  };
+  TRY(otcrypto_sha2_512(msg, &msg_digest));
+
+  // Convert the hashed message into a const byte buffer.
+  otcrypto_const_byte_buf_t msg_digest_buf = {
+      .data = (uint8_t *)msg_digest_data,
+      .len = sizeof(msg_digest_data),
+  };
+
+  // Allocate space for the signature.
+  uint32_t sig[kEd25519SignatureWords] = {0};
+
+  // Allocate a zero-size buffer for context
+  uint8_t context[0];
+
+  // Generate a signature for the message.
+  LOG_INFO("Signing...");
+  CHECK_STATUS_OK(otcrypto_ed25519_sign(
+      &private_key, msg_digest_buf,
+      (otcrypto_const_byte_buf_t){.data = context, .len = 0},
+      kOtcryptoEddsaSignModeHashEddsa,
+      (otcrypto_word32_buf_t){.data = sig, .len = ARRAYSIZE(sig)}));
+
+  // Verify the signature.
+  LOG_INFO("Verifying...");
+  CHECK_STATUS_OK(otcrypto_ed25519_verify(
+      &public_key, msg_digest_buf,
+      (otcrypto_const_byte_buf_t){.data = context, .len = 0},
+      kOtcryptoEddsaSignModeHashEddsa,
+      (otcrypto_const_word32_buf_t){.data = sig, .len = ARRAYSIZE(sig)},
+      verification_result));
+
+  return OTCRYPTO_OK;
+}
+
+OTTF_DEFINE_TEST_CONFIG();
+
+bool test_main(void) {
+  CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
+
+  hardened_bool_t verificationResult;
+  status_t err = sign_then_verify_test(&verificationResult);
+  if (!status_ok(err)) {
+    // If there was an error, print the OTBN error bits and instruction count.
+    LOG_INFO("OTBN error bits: 0x%08x", otbn_err_bits_get());
+    LOG_INFO("OTBN instruction count: 0x%08x", otbn_instruction_count_get());
+    // Print the error.
+    CHECK_STATUS_OK(err);
+    return false;
+  }
+
+  // Signature verification is expected to succeed.
+  if (verificationResult != kHardenedBoolTrue) {
+    LOG_ERROR("Signature failed to pass verification!");
+    return false;
+  }
+
+  return true;
+}

--- a/sw/otbn/crypto/BUILD
+++ b/sw/otbn/crypto/BUILD
@@ -6,7 +6,7 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:otbn.bzl", "otbn_binary", "otbn_library", )
+load("//rules:otbn.bzl", "otbn_binary", "otbn_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -34,6 +34,21 @@ otbn_library(
     name = "ed25519_scalar",
     srcs = [
         "ed25519_scalar.s",
+    ],
+)
+
+otbn_binary(
+    name = "run_ed25519",
+    srcs = [
+        "run_ed25519.s",
+    ],
+    deps = [
+        ":ed25519",
+        ":ed25519_scalar",
+        ":field25519",
+        ":sha512_compact",
+        ":sha512_interface",
+        ":sha512_padding",
     ],
 )
 

--- a/sw/otbn/crypto/ed25519.s
+++ b/sw/otbn/crypto/ed25519.s
@@ -1666,12 +1666,6 @@ fe_pow_2252m3:
 
 .section .scratchpad
 
-/* Hash of the secret key (512 bits). Intermediate value for sign. */
-.balign 32
-.weak ed25519_hash_h
-ed25519_hash_h:
-  .zero 64
-
 /* Hash value r (512 bits). Intermediate value for sign. */
 .balign 32
 .weak ed25519_hash_r
@@ -1775,6 +1769,12 @@ ed25519_sig_S:
 .weak ed25519_public_key
 ed25519_public_key:
   .zero 32
+
+/* Hash of the secret key (512 bits). Intermediate value for sign. */
+.balign 32
+.weak ed25519_hash_h
+ed25519_hash_h:
+  .zero 64
 
 /* Hash value k (512 bits). Input for verify, intermediate for sign. */
 .balign 32

--- a/sw/otbn/crypto/run_ed25519.s
+++ b/sw/otbn/crypto/run_ed25519.s
@@ -1,0 +1,157 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Entrypoint for Ed25519 operations.
+ *
+ * This binary has the following modes of operation:
+ * 1. ED25519_MODE_SIGN: generate an Ed25519 signature using caller-provided secret key
+ * 2. ED25519_MODE_VERIFY: verify an Ed25519 signature
+ */
+
+/**
+ * Mode magic values.
+ *
+ * Encoding generated with:
+ * $ ./util/design/sparse-fsm-encode.py -d 6 -m 2 -n 11 \
+ *     -s 923549298 --avoid-zero
+ *
+ * Call the same utility with the same arguments and a higher -m to generate
+ * additional value(s) without changing the others or sacrificing mutual HD.
+ *
+ * TODO(#17727): in some places the OTBN assembler support for .equ directives
+ * is lacking, so they cannot be used in bignum instructions or pseudo-ops such
+ * as `li`. If support is added, we could use 32-bit values here instead of
+ * 11-bit.
+ */
+.equ ED25519_MODE_SIGN, 0x5be
+.equ ED25519_MODE_VERIFY, 0x672
+
+/**
+ * Make the mode constants visible to Ibex.
+ */
+.globl ED25519_MODE_SIGN
+.globl ED25519_MODE_VERIFY
+
+.section .text.start
+.globl start
+start:
+  /* Init all-zero register. */
+  bn.xor  w31, w31, w31
+
+  /* Read the mode and tail-call the requested operation. */
+  la      x2, ed25519_mode
+  lw      x2, 0(x2)
+
+  addi    x3, x0, ED25519_MODE_SIGN
+  beq     x2, x3, ed25519_sign_top
+
+  addi  x3, x0, ED25519_MODE_VERIFY
+  beq   x2, x3, ed25519_verify_top
+
+  /* Invalid mode; fail. */
+  unimp
+  unimp
+  unimp
+
+/**
+ * Generate an Ed25519 signature.
+ * 
+ * See documentation for ed25519_sign_prehashed in ed25519.s for details.
+ *
+ * @param[in]  dmem[ed25519_hash_h]: hash of secret key (512 bits)
+ * @param[in]  dmem[ed25519_ctx]: context string (ctx_len bytes)
+ * @param[in]  dmem[ed25519_ctx_len]: length of context string in bytes
+ * @param[in]  dmem[ed25519_message]: pre-hashed message (512 bits)
+ * @param[out] dmem[ed25519_sig_R]: R component of signature (256 bits)
+ * @param[out] dmem[ed25519_sig_S]: S component of signature (256 bits)
+ */
+ed25519_sign_top:
+  jal x1, ed25519_sign_prehashed
+  ecall
+
+/**
+ * Verify an Ed25519 signature.
+ *
+ * See documentation for ed25519_verify_var in ed25519.s for details, including
+ * concrete values for SUCCESS and FAILURE.
+ *
+ * @param[in]  w31: all-zero
+ * @param[in]  dmem[ed25519_hash_k]: precomputed hash k, 512 bits
+ * @param[in]  dmem[ed25519_sig_R]: encoded signature point R_, 256 bits
+ * @param[in]  dmem[ed25519_sig_S]: signature scalar S, 256 bits
+ * @param[in]  dmem[ed25519_public_key]: encoded public key A_, 256 bits
+ * @param[out] dmem[ed25519_verify_result]: SUCCESS or FAILURE
+ */
+ed25519_verify_top:
+  jal x1, ed25519_verify_var
+  ecall
+
+.bss
+
+/* Operation mode. */
+.globl ed25519_mode
+.balign 4
+ed25519_mode:
+  .zero 4
+
+/* Context string length in bytes for pre-hashed EdDSA */
+.globl ed25519_ctx_len
+.balign 4
+ed25519_ctx_len:
+  .zero 4
+
+/* Verification result code (32 bits). Output for verify.
+   If verification is successful, this will be SUCCESS = 0xf77fe650.
+   Otherwise, this will be FAILURE = 0xeda2bfaf. */
+.globl ed25519_verify_result
+.balign 4
+ed25519_verify_result:
+  .zero 4
+
+/* Signature point R (256 bits). Input for verify and output for sign. */
+.globl ed25519_sig_R
+.balign 32
+ed25519_sig_R:
+  .zero 32
+
+/* Signature scalar S (253 bits). Input for verify and output for sign. */
+.globl ed25519_sig_S
+.balign 32
+ed25519_sig_S:
+  .zero 32
+
+/* Encoded public key A_ (256 bits). Input for verify. */
+.globl ed25519_public_key
+.balign 32
+ed25519_public_key:
+  .zero 32
+
+/* Hash of the secret key (512 bits). Intermediate value for sign. */
+.globl ed25519_hash_h
+.balign 32
+ed25519_hash_h:
+  .zero 64
+
+/* Hash value k (512 bits). Input for verify, intermediate for sign. */
+.globl ed25519_hash_k
+.balign 32
+ed25519_hash_k:
+  .zero 64
+
+/* Context string for pre-hashed EdDSA (up to 255 bytes).
+
+   Note: If the context length is not a multiple of 32 bytes, the bytes up to
+   the next multiple of 32 should be initialized in order to prevent read
+   errors. The value of these bytes is ignored. */
+.globl ed25519_ctx
+.balign 32
+ed25519_ctx:
+  .zero 256
+
+/* Message (pre-hashed, 64 bytes). */
+.globl ed25519_message
+.balign 32
+ed25519_message:
+  .zero 64


### PR DESCRIPTION
This PR adds the C implementation code necessary to make use of Jade's Ed25519 OTBN code.

Specifically, this PR adds support for Ed25519ph signing and verification using the `ed25519_sign_prehashed` and `ed25519_verify_var` top-level Ed25519 OTBN library functions.