### PR TITLE
[bazel] Make latest bitstream default as expo-specific Bazel fix

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -154,3 +154,6 @@ run --sandbox_explicit_pseudoterminal
 # Enable strict action env. This will prevent `PATH` and `LD_LIBRARY_PATH` from being passed into the sandbox
 # which would help the cacheability.
 build --incompatible_strict_action_env
+
+# zerorisc/expo-specific fix to use the latest bitstream.
+build --repo_env BITSTREAM=latest


### PR DESCRIPTION
This PR is a one-line fix which makes use of the latest bitstream default to prevent issues with builds in expo.