### PR TITLE
[dv, dv_libs] New DV library files for reset handling

### DIFF
--- a/hw/dv/sv/dv_lib/dv_base_monitor.sv
+++ b/hw/dv/sv/dv_lib/dv_base_monitor.sv
@@ -1,4 +1,5 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc.
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 

--- a/hw/dv/sv/dv_lib/dv_base_virtual_sequencer.sv
+++ b/hw/dv/sv/dv_lib/dv_base_virtual_sequencer.sv
@@ -1,9 +1,10 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
 class dv_base_virtual_sequencer #(type CFG_T = dv_base_env_cfg,
-                                  type COV_T = dv_base_env_cov) extends uvm_sequencer;
+                                  type COV_T = dv_base_env_cov) extends dv_base_sequencer;
   `uvm_component_param_utils(dv_base_virtual_sequencer #(CFG_T, COV_T))
 
   CFG_T         cfg;
@@ -11,22 +12,8 @@ class dv_base_virtual_sequencer #(type CFG_T = dv_base_env_cfg,
 
   function new(string name = "", uvm_component parent);
     super.new(name, parent);
+    do_not_reset         = 1;
+    is_virtual_sequencer = 1;
   endfunction
 
-  // Dynamic associative array to store sub-sequencers
-  uvm_sequencer_base sub_sequencers[string];
-
-  // Method to dynamically register a sub-sequencer
-  function void register_sequencer(string name, uvm_sequencer_base sequencer);
-    // Check if the sub_sequencer name does not exists before register it.
-    `DV_CHECK_FATAL(!sub_sequencers.exists(name))
-    sub_sequencers[name] = sequencer;
-  endfunction
-
-  // Method to retrieve a sequencer by name
-  function uvm_sequencer_base get_sequencer(string name);
-    // Check if the sub_sequencer name is registered before return it.
-    `DV_CHECK_FATAL(sub_sequencers.exists(name))
-    return sub_sequencers[name];
-  endfunction
 endclass

--- a/hw/dv/sv/dv_lib/dv_callback.sv
+++ b/hw/dv/sv/dv_lib/dv_callback.sv
@@ -1,0 +1,58 @@
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class dv_callback #(type ITEM_T=uvm_sequence_item) extends uvm_callback;
+
+   virtual function void connect_to_callback();
+
+     // The default implementation is to return a fail
+     // the extended class needs to provide a specific
+     // implementation
+     `uvm_fatal ("DV_BASE_CALLBACK", {"dv_callback cannont be used in the default mode.",
+                                      "Please use the macro \`dv_callback_imp_decl"});
+   endfunction
+
+   virtual function void indicated(ITEM_T trans);
+   endfunction
+endclass
+
+`define dv_callback_imp_decl(NAME_CB_OBJ, AGENT_NAME, ITEM_T, RECEIVER_T, RECEIVER_FUNC)       \
+`ifndef RECEIVER_T``_DEF                                                                       \
+`define RECEIVER_T``_DEF                                                                       \
+typedef class RECEIVER_T;                                                                      \
+`endif                                                                                         \
+                                                                                               \
+class NAME_CB_OBJ extends dv_callback #(ITEM_T);                                               \
+  RECEIVER_T rcv_obj;                                                                          \
+  function new ( RECEIVER_T _rcv_obj);                                                         \
+    rcv_obj = _rcv_obj;                                                                        \
+    `uvm_info(`"NAME_CB_OBJ`", {`"NAME_CB_OBJ`", "::new()"}, UVM_MEDIUM);                      \
+  endfunction                                                                                  \
+                                                                                               \
+  virtual function void connect_to_callback();                                                 \
+    string                monitor_name;                                                        \
+    dv_monitor#(ITEM_T)   _monitor;                                                            \
+    uvm_component         _monitor_list[$];                                                    \
+                                                                                               \
+    monitor_name = {AGENT_NAME,".monitor"};                                                    \
+    `uvm_info(`"NAME_CB_OBJ`", {`"NAME_CB_OBJ`", "::connect()"}, UVM_MEDIUM);                  \
+    `uvm_info(`"NAME_CB_OBJ`", {"Finding Monitor: ", monitor_name}, UVM_LOW);                  \
+    uvm_top.find_all (monitor_name, _monitor_list);                                            \
+    if (_monitor_list.size() > 1) begin                                                        \
+      `uvm_fatal(`"NAME_CB_OBJ`", {monitor_name, " - Monitor Not Unique In The Environment.",  \
+                                                   "Please Specify Unique Name"});             \
+    end                                                                                        \
+    else if (_monitor_list.size() == 0) begin                                                  \
+      `uvm_fatal(`"NAME_CB_OBJ`", {monitor_name, " - Monitor Not Found In The Environment.",   \
+                                                   "Please Specify Unique Name"});             \
+    end                                                                                        \
+    $cast (_monitor, _monitor_list[0]);                                                        \
+    uvm_callbacks#(dv_monitor#(ITEM_T), dv_callback#(ITEM_T))::add(_monitor, this);            \
+    `uvm_info(`"NAME_CB_OBJ`", {"Added Callback to:", monitor_name}, UVM_LOW);                 \
+  endfunction                                                                                  \
+                                                                                               \
+  virtual function void indicated( ITEM_T trans);                                              \
+    rcv_obj.``RECEIVER_FUNC(trans);                                                            \
+  endfunction                                                                                  \
+endclass

--- a/hw/dv/sv/dv_lib/dv_lib.core
+++ b/hw/dv/sv/dv_lib/dv_lib.core
@@ -1,5 +1,6 @@
 CAPI=2:
 # Copyright lowRISC contributors (OpenTitan project).
+# Copyright zeroRISC Inc.
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 name: "lowrisc:dv:dv_lib"
@@ -15,6 +16,15 @@ filesets:
       - lowrisc:opentitan:bus_params_pkg
     files:
       - dv_lib_pkg.sv
+
+      - dv_pair.sv: {is_include_file: true}
+      - dv_callback.sv: {is_include_file: true}
+      - dv_rst_safe_base_driver.sv: {is_include_file: true}
+      - dv_monitor.sv: {is_include_file: true}
+      - dv_rst_safe_base_monitor.sv: {is_include_file: true}
+      - dv_sequence.sv: {is_include_file: true}
+      - dv_rand_rst_base_seq.sv: {is_include_file: true}
+      - dv_sequencer_list.sv: {is_include_file: true}
 
       - dv_base_agent_cfg.sv: {is_include_file: true}
       - dv_base_agent_cov.sv: {is_include_file: true}

--- a/hw/dv/sv/dv_lib/dv_lib_pkg.sv
+++ b/hw/dv/sv/dv_lib/dv_lib_pkg.sv
@@ -1,4 +1,5 @@
 // Copyright lowRISC contributors (OpenTitan project).
+// Copyright zeroRISC Inc
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
@@ -18,6 +19,12 @@ package dv_lib_pkg;
   string msg_id = "dv_lib_pkg";
 
   // package sources
+  // UVM Wrapper classes that become the primary base classes for all DV code
+  `include "dv_pair.sv"
+  `include "dv_callback.sv"
+  `include "dv_monitor.sv"
+  `include "dv_sequencer_list.sv"
+
   // base agent
   `include "dv_base_agent_cfg.sv"
   `include "dv_base_agent_cov.sv"
@@ -25,6 +32,9 @@ package dv_lib_pkg;
   `include "dv_base_sequencer.sv"
   `include "dv_base_driver.sv"
   `include "dv_base_agent.sv"
+
+  `include "dv_rst_safe_base_driver.sv"
+  `include "dv_rst_safe_base_monitor.sv"
 
   // base seq
   `include "dv_base_seq.sv"

--- a/hw/dv/sv/dv_lib/dv_monitor.sv
+++ b/hw/dv/sv/dv_lib/dv_monitor.sv
@@ -1,0 +1,38 @@
+// Copyright zeroRISC Inc
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+// This is the base class for the new reset safe/aware monitor.
+class dv_monitor #(type ITEM_T = uvm_sequence_item) extends uvm_monitor;
+  `uvm_component_param_utils(dv_monitor #(ITEM_T))
+
+  // Analysis port for the collected transfer.
+  uvm_analysis_port #(ITEM_T) analysis_port;
+
+  extern function new(string name, uvm_component parent);
+  extern function void build_phase(uvm_phase phase);
+  extern virtual function void notify(ITEM_T   trans);
+endclass : dv_monitor
+
+
+function dv_monitor::new(string name, uvm_component parent);
+  super.new(name, parent);
+  uvm_callbacks#(dv_monitor#(ITEM_T), dv_callback#(ITEM_T))::m_register_pair(this.get_type_name(),
+                                                                             {name,"_monitor_cb"});
+endfunction : new
+
+function void dv_monitor::build_phase(uvm_phase phase);
+  super.build_phase(phase);
+  analysis_port = new("analysis_port", this);
+endfunction
+
+
+// Notify method is available to all monitors. This method wraps the analysis port 'write()' and
+// performs callbacks to registered clients at the same time.
+function void  dv_monitor::notify(ITEM_T trans);
+  // Indicate the current transaction being driven.
+  `uvm_info(get_name(), "dv_monitor::notify() - Called", UVM_MEDIUM);
+  `uvm_do_callbacks(dv_monitor#(ITEM_T), dv_callback#(ITEM_T), indicated(trans))
+
+  analysis_port.write(trans);
+endfunction : notify

--- a/hw/dv/sv/dv_lib/dv_pair.sv
+++ b/hw/dv/sv/dv_lib/dv_pair.sv
@@ -1,0 +1,15 @@
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+
+class dv_pair #(type T1=uvm_sequence_item, type T2=uvm_sequence_item);
+  T1 first;
+  T2 second;
+
+  function void fill_pair(T1 first_item, T2 second_item);
+    first  = first_item;
+    second = second_item;
+  endfunction
+endclass : dv_pair
+

--- a/hw/dv/sv/dv_lib/dv_rst_safe_base_driver.sv
+++ b/hw/dv/sv/dv_lib/dv_rst_safe_base_driver.sv
@@ -1,0 +1,92 @@
+// Copyright zeroRISC
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class dv_rst_safe_base_driver #(type ITEM_T     = uvm_sequence_item,
+                                type CFG_T      = dv_base_agent_cfg,
+                                type RSP_ITEM_T = ITEM_T)
+  extends uvm_driver #(.REQ(ITEM_T), .RSP(RSP_ITEM_T));
+
+  `uvm_component_param_utils(dv_rst_safe_base_driver #(.ITEM_T     (ITEM_T),
+                                                       .CFG_T      (CFG_T),
+                                                       .RSP_ITEM_T (RSP_ITEM_T)))
+  CFG_T cfg;
+
+  // Standard UVM component task/functions
+  extern function new (string name, uvm_component parent);
+  extern task run_phase(uvm_phase phase);
+
+  // 'get_and_drive' task is the main thread of the driver. This task functions
+  extern virtual task get_and_drive();
+
+  // 'reset_interface_and_driver' function is invoked when reset is triggered
+  // The derived driver needs to implement this as to get the driver and the pins to the default
+  // state when in POR
+  extern function void reset_interface_and_driver();
+endclass
+
+
+function dv_rst_safe_base_driver::new (string name, uvm_component parent);
+  super.new(name, parent);
+endfunction
+
+task dv_rst_safe_base_driver::run_phase(uvm_phase phase);
+  process reset_thread_id;
+  process get_and_drive_thread_id;
+
+  super.run_phase(phase);
+
+  // The first reset is POR. Wait until a full reset cycle is observed before
+  // driving any transaction on the interface
+  wait (!cfg.vif.rst_n);
+  reset_interface_and_driver();
+
+  wait (cfg.vif.rst_n);
+
+  forever begin
+    // Process threading is used instead of isolation forks as it is cleaner and allows for fine
+    // grained thread control.
+    fork
+      begin : reset_thread
+        // Capture Process handle for the spawned process
+        reset_thread_id = process::self();
+        wait (!cfg.vif.rst_n);
+        reset_interface_and_driver();
+      end
+      begin : interface_drive_thread
+        get_and_drive_thread_id = process::self();
+        get_and_drive();
+      end
+    join_none
+
+    // Wait until both threads have spawned properly
+    wait (reset_thread_id != null && get_and_drive_thread_id  != null);
+
+    // Now wait till reset thread finishes. Reset Thread should be the only one to finish first as
+    // the 'interface_drive_thread' should be a forever loop getting transactions from the sequencer
+    // and driving the interface signals.
+    // Since we are using threading mechanism the 'await()' method blocks until the process on
+    // which it is called has finished.
+    reset_thread_id.await();
+
+    if (   get_and_drive_thread_id.status() == process::RUNNING
+        || get_and_drive_thread_id.status() == process::WAITING
+        || get_and_drive_thread_id.status() == process::SUSPENDED) begin
+      `uvm_info (get_name(), "killing get_and_drive_thread_id() thread", UVM_MEDIUM)
+      get_and_drive_thread_id.kill();
+    end else if (get_and_drive_thread_id.status() == process::FINISHED)  begin
+      `uvm_fatal (`gfn, "get_and_drive_thread_id() thread finished before reset thread")
+    end
+
+    wait (cfg.vif.rst_n);
+  end // forever
+endtask
+
+function void dv_rst_safe_base_driver::reset_interface_and_driver();
+  `uvm_fatal (`gfn, "reset_interface_and_driver() needs an implementation")
+endfunction
+
+// drive trans received from sequencer
+task dv_rst_safe_base_driver::get_and_drive();
+  `uvm_fatal (`gfn, "get_and_drive() needs an implementation")
+endtask

--- a/hw/dv/sv/dv_lib/dv_rst_safe_base_monitor.sv
+++ b/hw/dv/sv/dv_lib/dv_rst_safe_base_monitor.sv
@@ -1,0 +1,114 @@
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+class dv_rst_safe_base_monitor #(type ITEM_T = uvm_sequence_item,
+                                 type REQ_ITEM_T = ITEM_T,
+                                 type RSP_ITEM_T = ITEM_T,
+                                 type CFG_T  = dv_base_agent_cfg,
+                                 type COV_T  = dv_base_agent_cov) extends dv_monitor#(ITEM_T);
+  `uvm_component_param_utils(dv_rst_safe_base_monitor #(ITEM_T, REQ_ITEM_T, RSP_ITEM_T,
+                                                        CFG_T, COV_T))
+
+  CFG_T cfg;
+  COV_T cov;
+
+  // item will be sent to this port for seq when req phase is done (last is set)
+  uvm_analysis_port #(REQ_ITEM_T) req_analysis_port;
+  // item will be sent to this port for seq when rsp phase is done (rsp_done is set)
+  uvm_analysis_port #(RSP_ITEM_T) rsp_analysis_port;
+
+  // Standard UVM component task/functions
+  extern function new (string name, uvm_component parent);
+  extern function void build_phase(uvm_phase phase);
+  extern task run_phase(uvm_phase phase);
+
+  // 'collect_trans()' task is the main task that monitors the inteface and builds the necessary
+  // transactions that the scoreboard uses.
+  extern virtual task collect_trans();
+
+  // 'reset_monitor()' function is used by the reset_thread to get the monitor to the default
+  // state
+  extern function void reset_monitor();
+endclass
+
+
+function dv_rst_safe_base_monitor::new (string name, uvm_component parent);
+  super.new(name, parent);
+endfunction
+
+function void dv_rst_safe_base_monitor::build_phase(uvm_phase phase);
+  super.build_phase(phase);
+  req_analysis_port = new("req_analysis_port", this);
+  rsp_analysis_port = new("rsp_analysis_port", this);
+endfunction
+
+task dv_rst_safe_base_monitor::run_phase(uvm_phase phase);
+  process reset_thread_id;
+  process collect_trans_thread_id;
+
+  super.run_phase(phase);
+
+  // The first reset is POR. Wait until a full reset cycle is observed before
+  // capturing any transaction on the interface
+  wait (!cfg.vif.rst_n);
+  reset_monitor();
+
+  wait (cfg.vif.rst_n);
+
+  forever begin
+    // At this point reset is released and the monitor is the default state. We now need to monitor
+    // reset and the interface signals conurrently. The interface monitor thread
+    // Process threading is used instead of isolation forks as it is cleaner and allows for fine
+    // grained thread control.
+    fork
+      begin : reset_thread
+        // Capture Process handle for the spawned process
+        reset_thread_id = process::self();
+        wait (!cfg.vif.rst_n);
+        reset_monitor();
+      end
+      begin : interface_monitor_thread
+        collect_trans_thread_id = process::self();
+        collect_trans();
+      end
+    join_none
+
+    // Wait until both threads have spawned properly
+    wait (reset_thread_id != null && collect_trans_thread_id != null);
+
+    // Now wait till reset thread finishes. Reset Thread should be the only one to finish first as
+    // the 'interface_monitor_thread' should be a forever loop monitoring the the interface
+    // signals.
+    // Since we are using threading mechanism the 'await()' method blocks until the process on
+    // which it is called has finished.
+    reset_thread_id.await();
+
+    // At this point the reset has been triggered on the interface. The monitor needs to get back
+    // to the original state as it was to just after the POR. So we will terminate anything the
+    // monitor is doing and wait till reset is released.
+    if (   collect_trans_thread_id.status() == process::RUNNING
+        || collect_trans_thread_id.status() == process::WAITING
+        || collect_trans_thread_id.status() == process::SUSPENDED) begin
+      `uvm_info (get_name(), "killing collect_trans() thread", UVM_MEDIUM)
+      collect_trans_thread_id.kill();
+    end else if (collect_trans_thread_id.status() == process::FINISHED)  begin
+      `uvm_fatal (`gfn, "collect_trans() thread finished before reset thread")
+    end
+
+    wait (cfg.vif.rst_n);
+  end // forever
+endtask
+
+// collect transactions forever
+task dv_rst_safe_base_monitor::collect_trans();
+  // This task has to be be implemented by the derived monitor to observe the interface and build
+  // transactions that the scoreboard can use
+  `uvm_fatal (`gfn, "collect_trans() needs an implementation")
+endtask
+
+function void dv_rst_safe_base_monitor::reset_monitor();
+  // This function has to be be implemented by the derived monitor to get the monitor back to
+  // default state
+  `uvm_fatal (`gfn, "reset_interface_and_monitor() needs an implementation")
+endfunction

--- a/hw/dv/sv/dv_lib/dv_sequencer_list.sv
+++ b/hw/dv/sv/dv_lib/dv_sequencer_list.sv
@@ -1,0 +1,34 @@
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+
+
+class dv_sequencer_list;
+  static local dv_pair#(uvm_sequencer_base, bit) sequencer_list[$];
+
+  extern function new(string name, uvm_component parent);
+  extern static function void register_sequencer(dv_pair#(uvm_sequencer_base, bit) seqr_pair);
+  extern static function void reset_sequencers();
+endclass
+
+
+function dv_sequencer_list::new(string name, uvm_component parent);
+  `uvm_fatal("dv_sequencer_list::new()", "Sequencer List object cannot be created");
+endfunction : new
+
+function void dv_sequencer_list::register_sequencer(dv_pair#(uvm_sequencer_base, bit) seqr_pair);
+  sequencer_list.push_back(seqr_pair);
+endfunction
+
+
+function void dv_sequencer_list::reset_sequencers();
+  uvm_sequencer_base seqr;
+  bit                do_not_reset;
+
+  foreach (sequencer_list[i]) begin
+    seqr         = sequencer_list[i].first;
+    do_not_reset = sequencer_list[i].second;
+    if (!do_not_reset) seqr.stop_sequences();
+  end
+endfunction


### PR DESCRIPTION
This PR contains files that are foundational to making TB components reset aware / safe. 
- Introducing new reset safe base driver & monitor that will become the parent for all drivers and monitors when we transition the agents
- Ability to add perform callbacks in monitors is also added 
- Sequencer code is refactored to allow to registration of sequencers on to a static list in the environment
- Additional utility code also added





