### PR TITLE
[ci] Fix bug in bitstream checkout for FPGA tests

### DIFF
--- a/.github/workflows/fpga.yml
+++ b/.github/workflows/fpga.yml
@@ -72,7 +72,15 @@ jobs:
         uses: ./.github/actions/download-partial-build-bin
         with:
           job-patterns: ${{ inputs.bitstream }}
-
+      - name: Create bitstream cache archive
+        run: |
+          shopt -s globstar # Allow use of **
+          ./bazelisk.sh build //util/py/scripts:bitstream_cache_create
+          ./bazelisk.sh run //util/py/scripts:bitstream_cache_create -- \
+            --schema $PWD/rules/scripts/bitstreams_manifest.schema.json \
+            --stamp-file $PWD/bazel-out/volatile-status.txt \
+            --out $PWD/build-bin/bitstream-cache \
+            $PWD/build-bin/**/manifest.json
       - name: Execute tests
         run: |
           . util/build_consts.sh

--- a/ci/scripts/run-fpga-tests.sh
+++ b/ci/scripts/run-fpga-tests.sh
@@ -22,9 +22,9 @@ shift 2
 COMMIT="$(git rev-parse HEAD)"
 readonly COMMIT
 readonly BIT_CACHE_DIR="${HOME}/.cache/opentitan-bitstreams/cache/${COMMIT}"
-readonly BIT_SRC_DIR="${BIN_DIR}/hw/top_earlgrey"
+readonly BIT_SRC="${BIN_DIR}/bitstream-cache/bitstream-cache.tar.gz"
 mkdir -p "${BIT_CACHE_DIR}"
-cp -rt "${BIT_CACHE_DIR}" "${BIT_SRC_DIR}"/*
+tar xzf ${BIT_SRC} -C ${BIT_CACHE_DIR}
 
 # We will lose serial access when we reboot, but if tests fail we should reboot
 # in case we've crashed the UART handler on the CW310's SAM3U


### PR DESCRIPTION
Minor correction to #115 

The bitstream checkout process for FPGA tests uses the uploaded bitstream artifact in GHA. However, when `bitstreams_workspace.py` is run prior to the FPGA tests (without network fetch), it expects that archive to be in the format used for the GCP bitstream cache. The former lacks global `manifest.json` file with the commit hash (separate from the per-bitstream `manifest.json`). This divergence went unnoticed because of the bug fixed in #115, and causes `bitstreams_workspace.py` to crash when running FPGA tests.

This PR fixes this defect by preceding the FPGA tests with a build of a GCP-capable cache archive that is uncompressed into the cache directory.