### PR TITLE
[cla] Bump cla-assistant-lite to v0.1.1

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I certify that I have read and agree that my contributions will be bound by the expo CLA.') || github.event_name == 'pull_request_target'
-        uses: zerorisc/cla-assistant-lite@v0.1.0
+        uses: zerorisc/cla-assistant-lite@v0.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # the below token should have repo scope and must be manually added by you in the repository's secret


### PR DESCRIPTION
Bumps the version of `cla-assistant-lite` to v0.1.1, correcting an issue where the update that was intended to shield non-committer authors from CLA notifications was not reflected in the GitHub Action.