### PR TITLE
[crypto] Update otcrypto_interface.* to include RSA key import/export

### DIFF
--- a/sw/device/tests/crypto/otcrypto_interface.c
+++ b/sw/device/tests/crypto/otcrypto_interface.c
@@ -168,9 +168,17 @@ const otcrypto_interface_t otcrypto = {
     .x25519_async_start = &otcrypto_x25519_async_start,
     .x25519_async_finalize = &otcrypto_x25519_async_finalize,
 
-    // RSA key construction.
+    // RSA key construction and deconstruction.
     .rsa_public_key_construct = &otcrypto_rsa_public_key_construct,
+    .rsa_public_key_deconstruct = &otcrypto_rsa_public_key_deconstruct,
     .rsa_private_key_construct = &otcrypto_rsa_private_key_construct,
+    .rsa_private_key_construct_and_check =
+        &otcrypto_rsa_private_key_construct_and_check,
+    .rsa_private_key_construct_and_check_async_start =
+        &otcrypto_rsa_private_key_construct_and_check_async_start,
+    .rsa_private_key_construct_and_check_async_finalize =
+        &otcrypto_rsa_private_key_construct_and_check_async_finalize,
+    .rsa_private_key_deconstruct = &otcrypto_rsa_private_key_deconstruct,
 
     // RSA key generation (blocking).
     .rsa_keygen = &otcrypto_rsa_keygen,

--- a/sw/device/tests/crypto/otcrypto_interface.h
+++ b/sw/device/tests/crypto/otcrypto_interface.h
@@ -170,9 +170,11 @@ typedef struct otcrypto_interface_t {
                                       otcrypto_unblinded_key_t *);
   otcrypto_status_t (*ed25519_sign)(const otcrypto_blinded_key_t *,
                                     otcrypto_const_byte_buf_t,
+                                    otcrypto_const_byte_buf_t,
                                     otcrypto_eddsa_sign_mode_t,
                                     otcrypto_word32_buf_t);
   otcrypto_status_t (*ed25519_verify)(const otcrypto_unblinded_key_t *,
+                                      otcrypto_const_byte_buf_t,
                                       otcrypto_const_byte_buf_t,
                                       otcrypto_eddsa_sign_mode_t,
                                       otcrypto_const_word32_buf_t,
@@ -183,13 +185,16 @@ typedef struct otcrypto_interface_t {
       otcrypto_blinded_key_t *, otcrypto_unblinded_key_t *);
   otcrypto_status_t (*ed25519_sign_async_start)(const otcrypto_blinded_key_t *,
                                                 otcrypto_const_byte_buf_t,
+                                                otcrypto_const_byte_buf_t,
                                                 otcrypto_eddsa_sign_mode_t,
                                                 otcrypto_word32_buf_t);
   otcrypto_status_t (*ed25519_sign_async_finalize)(otcrypto_word32_buf_t);
   otcrypto_status_t (*ed25519_verify_async_start)(
       const otcrypto_unblinded_key_t *, otcrypto_const_byte_buf_t,
-      otcrypto_eddsa_sign_mode_t, otcrypto_const_word32_buf_t);
-  otcrypto_status_t (*ed25519_verify_async_finalize)(hardened_bool_t *);
+      otcrypto_const_byte_buf_t, otcrypto_eddsa_sign_mode_t,
+      otcrypto_const_word32_buf_t);
+  otcrypto_status_t (*ed25519_verify_async_finalize)(
+      otcrypto_const_word32_buf_t, hardened_bool_t *);
 
   // X25519
   otcrypto_status_t (*x25519_keygen)(otcrypto_blinded_key_t *,
@@ -213,6 +218,9 @@ typedef struct otcrypto_interface_t {
                                                 otcrypto_const_word32_buf_t,
                                                 uint32_t,
                                                 otcrypto_unblinded_key_t *);
+  otcrypto_status_t (*rsa_public_key_deconstruct)(otcrypto_unblinded_key_t *,
+                                                  otcrypto_word32_buf_t,
+                                                  uint32_t *);
   otcrypto_status_t (*rsa_private_key_construct)(otcrypto_rsa_size_t,
                                                  otcrypto_const_word32_buf_t,
                                                  otcrypto_const_word32_buf_t,
@@ -220,6 +228,22 @@ typedef struct otcrypto_interface_t {
                                                  otcrypto_const_word32_buf_t,
                                                  otcrypto_const_word32_buf_t,
                                                  otcrypto_blinded_key_t *);
+  otcrypto_status_t (*rsa_private_key_construct_and_check)(
+      otcrypto_const_word32_buf_t, otcrypto_const_word32_buf_t,
+      otcrypto_const_word32_buf_t, otcrypto_const_word32_buf_t,
+      otcrypto_const_word32_buf_t, const otcrypto_unblinded_key_t *,
+      hardened_bool_t, otcrypto_blinded_key_t *, hardened_bool_t *);
+  otcrypto_status_t (*rsa_private_key_construct_and_check_async_start)(
+      otcrypto_const_word32_buf_t, otcrypto_const_word32_buf_t,
+      otcrypto_const_word32_buf_t, otcrypto_const_word32_buf_t,
+      otcrypto_const_word32_buf_t, const otcrypto_unblinded_key_t *,
+      hardened_bool_t, otcrypto_blinded_key_t *, hardened_bool_t *);
+  otcrypto_status_t (*rsa_private_key_construct_and_check_async_finalize)(
+      const otcrypto_unblinded_key_t *, hardened_bool_t,
+      otcrypto_blinded_key_t *, hardened_bool_t *);
+  otcrypto_status_t (*rsa_private_key_deconstruct)(
+      otcrypto_blinded_key_t *, otcrypto_word32_buf_t, otcrypto_word32_buf_t,
+      otcrypto_word32_buf_t, otcrypto_word32_buf_t, otcrypto_word32_buf_t);
   otcrypto_status_t (*rsa_keypair_from_cofactor)(
       otcrypto_rsa_size_t, otcrypto_const_word32_buf_t, uint32_t,
       otcrypto_const_word32_buf_t, otcrypto_const_word32_buf_t,
@@ -257,14 +281,15 @@ typedef struct otcrypto_interface_t {
   otcrypto_status_t (*rsa_sign_async_finalize)(otcrypto_word32_buf_t);
   otcrypto_status_t (*rsa_verify_async_start)(const otcrypto_unblinded_key_t *,
                                               otcrypto_const_word32_buf_t);
-  otcrypto_status_t (*rsa_verify_async_finalize)(const otcrypto_hash_digest_t,
-                                                 otcrypto_rsa_padding_t,
-                                                 hardened_bool_t *);
+  otcrypto_status_t (*rsa_verify_async_finalize)(
+      const otcrypto_unblinded_key_t *, const otcrypto_hash_digest_t,
+      otcrypto_rsa_padding_t, hardened_bool_t *);
   otcrypto_status_t (*rsa_encrypt_async_start)(const otcrypto_unblinded_key_t *,
                                                const otcrypto_hash_mode_t,
                                                otcrypto_const_byte_buf_t,
                                                otcrypto_const_byte_buf_t);
-  otcrypto_status_t (*rsa_encrypt_async_finalize)(otcrypto_word32_buf_t);
+  otcrypto_status_t (*rsa_encrypt_async_finalize)(
+      const otcrypto_unblinded_key_t *, otcrypto_word32_buf_t);
   otcrypto_status_t (*rsa_decrypt_async_start)(const otcrypto_blinded_key_t *,
                                                otcrypto_const_word32_buf_t);
   otcrypto_status_t (*rsa_decrypt_async_finalize)(const otcrypto_hash_mode_t,
@@ -308,7 +333,8 @@ typedef struct otcrypto_interface_t {
       otcrypto_blinded_key_t *, otcrypto_unblinded_key_t *);
   otcrypto_status_t (*ecdh_p256_async_start)(const otcrypto_blinded_key_t *,
                                              const otcrypto_unblinded_key_t *);
-  otcrypto_status_t (*ecdh_p256_async_finalize)(otcrypto_blinded_key_t *);
+  otcrypto_status_t (*ecdh_p256_async_finalize)(const otcrypto_blinded_key_t *,
+                                                otcrypto_blinded_key_t *);
 
   // P-384
   otcrypto_status_t (*ecdsa_p384_keygen)(otcrypto_blinded_key_t *,
@@ -347,7 +373,8 @@ typedef struct otcrypto_interface_t {
       otcrypto_blinded_key_t *, otcrypto_unblinded_key_t *);
   otcrypto_status_t (*ecdh_p384_async_start)(const otcrypto_blinded_key_t *,
                                              const otcrypto_unblinded_key_t *);
-  otcrypto_status_t (*ecdh_p384_async_finalize)(otcrypto_blinded_key_t *);
+  otcrypto_status_t (*ecdh_p384_async_finalize)(const otcrypto_blinded_key_t *,
+                                                otcrypto_blinded_key_t *);
 
 } otcrypto_interface_t;
 


### PR DESCRIPTION
This PR updates `otcrypto_interface.{c,h}` to include the RSA key import/export functions added in #168, as well as a few function signatures in `otcrypto_interface.h` that had fallen out of sync. 

`bazel build //sw/device/tests/crypto:otcrypto_interface --config=riscv32` results in a successful build again after the inclusion of this commit.