### PR TITLE
[doc] Fix BUILD.bazel doc_files target file list

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -15,11 +15,9 @@ filegroup(
     name = "doc_files",
     srcs = [
         "README.md",
-        "//doc:doc_files",
         "//hw:doc_files",
         "//rules/opentitan:doc_files",
         "//signing:doc_files",
-        "//site/book-theme:doc_files",
         "//sw:doc_files",
         "//third_party:doc_files",
         "//toolchain:doc_files",


### PR DESCRIPTION
This PR just changes a couple lines needed in order for CI to pass after the updates in #144. Specifically,

```
./bazelisk.sh build --nobuild //...
```

was failing in the lint check as two targets no longer exist.