### PR TITLE
[crypto] Convert private key check API to return OTCRYPTO_ASYNC_INCOMPLETE

### DIFF
--- a/sw/device/lib/crypto/impl/rsa.c
+++ b/sw/device/lib/crypto/impl/rsa.c
@@ -433,6 +433,7 @@ otcrypto_status_t otcrypto_rsa_private_key_construct_and_check(
     hardened_bool_t *key_valid) {
   HARDENED_TRY(otcrypto_rsa_private_key_construct_and_check_async_start(
       p, q, d_p, d_q, i_q, public_key, check_primes, private_key, key_valid));
+  OTBN_WIPE_IF_ERROR(otbn_busy_wait_for_done());
   return otcrypto_rsa_private_key_construct_and_check_async_finalize(
       public_key, check_primes, private_key, key_valid);
 }

--- a/sw/device/lib/crypto/impl/rsa/rsa_keygen.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_keygen.c
@@ -370,6 +370,9 @@ status_t rsa_key_check_2048_finalize(const rsa_2048_public_key_t *public_key,
                                      const rsa_2048_private_key_t *private_key,
                                      hardened_bool_t check_primes,
                                      hardened_bool_t *key_valid) {
+  // Return `OTCRYTPO_ASYNC_INCOMPLETE` if OTBN not done.
+  HARDENED_TRY(otbn_assert_idle());
+
   // Spin here waiting for OTBN to complete.
   OTBN_WIPE_IF_ERROR(otbn_busy_wait_for_done());
 
@@ -544,6 +547,9 @@ status_t rsa_key_check_3072_finalize(const rsa_3072_public_key_t *public_key,
                                      const rsa_3072_private_key_t *private_key,
                                      hardened_bool_t check_primes,
                                      hardened_bool_t *key_valid) {
+  // Return `OTCRYTPO_ASYNC_INCOMPLETE` if OTBN not done.
+  HARDENED_TRY(otbn_assert_idle());
+
   // Spin here waiting for OTBN to complete.
   OTBN_WIPE_IF_ERROR(otbn_busy_wait_for_done());
 
@@ -718,6 +724,9 @@ status_t rsa_key_check_4096_finalize(const rsa_4096_public_key_t *public_key,
                                      const rsa_4096_private_key_t *private_key,
                                      hardened_bool_t check_primes,
                                      hardened_bool_t *key_valid) {
+  // Return `OTCRYTPO_ASYNC_INCOMPLETE` if OTBN not done.
+  HARDENED_TRY(otbn_assert_idle());
+
   // Spin here waiting for OTBN to complete.
   OTBN_WIPE_IF_ERROR(otbn_busy_wait_for_done());
 


### PR DESCRIPTION
This PR quickly converts the private key import and check API from a blocking API to a truly asynchronous one, returning `OTCRYPTO_ASYNC_COMPLETE` if the OTBN key checks are still running.