### PR TITLE
[hw,spi_host,rtl] Add missing prim_assert.h

### DIFF
--- a/hw/ip/spi_host/rtl/spi_host_fsm.sv
+++ b/hw/ip/spi_host/rtl/spi_host_fsm.sv
@@ -5,6 +5,8 @@
 // Core Implementation module for Serial Peripheral Interface (SPI) Host IP.
 //
 
+`include "prim_assert.sv"
+
 module spi_host_fsm
   import spi_host_cmd_pkg::*;
 #(


### PR DESCRIPTION
Add missing include to `prim_assert.h` to spi_host_fsm. Some tools complain if it is not there.