### PR TITLE
[ci] Ignore `CData too large` errors for long test logs

### DIFF
--- a/.github/actions/publish-bazel-test-results/action.yml
+++ b/.github/actions/publish-bazel-test-results/action.yml
@@ -28,7 +28,7 @@ runs:
         count=0
         for xmlfile in $(find -L bazel-out -name "test.xml"); do
           cp ${xmlfile} /tmp/test-xml-files/test-${count}.xml
-          xmlstarlet ed --inplace -i '/testsuites/testsuite' -t attr -n hostname -v "${{ runner.name }}" /tmp/test-xml-files/test-${count}.xml
+          xmlstarlet ed --inplace -i '/testsuites/testsuite' -t attr -n hostname -v "${{ runner.name }}" /tmp/test-xml-files/test-${count}.xml || true
           count=$((count+1))
         done;
 


### PR DESCRIPTION
#134 was not enough to mitigate the `CData too large` error encountered when adding the hostname to FPGA test logs. The RSA KAT tests in the nightly CI alone are too long for `xmlstarlet` to handle. Adding the runner name is not critical to documenting the output, so this PR temporarily ignores failures from this tool.