### PR TITLE
[ci] Software jobs with high resource requirements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,7 +290,7 @@ jobs:
   verilator_earlgrey:
     name: Verilated Earl Grey
     runs-on:
-      group: zerorisc-none
+      group: zerorisc-large
     needs: quick_lint
     if: ${{ github.event_name != 'merge_group' }}
     timeout-minutes: 240
@@ -350,7 +350,7 @@ jobs:
   sw_build_test:
     name: Build and test software
     runs-on:
-      group: zerorisc-none
+      group: zerorisc-large
     timeout-minutes: 120
     needs: quick_lint
     if: ${{ github.event_name != 'merge_group' }}


### PR DESCRIPTION
Flips a few jobs (`sw_build_test`, `verilator_earlgrey`) that were struggling with our resource limits on the standard `zerorisc-none` runner to a dedicated runner type with additional resources.