### PR TITLE
[ci] Temporarily disable link check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,9 @@ jobs:
       - name: Trailing whitespace
         run: ./ci/scripts/whitespace.sh "$GITHUB_BASE_REF"
         if: ${{ github.event_name == 'pull_request' }}
-      - name: Broken links
-        run: ./ci/scripts/check-links.sh
+      # Temporarily disabled, see expo#153
+      # - name: Broken links
+      #   run: ./ci/scripts/check-links.sh
       - name: Lock files
         run: ./ci/scripts/check-lock-files.sh
 


### PR DESCRIPTION
This PR temporarily disables the CI link check in the initial quick lint pass for CI. See #153.