### PR TITLE
[cla] Enable GHA-based CLA Assistant

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,51 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+name: "CLA Assistant"
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+# explicitly configure permissions, in case your GITHUB_TOKEN workflow permissions are set to read-only in repository settings
+permissions:
+  actions: write
+  contents: read # this can be 'read' if the signatures are in remote repository
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I certify that I have read and agree that my contributions will be bound by the expo CLA.') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # the below token should have repo scope and must be manually added by you in the repository's secret
+          # This token is required only if you have configured to store the signatures in a remote repository/organization
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: 'signatures.json'
+          path-to-document: 'https://gist.github.com/rtorok-zr/7c1f95a78d6c63a2f3b0179dcf4b1b48' # e.g. a CLA or a DCO document
+          branch: 'main'
+
+          # Optional inputs - If the optional inputs are not given, then default values will be taken
+          #
+          # enter the remote organization name where the signatures should be stored (Default is storing the signatures in the same repository)
+          remote-organization-name: zerorisc
+          # enter the  remote repository name where the signatures should be stored (Default is storing the signatures in the same repository)
+          remote-repository-name: expo-cla-signatures
+          # 'For example: Creating file for storing CLA Signatures'
+          #create-file-commit-message:
+          # 'pull request comment with Introductory message to ask new contributors to sign'
+          custom-notsigned-prcomment: 'Welcome! Before accepting your contribution, the expo project requires you to sign the [Contributor License Agreement](https://gist.github.com/rtorok-zr/1ca3a78e9367cca492b183e553dc39d5). To indicate your agreement, please post a comment on this Pull Request with the message below.<br/><br/>If you are contributing on behalf of a company, please inform your supervisor to [contact zeroRISC](mailto:info@zerorisc.com) to sign a Corporate CLA instead.'
+          #'The signature to be committed in order to sign the CLA'
+          custom-pr-sign-comment: 'I certify that I have read and agree that my contributions will be bound by the expo CLA.'
+          # 'pull request comment when all contributors has signed, defaults to **CLA Assistant Lite bot** All Contributors have signed the CLA.'
+          custom-allsigned-prcomment: "**Expo CLA Assistant** All committers have signed the CLA."
+          #lock-pullrequest-aftermerge: false - if you don't want this bot to automatically lock the pull request after merging (default - true)
+          #use-dco-flag: true - If you are using DCO instead of CLA


### PR DESCRIPTION
This PR enables a the `cla-assistant-lite` tool, which uses GitHub Actions to collect CLA signatures.