### PR TITLE
[ci] Run FPGA tests up to 3 times

### DIFF
--- a/ci/scripts/run-fpga-tests.sh
+++ b/ci/scripts/run-fpga-tests.sh
@@ -54,5 +54,5 @@ tar xzf ${BIT_SRC} -C ${BIT_CACHE_DIR}
     --test_output=all \
     --build_tests_only \
     --define "$fpga"=lowrisc \
-    --flaky_test_attempts=2 \
+    --flaky_test_attempts=3 \
     --target_pattern_file="${target_pattern_file}" "$@"


### PR DESCRIPTION
Several FPGA tests in CI are flaky. This PR increases the number of attempts from 2 to 3, which should reduce the number of inconsistent failures. This should not significantly increase the runtime of the CI, because tests that pass on the first (or second) attempt will not incur additional attempts.