### PR TITLE
[ci] Build Darjeeling CW340 bitstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,6 +327,16 @@ jobs:
       top_name: earlgrey
       design_suffix: cw340
 
+  chip_darjeeling_cw340:
+    name: Darjeeling for CW340
+    needs: quick_lint
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/bitstream.yml
+    secrets: inherit
+    with:
+      top_name: darjeeling
+      design_suffix: cw340
+
   # Hyper310 FPGA jobs
   execute_tests_hyper310:
     name: Hyper310 Tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,6 +48,14 @@ jobs:
       top_name: earlgrey
       design_suffix: cw340
 
+  chip_darjeeling_cw340:
+    name: Darjeeling for CW340
+    uses: ./.github/workflows/bitstream.yml
+    secrets: inherit
+    with:
+      top_name: darjeeling
+      design_suffix: cw340
+
   cache_bitstreams:
     name: Cache bitstreams to GCP
     runs-on:


### PR DESCRIPTION
Adds a CI job to build the Darjeeling bitstream for the CW340 FPGA.