### PR TITLE
[crypto] ML-DSA (FIPS 204) signature implementation

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -361,6 +361,9 @@ use_repo(doxygen, "doxygen")
 mlkem_native = use_extension("//third_party/mlkem_native:extensions.bzl", "mlkem_native")
 use_repo(mlkem_native, "mlkem_native")
 
+mldsa_native = use_extension("//third_party/mldsa_native:extensions.bzl", "mldsa_native")
+use_repo(mldsa_native, "mldsa_native")
+
 # Hooks:
 # Extension for linking in externally managed test and provisioning customizations
 # for both secure/non-secure manufacturer domains.

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -573,6 +573,35 @@
         ]
       }
     },
+    "//third_party/mldsa_native:extensions.bzl%mldsa_native": {
+      "general": {
+        "bzlTransitiveDigest": "y43IQO/okKME5VlC4nmk81AahbfsJIJKHSmjNWclSGM=",
+        "usagesDigest": "4rdFe72MNnFSMIg7Xo/0lZ9ySu4EWs7yUMdF7a0JkI4=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "mldsa_native": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "build_file": "@@//third_party/mldsa_native:BUILD.mldsa_native.bazel",
+              "sha256": "23bcd38bc9d91e93c39df47189d6c4e5eb7172334700579c32951ff31857b9e5",
+              "strip_prefix": "mldsa-native-421e6622f250f99da5b57660572e921c91cbfcf4",
+              "urls": [
+                "https://github.com/pq-code-package/mldsa-native/archive/421e6622f250f99da5b57660572e921c91cbfcf4.tar.gz"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    },
     "//third_party/mlkem_native:extensions.bzl%mlkem_native": {
       "general": {
         "bzlTransitiveDigest": "kN7K0a14FAlVHwn9JwehYF9f0LW1s5+hkj1IMEc5Ues=",

--- a/quality/licenses.hjson
+++ b/quality/licenses.hjson
@@ -139,5 +139,16 @@
     "sw/device/lib/crypto/impl/mlkem/fips202x4_glue.h",
     "sw/device/lib/crypto/impl/mlkem/config.h",
     "sw/device/tests/crypto/mlkem_functest.c",
+    // Code contributed by mldsa-native authors
+    "sw/device/lib/crypto/impl/mldsa.c",
+    "sw/device/lib/crypto/include/mldsa.h",
+    "sw/device/lib/crypto/impl/mldsa/BUILD",
+    "sw/device/lib/crypto/impl/mldsa/mldsa_native_monobuild.c",
+    "sw/device/lib/crypto/impl/mldsa/mldsa_native_monobuild.h",
+    "sw/device/lib/crypto/impl/mldsa/mldsa_native_alloc.c",
+    "sw/device/lib/crypto/impl/mldsa/mldsa_native_alloc.h",
+    "sw/device/lib/crypto/impl/mldsa/fips202_glue.h",
+    "sw/device/lib/crypto/impl/mldsa/mldsa_native_config.h",
+    "sw/device/tests/crypto/mldsa_functest.c",
   ]
 }

--- a/sw/device/lib/crypto/impl/BUILD
+++ b/sw/device/lib/crypto/impl/BUILD
@@ -356,6 +356,22 @@ cc_library(
 )
 
 cc_library(
+    name = "mldsa",
+    srcs = ["mldsa.c"],
+    hdrs = [
+        "//sw/device/lib/crypto/include:mldsa.h",
+    ],
+    target_compatible_with = [OPENTITAN_CPU],
+    deps = [
+        ":integrity",
+        ":keyblob",
+        ":status",
+        "//sw/device/lib/crypto/impl/mldsa:mldsa_native",
+        "//sw/device/lib/crypto/include:datatypes",
+    ],
+)
+
+cc_library(
     name = "x25519",
     srcs = ["x25519.c"],
     hdrs = ["//sw/device/lib/crypto/include:x25519.h"],

--- a/sw/device/lib/crypto/impl/mldsa.c
+++ b/sw/device/lib/crypto/impl/mldsa.c
@@ -1,0 +1,590 @@
+// Copyright The mldsa-native project authors
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/include/mldsa.h"
+
+#include <string.h>
+
+#include "sw/device/lib/base/math.h"
+#include "sw/device/lib/crypto/drivers/entropy.h"
+#include "sw/device/lib/crypto/impl/integrity.h"
+#include "sw/device/lib/crypto/impl/keyblob.h"
+#include "sw/device/lib/crypto/impl/mldsa/mldsa_native_monobuild.h"
+#include "sw/device/lib/crypto/impl/status.h"
+
+// Module ID for status codes.
+#define MODULE_ID MAKE_MODULE_ID('m', 'l', 'd')
+
+// Static assertions to verify buffer sizes match mldsa-native
+_Static_assert(kOtcryptoMldsa44WorkBufferKeypairWords * sizeof(uint32_t) ==
+                   MLD_TOTAL_ALLOC_44_KEYPAIR,
+               "ML-DSA-44 keypair work buffer size mismatch");
+_Static_assert(kOtcryptoMldsa44WorkBufferSignWords * sizeof(uint32_t) ==
+                   MLD_TOTAL_ALLOC_44_SIGN,
+               "ML-DSA-44 sign work buffer size mismatch");
+_Static_assert(kOtcryptoMldsa44WorkBufferVerifyWords * sizeof(uint32_t) ==
+                   MLD_TOTAL_ALLOC_44_VERIFY,
+               "ML-DSA-44 verify work buffer size mismatch");
+
+_Static_assert(kOtcryptoMldsa65WorkBufferKeypairWords * sizeof(uint32_t) ==
+                   MLD_TOTAL_ALLOC_65_KEYPAIR,
+               "ML-DSA-65 keypair work buffer size mismatch");
+_Static_assert(kOtcryptoMldsa65WorkBufferSignWords * sizeof(uint32_t) ==
+                   MLD_TOTAL_ALLOC_65_SIGN,
+               "ML-DSA-65 sign work buffer size mismatch");
+_Static_assert(kOtcryptoMldsa65WorkBufferVerifyWords * sizeof(uint32_t) ==
+                   MLD_TOTAL_ALLOC_65_VERIFY,
+               "ML-DSA-65 verify work buffer size mismatch");
+
+_Static_assert(kOtcryptoMldsa87WorkBufferKeypairWords * sizeof(uint32_t) ==
+                   MLD_TOTAL_ALLOC_87_KEYPAIR,
+               "ML-DSA-87 keypair work buffer size mismatch");
+_Static_assert(kOtcryptoMldsa87WorkBufferSignWords * sizeof(uint32_t) ==
+                   MLD_TOTAL_ALLOC_87_SIGN,
+               "ML-DSA-87 sign work buffer size mismatch");
+_Static_assert(kOtcryptoMldsa87WorkBufferVerifyWords * sizeof(uint32_t) ==
+                   MLD_TOTAL_ALLOC_87_VERIFY,
+               "ML-DSA-87 verify work buffer size mismatch");
+
+otcrypto_status_t otcrypto_mldsa44_keygen(
+    otcrypto_unblinded_key_t *public_key, otcrypto_blinded_key_t *secret_key,
+    uint32_t work[kOtcryptoMldsa44WorkBufferKeypairWords]) {
+  HARDENED_TRY(entropy_complex_check());
+
+  uint32_t seed[ceil_div(kOtcryptoMldsa44SeedBytes, sizeof(uint32_t))];
+  HARDENED_TRY(entropy_csrng_instantiate(
+      /*disable_trng_input=*/kHardenedBoolFalse, &kEntropyEmptySeed));
+  HARDENED_TRY(entropy_csrng_generate(&kEntropyEmptySeed, seed, ARRAYSIZE(seed),
+                                      /*fips_check=*/kHardenedBoolTrue));
+  HARDENED_TRY(entropy_csrng_uninstantiate());
+
+  otcrypto_const_byte_buf_t seed_buf = {.data = (unsigned char *)seed,
+                                        .len = sizeof(seed)};
+  return otcrypto_mldsa44_keypair_derand(seed_buf, public_key, secret_key,
+                                         work);
+}
+
+otcrypto_status_t otcrypto_mldsa44_keypair_derand(
+    otcrypto_const_byte_buf_t seed, otcrypto_unblinded_key_t *public_key,
+    otcrypto_blinded_key_t *secret_key,
+    uint32_t work[kOtcryptoMldsa44WorkBufferKeypairWords]) {
+  if (seed.len != kOtcryptoMldsa44SeedBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (public_key == NULL || secret_key == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (public_key->key_mode != kOtcryptoKeyModeMldsa44) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (secret_key->config.key_mode != kOtcryptoKeyModeMldsa44) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (public_key->key_length != kOtcryptoMldsa44PublicKeyBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (secret_key->config.key_length != kOtcryptoMldsa44SecretKeyBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  // Write the unmasked secret key into the first share of the keyblob.
+  uint32_t *sk_share0;
+  uint32_t *sk_share1;
+  HARDENED_TRY(keyblob_to_shares(secret_key, &sk_share0, &sk_share1));
+  memset(sk_share1, 0, kOtcryptoMldsa44SecretKeyBytes);
+
+  mld_alloc_ctx_t ctx = {.base = work,
+                         .size_words = kOtcryptoMldsa44WorkBufferKeypairWords,
+                         .offset_words = 0};
+  int result = mldsa44_keypair_internal((uint8_t *)public_key->key,
+                                        (uint8_t *)sk_share0, seed.data, &ctx);
+  if (result != 0) {
+    memset(sk_share0, 0, kOtcryptoMldsa44SecretKeyBytes);
+    return OTCRYPTO_FATAL_ERR;
+  }
+
+  public_key->checksum = integrity_unblinded_checksum(public_key);
+  secret_key->checksum = integrity_blinded_checksum(secret_key);
+
+  return OTCRYPTO_OK;
+}
+
+otcrypto_status_t otcrypto_mldsa44_sign(
+    const otcrypto_blinded_key_t *secret_key, otcrypto_const_byte_buf_t message,
+    otcrypto_const_byte_buf_t context, otcrypto_mldsa_sign_mode_t sign_mode,
+    otcrypto_byte_buf_t signature,
+    uint32_t work[kOtcryptoMldsa44WorkBufferSignWords]) {
+  HARDENED_TRY(entropy_complex_check());
+
+  uint32_t rnd[ceil_div(kOtcryptoMldsa44SeedBytes, sizeof(uint32_t))];
+  HARDENED_TRY(entropy_csrng_instantiate(
+      /*disable_trng_input=*/kHardenedBoolFalse, &kEntropyEmptySeed));
+  HARDENED_TRY(entropy_csrng_generate(&kEntropyEmptySeed, rnd, ARRAYSIZE(rnd),
+                                      /*fips_check=*/kHardenedBoolTrue));
+  HARDENED_TRY(entropy_csrng_uninstantiate());
+
+  otcrypto_const_byte_buf_t rnd_buf = {.data = (unsigned char *)rnd,
+                                       .len = sizeof(rnd)};
+  return otcrypto_mldsa44_sign_derand(secret_key, message, context, sign_mode,
+                                      rnd_buf, signature, work);
+}
+
+otcrypto_status_t otcrypto_mldsa44_sign_derand(
+    const otcrypto_blinded_key_t *secret_key, otcrypto_const_byte_buf_t message,
+    otcrypto_const_byte_buf_t context, otcrypto_mldsa_sign_mode_t sign_mode,
+    otcrypto_const_byte_buf_t rnd, otcrypto_byte_buf_t signature,
+    uint32_t work[kOtcryptoMldsa44WorkBufferSignWords]) {
+  if (secret_key == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (secret_key->config.key_mode != kOtcryptoKeyModeMldsa44) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (secret_key->config.key_length != kOtcryptoMldsa44SecretKeyBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (sign_mode != kOtcryptoMldsaSignModeMldsa) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (rnd.len != kOtcryptoMldsa44SeedBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (signature.len < kOtcryptoMldsa44SignatureBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (context.len > 255) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (integrity_blinded_key_check(secret_key) != kHardenedBoolTrue) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  // Secret keys are stored unmasked in share0 (share1 is zero).
+  uint32_t *sk_share0;
+  uint32_t *sk_share1;
+  HARDENED_TRY(keyblob_to_shares(secret_key, &sk_share0, &sk_share1));
+
+  mld_alloc_ctx_t ctx = {.base = work,
+                         .size_words = kOtcryptoMldsa44WorkBufferSignWords,
+                         .offset_words = 0};
+
+  uint32_t pre_buf[(2 + 255 + (sizeof(uint32_t) - 1)) / sizeof(uint32_t)];
+  uint8_t *pre = (uint8_t *)pre_buf;
+  pre[0] = 0;
+  pre[1] = (uint8_t)context.len;
+  if (context.len > 0) {
+    memcpy(pre + 2, context.data, context.len);
+  }
+
+  size_t signature_len;
+  int result = mldsa44_signature_internal(
+      signature.data, &signature_len, message.data, message.len, pre,
+      2 + context.len, rnd.data, (const uint8_t *)sk_share0, 0, &ctx);
+
+  if (result != 0) {
+    return OTCRYPTO_FATAL_ERR;
+  }
+
+  return OTCRYPTO_OK;
+}
+
+otcrypto_status_t otcrypto_mldsa44_verify(
+    const otcrypto_unblinded_key_t *public_key,
+    otcrypto_const_byte_buf_t message, otcrypto_const_byte_buf_t context,
+    otcrypto_mldsa_sign_mode_t sign_mode, otcrypto_const_byte_buf_t signature,
+    hardened_bool_t *verification_result,
+    uint32_t work[kOtcryptoMldsa44WorkBufferVerifyWords]) {
+  if (public_key == NULL || verification_result == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (public_key->key_mode != kOtcryptoKeyModeMldsa44) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (public_key->key_length != kOtcryptoMldsa44PublicKeyBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (sign_mode != kOtcryptoMldsaSignModeMldsa) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (context.len > 255) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (integrity_unblinded_key_check(public_key) != kHardenedBoolTrue) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  mld_alloc_ctx_t ctx = {.base = work,
+                         .size_words = kOtcryptoMldsa44WorkBufferVerifyWords,
+                         .offset_words = 0};
+  int result = mldsa44_verify(signature.data, signature.len, message.data,
+                              message.len, context.data, context.len,
+                              (const uint8_t *)public_key->key, &ctx);
+
+  *verification_result = (result == 0) ? kHardenedBoolTrue : kHardenedBoolFalse;
+
+  return OTCRYPTO_OK;
+}
+
+// ML-DSA-65 functions
+
+otcrypto_status_t otcrypto_mldsa65_keygen(
+    otcrypto_unblinded_key_t *public_key, otcrypto_blinded_key_t *secret_key,
+    uint32_t work[kOtcryptoMldsa65WorkBufferKeypairWords]) {
+  HARDENED_TRY(entropy_complex_check());
+
+  uint32_t seed[ceil_div(kOtcryptoMldsa65SeedBytes, sizeof(uint32_t))];
+  HARDENED_TRY(entropy_csrng_instantiate(
+      /*disable_trng_input=*/kHardenedBoolFalse, &kEntropyEmptySeed));
+  HARDENED_TRY(entropy_csrng_generate(&kEntropyEmptySeed, seed, ARRAYSIZE(seed),
+                                      /*fips_check=*/kHardenedBoolTrue));
+  HARDENED_TRY(entropy_csrng_uninstantiate());
+
+  otcrypto_const_byte_buf_t seed_buf = {.data = (unsigned char *)seed,
+                                        .len = sizeof(seed)};
+  return otcrypto_mldsa65_keypair_derand(seed_buf, public_key, secret_key,
+                                         work);
+}
+
+otcrypto_status_t otcrypto_mldsa65_keypair_derand(
+    otcrypto_const_byte_buf_t seed, otcrypto_unblinded_key_t *public_key,
+    otcrypto_blinded_key_t *secret_key,
+    uint32_t work[kOtcryptoMldsa65WorkBufferKeypairWords]) {
+  if (seed.len != kOtcryptoMldsa65SeedBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (public_key == NULL || secret_key == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (public_key->key_mode != kOtcryptoKeyModeMldsa65) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (secret_key->config.key_mode != kOtcryptoKeyModeMldsa65) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (public_key->key_length != kOtcryptoMldsa65PublicKeyBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (secret_key->config.key_length != kOtcryptoMldsa65SecretKeyBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  // Write the unmasked secret key into the first share of the keyblob.
+  uint32_t *sk_share0;
+  uint32_t *sk_share1;
+  HARDENED_TRY(keyblob_to_shares(secret_key, &sk_share0, &sk_share1));
+  memset(sk_share1, 0, kOtcryptoMldsa65SecretKeyBytes);
+
+  mld_alloc_ctx_t ctx = {.base = work,
+                         .size_words = kOtcryptoMldsa65WorkBufferKeypairWords,
+                         .offset_words = 0};
+  int result = mldsa65_keypair_internal((uint8_t *)public_key->key,
+                                        (uint8_t *)sk_share0, seed.data, &ctx);
+  if (result != 0) {
+    memset(sk_share0, 0, kOtcryptoMldsa65SecretKeyBytes);
+    return OTCRYPTO_FATAL_ERR;
+  }
+
+  public_key->checksum = integrity_unblinded_checksum(public_key);
+  secret_key->checksum = integrity_blinded_checksum(secret_key);
+
+  return OTCRYPTO_OK;
+}
+
+otcrypto_status_t otcrypto_mldsa65_sign(
+    const otcrypto_blinded_key_t *secret_key, otcrypto_const_byte_buf_t message,
+    otcrypto_const_byte_buf_t context, otcrypto_mldsa_sign_mode_t sign_mode,
+    otcrypto_byte_buf_t signature,
+    uint32_t work[kOtcryptoMldsa65WorkBufferSignWords]) {
+  HARDENED_TRY(entropy_complex_check());
+
+  uint32_t rnd[ceil_div(kOtcryptoMldsa65SeedBytes, sizeof(uint32_t))];
+  HARDENED_TRY(entropy_csrng_instantiate(
+      /*disable_trng_input=*/kHardenedBoolFalse, &kEntropyEmptySeed));
+  HARDENED_TRY(entropy_csrng_generate(&kEntropyEmptySeed, rnd, ARRAYSIZE(rnd),
+                                      /*fips_check=*/kHardenedBoolTrue));
+  HARDENED_TRY(entropy_csrng_uninstantiate());
+
+  otcrypto_const_byte_buf_t rnd_buf = {.data = (unsigned char *)rnd,
+                                       .len = sizeof(rnd)};
+  return otcrypto_mldsa65_sign_derand(secret_key, message, context, sign_mode,
+                                      rnd_buf, signature, work);
+}
+
+otcrypto_status_t otcrypto_mldsa65_sign_derand(
+    const otcrypto_blinded_key_t *secret_key, otcrypto_const_byte_buf_t message,
+    otcrypto_const_byte_buf_t context, otcrypto_mldsa_sign_mode_t sign_mode,
+    otcrypto_const_byte_buf_t rnd, otcrypto_byte_buf_t signature,
+    uint32_t work[kOtcryptoMldsa65WorkBufferSignWords]) {
+  if (secret_key == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (secret_key->config.key_mode != kOtcryptoKeyModeMldsa65) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (secret_key->config.key_length != kOtcryptoMldsa65SecretKeyBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (sign_mode != kOtcryptoMldsaSignModeMldsa) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (rnd.len != kOtcryptoMldsa65SeedBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (signature.len < kOtcryptoMldsa65SignatureBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (context.len > 255) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (integrity_blinded_key_check(secret_key) != kHardenedBoolTrue) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  // Secret keys are stored unmasked in share0 (share1 is zero).
+  uint32_t *sk_share0;
+  uint32_t *sk_share1;
+  HARDENED_TRY(keyblob_to_shares(secret_key, &sk_share0, &sk_share1));
+
+  mld_alloc_ctx_t ctx = {.base = work,
+                         .size_words = kOtcryptoMldsa65WorkBufferSignWords,
+                         .offset_words = 0};
+
+  uint32_t pre_buf[(2 + 255 + (sizeof(uint32_t) - 1)) / sizeof(uint32_t)];
+  uint8_t *pre = (uint8_t *)pre_buf;
+  pre[0] = 0;
+  pre[1] = (uint8_t)context.len;
+  if (context.len > 0) {
+    memcpy(pre + 2, context.data, context.len);
+  }
+
+  size_t signature_len;
+  int result = mldsa65_signature_internal(
+      signature.data, &signature_len, message.data, message.len, pre,
+      2 + context.len, rnd.data, (const uint8_t *)sk_share0, 0, &ctx);
+
+  if (result != 0) {
+    return OTCRYPTO_FATAL_ERR;
+  }
+
+  return OTCRYPTO_OK;
+}
+
+otcrypto_status_t otcrypto_mldsa65_verify(
+    const otcrypto_unblinded_key_t *public_key,
+    otcrypto_const_byte_buf_t message, otcrypto_const_byte_buf_t context,
+    otcrypto_mldsa_sign_mode_t sign_mode, otcrypto_const_byte_buf_t signature,
+    hardened_bool_t *verification_result,
+    uint32_t work[kOtcryptoMldsa65WorkBufferVerifyWords]) {
+  if (public_key == NULL || verification_result == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (public_key->key_mode != kOtcryptoKeyModeMldsa65) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (public_key->key_length != kOtcryptoMldsa65PublicKeyBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (sign_mode != kOtcryptoMldsaSignModeMldsa) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (context.len > 255) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (integrity_unblinded_key_check(public_key) != kHardenedBoolTrue) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  mld_alloc_ctx_t ctx = {.base = work,
+                         .size_words = kOtcryptoMldsa65WorkBufferVerifyWords,
+                         .offset_words = 0};
+  int result = mldsa65_verify(signature.data, signature.len, message.data,
+                              message.len, context.data, context.len,
+                              (const uint8_t *)public_key->key, &ctx);
+
+  *verification_result = (result == 0) ? kHardenedBoolTrue : kHardenedBoolFalse;
+
+  return OTCRYPTO_OK;
+}
+
+// ML-DSA-87 functions
+
+otcrypto_status_t otcrypto_mldsa87_keygen(
+    otcrypto_unblinded_key_t *public_key, otcrypto_blinded_key_t *secret_key,
+    uint32_t work[kOtcryptoMldsa87WorkBufferKeypairWords]) {
+  HARDENED_TRY(entropy_complex_check());
+
+  uint32_t seed[ceil_div(kOtcryptoMldsa87SeedBytes, sizeof(uint32_t))];
+  HARDENED_TRY(entropy_csrng_instantiate(
+      /*disable_trng_input=*/kHardenedBoolFalse, &kEntropyEmptySeed));
+  HARDENED_TRY(entropy_csrng_generate(&kEntropyEmptySeed, seed, ARRAYSIZE(seed),
+                                      /*fips_check=*/kHardenedBoolTrue));
+  HARDENED_TRY(entropy_csrng_uninstantiate());
+
+  otcrypto_const_byte_buf_t seed_buf = {.data = (unsigned char *)seed,
+                                        .len = sizeof(seed)};
+  return otcrypto_mldsa87_keypair_derand(seed_buf, public_key, secret_key,
+                                         work);
+}
+
+otcrypto_status_t otcrypto_mldsa87_keypair_derand(
+    otcrypto_const_byte_buf_t seed, otcrypto_unblinded_key_t *public_key,
+    otcrypto_blinded_key_t *secret_key,
+    uint32_t work[kOtcryptoMldsa87WorkBufferKeypairWords]) {
+  if (seed.len != kOtcryptoMldsa87SeedBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (public_key == NULL || secret_key == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (public_key->key_mode != kOtcryptoKeyModeMldsa87) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (secret_key->config.key_mode != kOtcryptoKeyModeMldsa87) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (public_key->key_length != kOtcryptoMldsa87PublicKeyBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (secret_key->config.key_length != kOtcryptoMldsa87SecretKeyBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  // Write the unmasked secret key into the first share of the keyblob.
+  uint32_t *sk_share0;
+  uint32_t *sk_share1;
+  HARDENED_TRY(keyblob_to_shares(secret_key, &sk_share0, &sk_share1));
+  memset(sk_share1, 0, kOtcryptoMldsa87SecretKeyBytes);
+
+  mld_alloc_ctx_t ctx = {.base = work,
+                         .size_words = kOtcryptoMldsa87WorkBufferKeypairWords,
+                         .offset_words = 0};
+  int result = mldsa87_keypair_internal((uint8_t *)public_key->key,
+                                        (uint8_t *)sk_share0, seed.data, &ctx);
+  if (result != 0) {
+    memset(sk_share0, 0, kOtcryptoMldsa87SecretKeyBytes);
+    return OTCRYPTO_FATAL_ERR;
+  }
+
+  public_key->checksum = integrity_unblinded_checksum(public_key);
+  secret_key->checksum = integrity_blinded_checksum(secret_key);
+
+  return OTCRYPTO_OK;
+}
+
+otcrypto_status_t otcrypto_mldsa87_sign(
+    const otcrypto_blinded_key_t *secret_key, otcrypto_const_byte_buf_t message,
+    otcrypto_const_byte_buf_t context, otcrypto_mldsa_sign_mode_t sign_mode,
+    otcrypto_byte_buf_t signature,
+    uint32_t work[kOtcryptoMldsa87WorkBufferSignWords]) {
+  HARDENED_TRY(entropy_complex_check());
+
+  uint32_t rnd[ceil_div(kOtcryptoMldsa87SeedBytes, sizeof(uint32_t))];
+  HARDENED_TRY(entropy_csrng_instantiate(
+      /*disable_trng_input=*/kHardenedBoolFalse, &kEntropyEmptySeed));
+  HARDENED_TRY(entropy_csrng_generate(&kEntropyEmptySeed, rnd, ARRAYSIZE(rnd),
+                                      /*fips_check=*/kHardenedBoolTrue));
+  HARDENED_TRY(entropy_csrng_uninstantiate());
+
+  otcrypto_const_byte_buf_t rnd_buf = {.data = (unsigned char *)rnd,
+                                       .len = sizeof(rnd)};
+  return otcrypto_mldsa87_sign_derand(secret_key, message, context, sign_mode,
+                                      rnd_buf, signature, work);
+}
+
+otcrypto_status_t otcrypto_mldsa87_sign_derand(
+    const otcrypto_blinded_key_t *secret_key, otcrypto_const_byte_buf_t message,
+    otcrypto_const_byte_buf_t context, otcrypto_mldsa_sign_mode_t sign_mode,
+    otcrypto_const_byte_buf_t rnd, otcrypto_byte_buf_t signature,
+    uint32_t work[kOtcryptoMldsa87WorkBufferSignWords]) {
+  if (secret_key == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (secret_key->config.key_mode != kOtcryptoKeyModeMldsa87) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (secret_key->config.key_length != kOtcryptoMldsa87SecretKeyBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (sign_mode != kOtcryptoMldsaSignModeMldsa) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (rnd.len != kOtcryptoMldsa87SeedBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (signature.len < kOtcryptoMldsa87SignatureBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (context.len > 255) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (integrity_blinded_key_check(secret_key) != kHardenedBoolTrue) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  // Secret keys are stored unmasked in share0 (share1 is zero).
+  uint32_t *sk_share0;
+  uint32_t *sk_share1;
+  HARDENED_TRY(keyblob_to_shares(secret_key, &sk_share0, &sk_share1));
+
+  mld_alloc_ctx_t ctx = {.base = work,
+                         .size_words = kOtcryptoMldsa87WorkBufferSignWords,
+                         .offset_words = 0};
+
+  uint32_t pre_buf[(2 + 255 + (sizeof(uint32_t) - 1)) / sizeof(uint32_t)];
+  uint8_t *pre = (uint8_t *)pre_buf;
+  pre[0] = 0;
+  pre[1] = (uint8_t)context.len;
+  if (context.len > 0) {
+    memcpy(pre + 2, context.data, context.len);
+  }
+
+  size_t signature_len;
+  int result = mldsa87_signature_internal(
+      signature.data, &signature_len, message.data, message.len, pre,
+      2 + context.len, rnd.data, (const uint8_t *)sk_share0, 0, &ctx);
+
+  if (result != 0) {
+    return OTCRYPTO_FATAL_ERR;
+  }
+
+  return OTCRYPTO_OK;
+}
+
+otcrypto_status_t otcrypto_mldsa87_verify(
+    const otcrypto_unblinded_key_t *public_key,
+    otcrypto_const_byte_buf_t message, otcrypto_const_byte_buf_t context,
+    otcrypto_mldsa_sign_mode_t sign_mode, otcrypto_const_byte_buf_t signature,
+    hardened_bool_t *verification_result,
+    uint32_t work[kOtcryptoMldsa87WorkBufferVerifyWords]) {
+  if (public_key == NULL || verification_result == NULL) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (public_key->key_mode != kOtcryptoKeyModeMldsa87) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (public_key->key_length != kOtcryptoMldsa87PublicKeyBytes) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (sign_mode != kOtcryptoMldsaSignModeMldsa) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (context.len > 255) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+  if (integrity_unblinded_key_check(public_key) != kHardenedBoolTrue) {
+    return OTCRYPTO_BAD_ARGS;
+  }
+
+  mld_alloc_ctx_t ctx = {.base = work,
+                         .size_words = kOtcryptoMldsa87WorkBufferVerifyWords,
+                         .offset_words = 0};
+  int result = mldsa87_verify(signature.data, signature.len, message.data,
+                              message.len, context.data, context.len,
+                              (const uint8_t *)public_key->key, &ctx);
+
+  *verification_result = (result == 0) ? kHardenedBoolTrue : kHardenedBoolFalse;
+
+  return OTCRYPTO_OK;
+}

--- a/sw/device/lib/crypto/impl/mldsa/BUILD
+++ b/sw/device/lib/crypto/impl/mldsa/BUILD
@@ -1,0 +1,25 @@
+# Copyright The mldsa-native project authors
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "mldsa_native",
+    srcs = [
+        "mldsa_native_alloc.c",
+        "mldsa_native_monobuild.c",
+    ],
+    hdrs = [
+        "fips202_glue.h",
+        "mldsa_native_alloc.h",
+        "mldsa_native_config.h",
+        "mldsa_native_monobuild.h",
+    ],
+    includes = ["."],
+    deps = [
+        "//sw/device/lib/crypto/impl:sha3",
+        "@mldsa_native//:mldsa_native_sources",
+    ],
+)

--- a/sw/device/lib/crypto/impl/mldsa/fips202_glue.h
+++ b/sw/device/lib/crypto/impl/mldsa/fips202_glue.h
@@ -1,0 +1,169 @@
+// Copyright The mldsa-native project authors
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_MLDSA_FIPS202_GLUE_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_MLDSA_FIPS202_GLUE_H_
+#include <stdint.h>
+
+#include "mldsa/src/common.h"
+#include "sw/device/lib/base/macros.h"
+#include "sw/device/lib/crypto/drivers/kmac.h"
+#include "sw/device/lib/crypto/include/sha3.h"
+
+#define SHAKE128_RATE 168
+#define SHAKE256_RATE 136
+
+typedef struct {
+} MLD_ALIGN mld_shake128ctx;
+
+typedef struct {
+} MLD_ALIGN mld_shake256ctx;
+
+static MLD_INLINE void mld_shake128_absorb_once(mld_shake128ctx *state,
+                                                const uint8_t *input,
+                                                size_t inlen) {
+  (void)state;
+  kmac_shake128_begin();
+  kmac_absorb(input, inlen);
+  kmac_process();
+}
+
+static MLD_INLINE void mld_shake128_squeezeblocks(uint8_t *output,
+                                                  size_t nblocks,
+                                                  mld_shake128ctx *state) {
+  (void)state;
+  kmac_squeeze_blocks(nblocks, kHardenedBoolFalse, (uint32_t *)output, NULL);
+}
+
+static MLD_INLINE void mld_shake128_init(mld_shake128ctx *state) {
+  (void)state;
+  kmac_shake128_begin();
+}
+
+static MLD_INLINE void mld_shake128_absorb(mld_shake128ctx *state,
+                                           const uint8_t *input, size_t inlen) {
+  (void)state;
+  kmac_absorb(input, inlen);
+}
+
+static MLD_INLINE void mld_shake128_finalize(mld_shake128ctx *state) {
+  (void)state;
+  kmac_process();
+}
+
+static MLD_INLINE void mld_shake128_squeeze(uint8_t *output, size_t outlen,
+                                            mld_shake128ctx *state) {
+  (void)state;
+  size_t nblocks = outlen / SHAKE128_RATE;
+  size_t remainder = outlen % SHAKE128_RATE;
+
+  if (nblocks > 0) {
+    kmac_squeeze_blocks(nblocks, kHardenedBoolFalse, (uint32_t *)output, NULL);
+  }
+
+  if (remainder > 0) {
+    uint8_t block[SHAKE128_RATE];
+    kmac_squeeze_blocks(1, kHardenedBoolFalse, (uint32_t *)block, NULL);
+    for (size_t i = 0; i < remainder; i++) {
+      output[nblocks * SHAKE128_RATE + i] = block[i];
+    }
+  }
+}
+
+static MLD_INLINE void mld_shake128_release(mld_shake128ctx *state) {
+  (void)state;
+  kmac_squeeze_end(0, kHardenedBoolFalse, NULL, NULL);
+}
+
+static MLD_INLINE void mld_shake256_absorb_once(mld_shake256ctx *state,
+                                                const uint8_t *input,
+                                                size_t inlen) {
+  (void)state;
+  kmac_shake256_begin();
+  kmac_absorb(input, inlen);
+  kmac_process();
+}
+
+static MLD_INLINE void mld_shake256_squeezeblocks(uint8_t *output,
+                                                  size_t nblocks,
+                                                  mld_shake256ctx *state) {
+  (void)state;
+  kmac_squeeze_blocks(nblocks, kHardenedBoolFalse, (uint32_t *)output, NULL);
+}
+
+static MLD_INLINE void mld_shake256_init(mld_shake256ctx *state) {
+  (void)state;
+  kmac_shake256_begin();
+}
+
+static MLD_INLINE void mld_shake256_absorb(mld_shake256ctx *state,
+                                           const uint8_t *input, size_t inlen) {
+  (void)state;
+  kmac_absorb(input, inlen);
+}
+
+static MLD_INLINE void mld_shake256_finalize(mld_shake256ctx *state) {
+  (void)state;
+  kmac_process();
+}
+
+static MLD_INLINE void mld_shake256_squeeze(uint8_t *output, size_t outlen,
+                                            mld_shake256ctx *state) {
+  (void)state;
+  size_t nblocks = outlen / SHAKE256_RATE;
+  size_t remainder = outlen % SHAKE256_RATE;
+
+  if (nblocks > 0) {
+    kmac_squeeze_blocks(nblocks, kHardenedBoolFalse, (uint32_t *)output, NULL);
+  }
+
+  if (remainder > 0) {
+    uint8_t block[SHAKE256_RATE];
+    kmac_squeeze_blocks(1, kHardenedBoolFalse, (uint32_t *)block, NULL);
+    for (size_t i = 0; i < remainder; i++) {
+      output[nblocks * SHAKE256_RATE + i] = block[i];
+    }
+  }
+}
+
+static MLD_INLINE void mld_shake256_release(mld_shake256ctx *state) {
+  (void)state;
+  kmac_squeeze_end(0, kHardenedBoolFalse, NULL, NULL);
+}
+
+static MLD_INLINE void mld_shake256(uint8_t *output, size_t outlen,
+                                    const uint8_t *input, size_t inlen) {
+  otcrypto_hash_digest_t md = {.data = (uint32_t *)output,
+                               .len = outlen / sizeof(uint32_t),
+                               .mode = kOtcryptoHashXofModeShake256};
+
+  otcrypto_const_byte_buf_t d = {.data = input, .len = inlen};
+
+  otcrypto_shake256(d, &md);
+}
+
+static MLD_INLINE void mld_sha3_256(uint8_t *output, const uint8_t *input,
+                                    size_t inlen) {
+  otcrypto_hash_digest_t md = {.data = (uint32_t *)output,
+                               .len = 32 / sizeof(uint32_t),
+                               .mode = kOtcryptoHashModeSha3_256};
+
+  otcrypto_const_byte_buf_t d = {.data = input, .len = inlen};
+
+  otcrypto_sha3_256(d, &md);
+}
+
+static MLD_INLINE void mld_sha3_512(uint8_t *output, const uint8_t *input,
+                                    size_t inlen) {
+  otcrypto_hash_digest_t md = {.data = (uint32_t *)output,
+                               .len = 64 / sizeof(uint32_t),
+                               .mode = kOtcryptoHashModeSha3_512};
+
+  otcrypto_const_byte_buf_t d = {.data = input, .len = inlen};
+
+  otcrypto_sha3_512(d, &md);
+}
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_MLDSA_FIPS202_GLUE_H_

--- a/sw/device/lib/crypto/impl/mldsa/mldsa_native_alloc.c
+++ b/sw/device/lib/crypto/impl/mldsa/mldsa_native_alloc.c
@@ -1,0 +1,36 @@
+// Copyright The mldsa-native project authors
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "sw/device/lib/crypto/impl/mldsa/mldsa_native_alloc.h"
+
+#include "sw/device/lib/base/hardened.h"
+
+void *mld_alloc(mld_alloc_ctx_t *ctx, size_t size_bytes) {
+  size_t size_words = MLD_ALIGN_UP(size_bytes) / sizeof(uint32_t);
+  size_t bytes_available =
+      sizeof(uint32_t) * (ctx->size_words - ctx->offset_words);
+
+  if (size_bytes > bytes_available) {
+    return NULL;  // Out of space
+  }
+
+  void *ptr = (void *)(ctx->base + ctx->offset_words);
+  ctx->offset_words += size_words;
+  return ptr;
+}
+
+void mld_free(void *ptr, mld_alloc_ctx_t *ctx, size_t size_bytes) {
+  if (ptr == NULL) {
+    return;  // No-op if NULL
+  }
+
+  size_t size_words = MLD_ALIGN_UP(size_bytes) / sizeof(uint32_t);
+
+  // Ensure freeing in reverse allocation order
+  void *expected_ptr = (void *)(ctx->base + ctx->offset_words - size_words);
+  HARDENED_CHECK_EQ(ptr, expected_ptr);
+
+  ctx->offset_words -= size_words;
+}

--- a/sw/device/lib/crypto/impl/mldsa/mldsa_native_alloc.h
+++ b/sw/device/lib/crypto/impl/mldsa/mldsa_native_alloc.h
@@ -1,0 +1,42 @@
+// Copyright The mldsa-native project authors
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_MLDSA_MLDSA_NATIVE_ALLOC_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_MLDSA_MLDSA_NATIVE_ALLOC_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "mldsa/src/sys.h"
+
+// Bump allocator context
+typedef struct {
+  uint32_t *base;       // Base pointer to start of buffer
+  size_t size_words;    // Total size of buffer (in words)
+  size_t offset_words;  // Current offset into buffer (in words)
+} mld_alloc_ctx_t;
+
+/**
+ * Allocate memory from bump allocator
+ *
+ * @param ctx Allocator context
+ * @param size_bytes Number of bytes to allocate
+ * @return Pointer to allocated memory, or NULL if out of space
+ */
+void *mld_alloc(mld_alloc_ctx_t *ctx, size_t size_bytes);
+
+/**
+ * Free memory from bump allocator
+ *
+ * Decrements the allocator offset. This is a simple bump allocator,
+ * so freeing must be done in reverse order of allocation.
+ *
+ * @param ptr Pointer to free (may be NULL, in which case this is a no-op)
+ * @param ctx Allocator context
+ * @param size_bytes Number of bytes to free
+ */
+void mld_free(void *ptr, mld_alloc_ctx_t *ctx, size_t size_bytes);
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_MLDSA_MLDSA_NATIVE_ALLOC_H_

--- a/sw/device/lib/crypto/impl/mldsa/mldsa_native_config.h
+++ b/sw/device/lib/crypto/impl/mldsa/mldsa_native_config.h
@@ -1,0 +1,219 @@
+// Copyright The mldsa-native project authors
+//  Copyright zeroRISC Inc.
+//  Licensed under the Apache License, Version 2.0, see LICENSE for details.
+//  SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_MLDSA_MLDSA_NATIVE_CONFIG_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_MLDSA_MLDSA_NATIVE_CONFIG_H_
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_MULTILEVEL_BUILD
+ *
+ * Description: Set this if the build is part of a multi-level build supporting
+ *              multiple parameter sets.
+ *
+ *              If you need only a single parameter set, keep this unset.
+ *
+ *              To build mldsa-native with support for all parameter sets,
+ *              build it three times -- once per parameter set -- and set the
+ *              option MLD_CONFIG_MULTILEVEL_WITH_SHARED for exactly one of
+ *              them, and MLD_CONFIG_MULTILEVEL_NO_SHARED for the others.
+ *              MLD_CONFIG_MULTILEVEL_BUILD should be set for all of them.
+ *
+ *              See examples/multilevel_build for an example.
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+#define MLD_CONFIG_MULTILEVEL_BUILD
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_NAMESPACE_PREFIX
+ *
+ * Description: The prefix to use to namespace global symbols from mldsa/.
+ *
+ *              In a multi-level build (that is, if either
+ *              - MLD_CONFIG_MULTILEVEL_WITH_SHARED, or
+ *              - MLD_CONFIG_MULTILEVEL_NO_SHARED,
+ *              are set, level-dependent symbols will additionally be prefixed
+ *              with the parameter set (44/65/87).
+ *
+ *              This can also be set using CFLAGS.
+ *
+ *****************************************************************************/
+#define MLD_CONFIG_NAMESPACE_PREFIX mldsa
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_NO_RANDOMIZED_API
+ *
+ * Description: If this option is set, mldsa-native will be built without the
+ *              randomized API functions (crypto_sign_keypair,
+ *              crypto_sign, crypto_sign_signature, and
+ *              crypto_sign_signature_extmu).
+ *              This allows users to build mldsa-native without providing a
+ *              randombytes() implementation if they only need the
+ *              internal deterministic API
+ *              (crypto_sign_keypair_internal, crypto_sign_signature_internal).
+ *
+ *              NOTE: This option is incompatible with MLD_CONFIG_KEYGEN_PCT
+ *              as the current PCT implementation requires
+ *              crypto_sign_signature().
+ *
+ *****************************************************************************/
+#define MLD_CONFIG_NO_RANDOMIZED_API
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_NO_SUPERCOP
+ *
+ * Description: By default, mldsa_native.h exposes the mldsa-native API in the
+ *              SUPERCOP naming convention (crypto_sign_xxx). If you don't need
+ *              this, set MLD_CONFIG_NO_SUPERCOP.
+ *
+ *              NOTE: You must set this for a multi-level build as the SUPERCOP
+ *              naming does not disambiguate between the parameter sets.
+ *
+ *****************************************************************************/
+#define MLD_CONFIG_NO_SUPERCOP
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_INTERNAL_API_QUALIFIER
+ *
+ * Description: If set, this option provides an additional function
+ *              qualifier to be added to declarations of internal API.
+ *
+ *              The primary use case for this option are single-CU builds,
+ *              in which case this option can be set to `static`.
+ *
+ *****************************************************************************/
+#define MLD_CONFIG_INTERNAL_API_QUALIFIER static
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_FIPS202_CUSTOM_HEADER
+ *
+ * Description: Custom header to use for FIPS-202
+ *
+ *              This should only be set if you intend to use a custom
+ *              FIPS-202 implementation, different from the one shipped
+ *              with mldsa-native.
+ *
+ *              If set, it must be the name of a file serving as the
+ *              replacement for mldsa/src/fips202/fips202.h, and exposing
+ *              the same API (see FIPS202.md).
+ *
+ *****************************************************************************/
+#define MLD_CONFIG_FIPS202_CUSTOM_HEADER "fips202_glue.h"
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_SERIAL_FIPS202_ONLY
+ *
+ * Description: Set this to use a FIPS202 implementation with global state
+ *              that supports only one active Keccak computation at a time
+ *              (e.g. some hardware accelerators).
+ *
+ *              If this option is set, ML-DSA will use FIPS202 operations
+ *              serially, ensuring that only one SHAKE context is active
+ *              at any given time.
+ *
+ *              This allows offloading Keccak computations to a hardware
+ *              accelerator that holds only a single Keccak state locally,
+ *              rather than requiring support for multiple concurrent
+ *              Keccak states.
+ *
+ *              NOTE: Depending on the target CPU, this may reduce
+ *              performance when using software FIPS202 implementations.
+ *              Only enable this when you have to.
+ *
+ *****************************************************************************/
+#define MLD_CONFIG_SERIAL_FIPS202_ONLY
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CONTEXT_PARAMETER
+ *
+ * Description: Set this to add a context parameter that is provided to public
+ *              API functions and is then available in custom callbacks.
+ *
+ *              The type of the context parameter is configured via
+ *              MLD_CONFIG_CONTEXT_PARAMETER_TYPE.
+ *
+ *****************************************************************************/
+#define MLD_CONFIG_CONTEXT_PARAMETER
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CONTEXT_PARAMETER_TYPE
+ *
+ * Description: Set this to define the type for the context parameter used by
+ *              MLD_CONFIG_CONTEXT_PARAMETER.
+ *
+ *              This is only relevant if MLD_CONFIG_CONTEXT_PARAMETER is set.
+ *
+ *****************************************************************************/
+#if !defined(__ASSEMBLER__)
+#include "sw/device/lib/crypto/impl/mldsa/mldsa_native_alloc.h"
+
+#define MLD_CONFIG_CONTEXT_PARAMETER_TYPE mld_alloc_ctx_t *
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_CUSTOM_ALLOC_FREE [EXPERIMENTAL]
+ *
+ * Description: Set this option and define `MLD_CUSTOM_ALLOC` and
+ *              `MLD_CUSTOM_FREE` if you want to use custom allocation for
+ *              large local structures or buffers.
+ *
+ *              By default, all buffers/structures are allocated on the stack.
+ *              If this option is set, most of them will be allocated via
+ *              MLD_CUSTOM_ALLOC.
+ *
+ *              Parameters to MLD_CUSTOM_ALLOC:
+ *              - T* v: Target pointer to declare.
+ *              - T: Type of structure to be allocated
+ *              - N: Number of elements to be allocated.
+ *
+ *              Parameters to MLD_CUSTOM_FREE:
+ *              - T* v: Target pointer to free. May be NULL.
+ *              - T: Type of structure to be freed.
+ *              - N: Number of elements to be freed.
+ *
+ *              WARNING: This option is experimental!
+ *              Its scope, configuration and function/macro signatures may
+ *              change at any time. We expect a stable API for v2.
+ *
+ *              NOTE: Even if this option is set, some allocations further down
+ *              the call stack will still be made from the stack. Those will
+ *              likely be added to the scope of this option in the future.
+ *
+ *              NOTE: MLD_CUSTOM_ALLOC need not guarantee a successful
+ *              allocation nor include error handling. Upon failure, the
+ *              target pointer should simply be set to NULL. The calling
+ *              code will handle this case and invoke MLD_CUSTOM_FREE.
+ *
+ *****************************************************************************/
+#define MLD_CONFIG_CUSTOM_ALLOC_FREE
+
+#define MLD_CUSTOM_ALLOC(v, T, N, context) \
+  T *(v) = (T *)mld_alloc((context), sizeof(T) * (N))
+
+#define MLD_CUSTOM_FREE(v, T, N, context) \
+  mld_free((void *)(v), (context), sizeof(T) * (N))
+
+#endif
+
+/******************************************************************************
+ * Name:        MLD_CONFIG_REDUCE_RAM [EXPERIMENTAL]
+ *
+ * Description: Set this to reduce RAM usage.
+ *              This trades memory for performance.
+ *
+ *              For expected memory usage, see the MLD_TOTAL_ALLOC_* constants
+ *              defined in mldsa_native.h.
+ *
+ *              This option is useful for embedded systems with tight RAM
+ *              constraints but relaxed performance requirements.
+ *
+ *              WARNING: This option is experimental!
+ *              CBMC proofs do not currently cover this configuration option.
+ *              Its scope and configuration may change at any time.
+ *
+ *****************************************************************************/
+#define MLD_CONFIG_REDUCE_RAM
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_MLDSA_MLDSA_NATIVE_CONFIG_H_

--- a/sw/device/lib/crypto/impl/mldsa/mldsa_native_monobuild.c
+++ b/sw/device/lib/crypto/impl/mldsa/mldsa_native_monobuild.c
@@ -1,0 +1,30 @@
+// Copyright The mldsa-native project authors
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "mldsa_native_monobuild.h"
+
+/* Three instances of mldsa-native for ML-DSA-44, ML-DSA-65, and ML-DSA-87 */
+
+/* Include level-independent code */
+#define MLD_CONFIG_MULTILEVEL_WITH_SHARED
+/* Keep level-independent headers at the end of monobuild file */
+#define MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+#define MLD_CONFIG_PARAMETER_SET 44
+#include "mldsa/mldsa_native.c"
+#undef MLD_CONFIG_PARAMETER_SET
+#undef MLD_CONFIG_MULTILEVEL_WITH_SHARED
+
+/* Exclude level-independent code */
+#define MLD_CONFIG_MULTILEVEL_NO_SHARED
+#define MLD_CONFIG_PARAMETER_SET 65
+#include "mldsa/mldsa_native.c"
+#undef MLD_CONFIG_PARAMETER_SET
+
+/* `#undef` all headers at the end of the monobuild file */
+#undef MLD_CONFIG_MONOBUILD_KEEP_SHARED_HEADERS
+
+#define MLD_CONFIG_PARAMETER_SET 87
+#include "mldsa/mldsa_native.c"
+#undef MLD_CONFIG_PARAMETER_SET

--- a/sw/device/lib/crypto/impl/mldsa/mldsa_native_monobuild.h
+++ b/sw/device/lib/crypto/impl/mldsa/mldsa_native_monobuild.h
@@ -1,0 +1,27 @@
+// Copyright The mldsa-native project authors
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_MLDSA_MLDSA_NATIVE_MONOBUILD_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_MLDSA_MLDSA_NATIVE_MONOBUILD_H_
+
+/* API for MLDSA-44 */
+#define MLD_CONFIG_PARAMETER_SET 44
+#include "mldsa/mldsa_native.h"
+#undef MLD_CONFIG_PARAMETER_SET
+#undef MLD_H
+
+/* API for MLDSA-65 */
+#define MLD_CONFIG_PARAMETER_SET 65
+#include "mldsa/mldsa_native.h"
+#undef MLD_CONFIG_PARAMETER_SET
+#undef MLD_H
+
+/* API for MLDSA-87 */
+#define MLD_CONFIG_PARAMETER_SET 87
+#include "mldsa/mldsa_native.h"
+#undef MLD_CONFIG_PARAMETER_SET
+#undef MLD_H
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_IMPL_MLDSA_MLDSA_NATIVE_MONOBUILD_H_

--- a/sw/device/lib/crypto/include/datatypes.h
+++ b/sw/device/lib/crypto/include/datatypes.h
@@ -160,6 +160,8 @@ typedef enum otcrypto_key_type {
   kOtcryptoKeyTypeKdf = 0x3e1,
   // Key type ML-KEM.
   kOtcryptoKeyTypeMlkem = 0x396,
+  // Key type ML-DSA.
+  kOtcryptoKeyTypeMldsa = 0x8ab,
 } otcrypto_key_type_t;
 
 /**
@@ -294,6 +296,23 @@ typedef enum otcrypto_mlkem_key_mode {
 } otcrypto_mlkem_key_mode_t;
 
 /**
+ * Enum to specify ML-DSA key modes.
+ *
+ * This will be used in the `otcrypto_key_mode_t` struct to indicate the mode
+ * for which the provided key is intended for.
+ *
+ * Values are hardened.
+ */
+typedef enum otcrypto_mldsa_key_mode {
+  // Mode ML-DSA-44.
+  kOtcryptoMldsaKeyMode44 = 0x904,
+  // Mode ML-DSA-65.
+  kOtcryptoMldsaKeyMode65 = 0x9d3,
+  // Mode ML-DSA-87.
+  kOtcryptoMldsaKeyMode87 = 0xa9d,
+} otcrypto_mldsa_key_mode_t;
+
+/**
  * Enum for opentitan crypto modes that use a key.
  *
  * Denotes the crypto mode for which the provided key is to be used.
@@ -377,6 +396,15 @@ typedef enum otcrypto_key_mode {
   // Key is intended for ML-KEM-1024.
   kOtcryptoKeyModeMlkem1024 =
       kOtcryptoKeyTypeMlkem << 16 | kOtcryptoMlkemKeyMode1024,
+  // Key is intended for ML-DSA-44.
+  kOtcryptoKeyModeMldsa44 =
+      kOtcryptoKeyTypeMldsa << 16 | kOtcryptoMldsaKeyMode44,
+  // Key is intended for ML-DSA-65.
+  kOtcryptoKeyModeMldsa65 =
+      kOtcryptoKeyTypeMldsa << 16 | kOtcryptoMldsaKeyMode65,
+  // Key is intended for ML-DSA-87.
+  kOtcryptoKeyModeMldsa87 =
+      kOtcryptoKeyTypeMldsa << 16 | kOtcryptoMldsaKeyMode87,
 } otcrypto_key_mode_t;
 
 /**

--- a/sw/device/lib/crypto/include/mldsa.h
+++ b/sw/device/lib/crypto/include/mldsa.h
@@ -1,0 +1,376 @@
+// Copyright The mldsa-native project authors
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_MLDSA_H_
+#define OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_MLDSA_H_
+
+#include "datatypes.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif  // __cplusplus
+
+/**
+ * Signature mode for ML-DSA.
+ *
+ * Values are hardened.
+ */
+typedef enum otcrypto_mldsa_sign_mode {
+  // Signature mode ML-DSA (pure).
+  kOtcryptoMldsaSignModeMldsa = 0x37f,
+  // TODO: Add HashML-DSA mode (mldsa-native supports it, just needs
+  // integration).
+} otcrypto_mldsa_sign_mode_t;
+
+enum {
+  kOtcryptoMldsa44PublicKeyBytes = 1312,
+  kOtcryptoMldsa44SecretKeyBytes = 2560,
+  kOtcryptoMldsa44SignatureBytes = 2420,
+  kOtcryptoMldsa44SeedBytes = 32,
+
+  kOtcryptoMldsa65PublicKeyBytes = 1952,
+  kOtcryptoMldsa65SecretKeyBytes = 4032,
+  kOtcryptoMldsa65SignatureBytes = 3309,
+  kOtcryptoMldsa65SeedBytes = 32,
+
+  kOtcryptoMldsa87PublicKeyBytes = 2592,
+  kOtcryptoMldsa87SecretKeyBytes = 4896,
+  kOtcryptoMldsa87SignatureBytes = 4627,
+  kOtcryptoMldsa87SeedBytes = 32,
+
+  // Work buffer sizes in 32-bit words
+  kOtcryptoMldsa44WorkBufferKeypairWords = 32992 / sizeof(uint32_t),
+  kOtcryptoMldsa44WorkBufferSignWords = 32448 / sizeof(uint32_t),
+  kOtcryptoMldsa44WorkBufferVerifyWords = 22464 / sizeof(uint32_t),
+
+  kOtcryptoMldsa65WorkBufferKeypairWords = 46304 / sizeof(uint32_t),
+  kOtcryptoMldsa65WorkBufferSignWords = 44768 / sizeof(uint32_t),
+  kOtcryptoMldsa65WorkBufferVerifyWords = 30720 / sizeof(uint32_t),
+
+  kOtcryptoMldsa87WorkBufferKeypairWords = 62688 / sizeof(uint32_t),
+  kOtcryptoMldsa87WorkBufferSignWords = 59104 / sizeof(uint32_t),
+  kOtcryptoMldsa87WorkBufferVerifyWords = 41216 / sizeof(uint32_t),
+};
+
+/**
+ * Generates a fresh random ML-DSA-44 key pair.
+ *
+ * The caller should allocate and partially populate the key structs, including
+ * populating the key configuration and allocating space for the keyblob and
+ * public key data. The key modes should both indicate ML-DSA-44. The key
+ * blob for the secret key should have a length of 2x
+ * ceil(kOtcryptoMldsa44SecretKeyBytes / sizeof(uint32_t)) = 1280 words.
+ *
+ * @param[out] public_key Generated public key.
+ * @param[out] secret_key Generated secret key.
+ * @param work Work buffer (`kOtcryptoMldsa44WorkBufferKeypairWords` words).
+ * @return Status code (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_mldsa44_keygen(
+    otcrypto_unblinded_key_t *public_key, otcrypto_blinded_key_t *secret_key,
+    uint32_t work[kOtcryptoMldsa44WorkBufferKeypairWords]);
+
+/**
+ * ML-DSA-44 deterministic keypair generation.
+ *
+ * Generates a public/secret key pair from a given seed.
+ *
+ * The caller should allocate and partially populate the key structs, including
+ * populating the key configuration and allocating space for the keyblob and
+ * public key data. The key modes should both indicate ML-DSA-44. The key
+ * blob for the secret key should have a length of 2x
+ * ceil(kOtcryptoMldsa44SecretKeyBytes / sizeof(uint32_t)) = 1280 words.
+ *
+ * @param seed Input seed (`kOtcryptoMldsa44SeedBytes` bytes).
+ * @param[out] public_key Generated public key.
+ * @param[out] secret_key Generated secret key.
+ * @param work Work buffer (`kOtcryptoMldsa44WorkBufferKeypairWords` words).
+ * @return Status code (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_mldsa44_keypair_derand(
+    otcrypto_const_byte_buf_t seed, otcrypto_unblinded_key_t *public_key,
+    otcrypto_blinded_key_t *secret_key,
+    uint32_t work[kOtcryptoMldsa44WorkBufferKeypairWords]);
+
+/**
+ * ML-DSA-44 signature generation.
+ *
+ * Generates a signature on a message using fresh randomness.
+ *
+ * @param secret_key Secret key.
+ * @param message Message to sign.
+ * @param context Context string (optional, may be empty).
+ * @param sign_mode Signature mode.
+ * @param[out] signature Pointer to the generated signature.
+ * @param work Work buffer (`kOtcryptoMldsa44WorkBufferSignWords` words).
+ * @return Status code (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_mldsa44_sign(
+    const otcrypto_blinded_key_t *secret_key, otcrypto_const_byte_buf_t message,
+    otcrypto_const_byte_buf_t context, otcrypto_mldsa_sign_mode_t sign_mode,
+    otcrypto_byte_buf_t signature,
+    uint32_t work[kOtcryptoMldsa44WorkBufferSignWords]);
+
+/**
+ * ML-DSA-44 deterministic signature generation.
+ *
+ * Generates a signature on a message using deterministic randomness.
+ *
+ * @param secret_key Secret key.
+ * @param message Message to sign.
+ * @param context Context string (optional, may be empty).
+ * @param sign_mode Signature mode.
+ * @param rnd Randomness for signing (`kOtcryptoMldsa44SeedBytes` bytes).
+ * @param[out] signature Pointer to the generated signature.
+ * @param work Work buffer (`kOtcryptoMldsa44WorkBufferSignWords` words).
+ * @return Status code (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_mldsa44_sign_derand(
+    const otcrypto_blinded_key_t *secret_key, otcrypto_const_byte_buf_t message,
+    otcrypto_const_byte_buf_t context, otcrypto_mldsa_sign_mode_t sign_mode,
+    otcrypto_const_byte_buf_t rnd, otcrypto_byte_buf_t signature,
+    uint32_t work[kOtcryptoMldsa44WorkBufferSignWords]);
+
+/**
+ * ML-DSA-44 signature verification.
+ *
+ * Verifies a signature on a message.
+ *
+ * @param public_key Public key.
+ * @param message Message that was signed.
+ * @param context Context string used during signing.
+ * @param sign_mode Signature mode.
+ * @param signature Signature to verify.
+ * @param[out] verification_result Result of verification (success or failure).
+ * @param work Work buffer (`kOtcryptoMldsa44WorkBufferVerifyWords` words).
+ * @return Status code (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_mldsa44_verify(
+    const otcrypto_unblinded_key_t *public_key,
+    otcrypto_const_byte_buf_t message, otcrypto_const_byte_buf_t context,
+    otcrypto_mldsa_sign_mode_t sign_mode, otcrypto_const_byte_buf_t signature,
+    hardened_bool_t *verification_result,
+    uint32_t work[kOtcryptoMldsa44WorkBufferVerifyWords]);
+
+/**
+ * Generates a fresh random ML-DSA-65 key pair.
+ *
+ * The caller should allocate and partially populate the key structs, including
+ * populating the key configuration and allocating space for the keyblob and
+ * public key data. The key modes should both indicate ML-DSA-65. The key
+ * blob for the secret key should have a length of 2x
+ * ceil(kOtcryptoMldsa65SecretKeyBytes / sizeof(uint32_t)) = 2016 words.
+ *
+ * @param[out] public_key Generated public key.
+ * @param[out] secret_key Generated secret key.
+ * @param work Work buffer (`kOtcryptoMldsa65WorkBufferKeypairWords` words).
+ * @return Status code (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_mldsa65_keygen(
+    otcrypto_unblinded_key_t *public_key, otcrypto_blinded_key_t *secret_key,
+    uint32_t work[kOtcryptoMldsa65WorkBufferKeypairWords]);
+
+/**
+ * ML-DSA-65 deterministic keypair generation.
+ *
+ * Generates a public/secret key pair from a given seed.
+ *
+ * The caller should allocate and partially populate the key structs, including
+ * populating the key configuration and allocating space for the keyblob and
+ * public key data. The key modes should both indicate ML-DSA-65. The key
+ * blob for the secret key should have a length of 2x
+ * ceil(kOtcryptoMldsa65SecretKeyBytes / sizeof(uint32_t)) = 2016 words.
+ *
+ * @param seed Input seed (`kOtcryptoMldsa65SeedBytes` bytes).
+ * @param[out] public_key Generated public key.
+ * @param[out] secret_key Generated secret key.
+ * @param work Work buffer (`kOtcryptoMldsa65WorkBufferKeypairWords` words).
+ * @return Status code (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_mldsa65_keypair_derand(
+    otcrypto_const_byte_buf_t seed, otcrypto_unblinded_key_t *public_key,
+    otcrypto_blinded_key_t *secret_key,
+    uint32_t work[kOtcryptoMldsa65WorkBufferKeypairWords]);
+
+/**
+ * ML-DSA-65 signature generation.
+ *
+ * Generates a signature on a message using fresh randomness.
+ *
+ * @param secret_key Secret key.
+ * @param message Message to sign.
+ * @param context Context string (optional, may be empty).
+ * @param sign_mode Signature mode.
+ * @param[out] signature Pointer to the generated signature.
+ * @param work Work buffer (`kOtcryptoMldsa65WorkBufferSignWords` words).
+ * @return Status code (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_mldsa65_sign(
+    const otcrypto_blinded_key_t *secret_key, otcrypto_const_byte_buf_t message,
+    otcrypto_const_byte_buf_t context, otcrypto_mldsa_sign_mode_t sign_mode,
+    otcrypto_byte_buf_t signature,
+    uint32_t work[kOtcryptoMldsa65WorkBufferSignWords]);
+
+/**
+ * ML-DSA-65 deterministic signature generation.
+ *
+ * Generates a signature on a message using deterministic randomness.
+ *
+ * @param secret_key Secret key.
+ * @param message Message to sign.
+ * @param context Context string (optional, may be empty).
+ * @param sign_mode Signature mode.
+ * @param rnd Randomness for signing (`kOtcryptoMldsa65SeedBytes` bytes).
+ * @param[out] signature Pointer to the generated signature.
+ * @param work Work buffer (`kOtcryptoMldsa65WorkBufferSignWords` words).
+ * @return Status code (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_mldsa65_sign_derand(
+    const otcrypto_blinded_key_t *secret_key, otcrypto_const_byte_buf_t message,
+    otcrypto_const_byte_buf_t context, otcrypto_mldsa_sign_mode_t sign_mode,
+    otcrypto_const_byte_buf_t rnd, otcrypto_byte_buf_t signature,
+    uint32_t work[kOtcryptoMldsa65WorkBufferSignWords]);
+
+/**
+ * ML-DSA-65 signature verification.
+ *
+ * Verifies a signature on a message.
+ *
+ * @param public_key Public key.
+ * @param message Message that was signed.
+ * @param context Context string used during signing.
+ * @param sign_mode Signature mode.
+ * @param signature Signature to verify.
+ * @param[out] verification_result Result of verification (success or failure).
+ * @param work Work buffer (`kOtcryptoMldsa65WorkBufferVerifyWords` words).
+ * @return Status code (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_mldsa65_verify(
+    const otcrypto_unblinded_key_t *public_key,
+    otcrypto_const_byte_buf_t message, otcrypto_const_byte_buf_t context,
+    otcrypto_mldsa_sign_mode_t sign_mode, otcrypto_const_byte_buf_t signature,
+    hardened_bool_t *verification_result,
+    uint32_t work[kOtcryptoMldsa65WorkBufferVerifyWords]);
+
+/**
+ * Generates a fresh random ML-DSA-87 key pair.
+ *
+ * The caller should allocate and partially populate the key structs, including
+ * populating the key configuration and allocating space for the keyblob and
+ * public key data. The key modes should both indicate ML-DSA-87. The key
+ * blob for the secret key should have a length of 2x
+ * ceil(kOtcryptoMldsa87SecretKeyBytes / sizeof(uint32_t)) = 2448 words.
+ *
+ * @param[out] public_key Generated public key.
+ * @param[out] secret_key Generated secret key.
+ * @param work Work buffer (`kOtcryptoMldsa87WorkBufferKeypairWords` words).
+ * @return Status code (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_mldsa87_keygen(
+    otcrypto_unblinded_key_t *public_key, otcrypto_blinded_key_t *secret_key,
+    uint32_t work[kOtcryptoMldsa87WorkBufferKeypairWords]);
+
+/**
+ * ML-DSA-87 deterministic keypair generation.
+ *
+ * Generates a public/secret key pair from a given seed.
+ *
+ * The caller should allocate and partially populate the key structs, including
+ * populating the key configuration and allocating space for the keyblob and
+ * public key data. The key modes should both indicate ML-DSA-87. The key
+ * blob for the secret key should have a length of 2x
+ * ceil(kOtcryptoMldsa87SecretKeyBytes / sizeof(uint32_t)) = 2448 words.
+ *
+ * @param seed Input seed (`kOtcryptoMldsa87SeedBytes` bytes).
+ * @param[out] public_key Generated public key.
+ * @param[out] secret_key Generated secret key.
+ * @param work Work buffer (`kOtcryptoMldsa87WorkBufferKeypairWords` words).
+ * @return Status code (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_mldsa87_keypair_derand(
+    otcrypto_const_byte_buf_t seed, otcrypto_unblinded_key_t *public_key,
+    otcrypto_blinded_key_t *secret_key,
+    uint32_t work[kOtcryptoMldsa87WorkBufferKeypairWords]);
+
+/**
+ * ML-DSA-87 signature generation.
+ *
+ * Generates a signature on a message using fresh randomness.
+ *
+ * @param secret_key Secret key.
+ * @param message Message to sign.
+ * @param context Context string (optional, may be empty).
+ * @param sign_mode Signature mode.
+ * @param[out] signature Pointer to the generated signature.
+ * @param work Work buffer (`kOtcryptoMldsa87WorkBufferSignWords` words).
+ * @return Status code (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_mldsa87_sign(
+    const otcrypto_blinded_key_t *secret_key, otcrypto_const_byte_buf_t message,
+    otcrypto_const_byte_buf_t context, otcrypto_mldsa_sign_mode_t sign_mode,
+    otcrypto_byte_buf_t signature,
+    uint32_t work[kOtcryptoMldsa87WorkBufferSignWords]);
+
+/**
+ * ML-DSA-87 deterministic signature generation.
+ *
+ * Generates a signature on a message using deterministic randomness.
+ *
+ * @param secret_key Secret key.
+ * @param message Message to sign.
+ * @param context Context string (optional, may be empty).
+ * @param sign_mode Signature mode.
+ * @param rnd Randomness for signing (`kOtcryptoMldsa87SeedBytes` bytes).
+ * @param[out] signature Pointer to the generated signature.
+ * @param work Work buffer (`kOtcryptoMldsa87WorkBufferSignWords` words).
+ * @return Status code (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_mldsa87_sign_derand(
+    const otcrypto_blinded_key_t *secret_key, otcrypto_const_byte_buf_t message,
+    otcrypto_const_byte_buf_t context, otcrypto_mldsa_sign_mode_t sign_mode,
+    otcrypto_const_byte_buf_t rnd, otcrypto_byte_buf_t signature,
+    uint32_t work[kOtcryptoMldsa87WorkBufferSignWords]);
+
+/**
+ * ML-DSA-87 signature verification.
+ *
+ * Verifies a signature on a message.
+ *
+ * @param public_key Public key.
+ * @param message Message that was signed.
+ * @param context Context string used during signing.
+ * @param sign_mode Signature mode.
+ * @param signature Signature to verify.
+ * @param[out] verification_result Result of verification (success or failure).
+ * @param work Work buffer (`kOtcryptoMldsa87WorkBufferVerifyWords` words).
+ * @return Status code (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+otcrypto_status_t otcrypto_mldsa87_verify(
+    const otcrypto_unblinded_key_t *public_key,
+    otcrypto_const_byte_buf_t message, otcrypto_const_byte_buf_t context,
+    otcrypto_mldsa_sign_mode_t sign_mode, otcrypto_const_byte_buf_t signature,
+    hardened_bool_t *verification_result,
+    uint32_t work[kOtcryptoMldsa87WorkBufferVerifyWords]);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif  // __cplusplus
+
+#endif  // OPENTITAN_SW_DEVICE_LIB_CRYPTO_INCLUDE_MLDSA_H_

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -1088,6 +1088,52 @@ opentitan_test(
     ],
 )
 
+opentitan_test(
+    name = "mldsa_functest",
+    srcs = ["mldsa_functest.c"],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+            "//hw/top_earlgrey:silicon_creator": None,
+        },
+    ),
+    verilator = verilator_params(timeout = "eternal"),
+    deps = [
+        "//sw/device/lib/crypto/impl:mldsa",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:profile",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
+opentitan_test(
+    name = "mldsa_benchmark",
+    srcs = ["mldsa_functest.c"],
+    copts = ["-DMLDSA_BENCHMARK_MODE"],
+    exec_env = dicts.add(
+        EARLGREY_TEST_ENVS,
+        EARLGREY_SILICON_OWNER_ROM_EXT_ENVS,
+        {
+            "//hw/top_earlgrey:fpga_cw310_sival": None,
+            "//hw/top_earlgrey:fpga_cw310_sival_rom_ext": None,
+            "//hw/top_earlgrey:silicon_creator": None,
+        },
+    ),
+    verilator = verilator_params(
+        timeout = "eternal",
+        tags = ["manual"],
+    ),
+    deps = [
+        "//sw/device/lib/crypto/impl:mldsa",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing:profile",
+        "//sw/device/lib/testing/test_framework:ottf_main",
+    ],
+)
+
 py_binary(
     name = "ecdsa_p256_verify_set_testvectors",
     srcs = ["ecdsa_p256_verify_set_testvectors.py"],

--- a/sw/device/tests/crypto/mldsa_functest.c
+++ b/sw/device/tests/crypto/mldsa_functest.c
@@ -1,0 +1,440 @@
+// Copyright The mldsa-native project authors
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <string.h>
+
+#include "sw/device/lib/base/math.h"
+#include "sw/device/lib/crypto/include/mldsa.h"
+#include "sw/device/lib/crypto/include/sha3.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/profile.h"
+#include "sw/device/lib/testing/test_framework/check.h"
+#include "sw/device/lib/testing/test_framework/ottf_main.h"
+
+OTTF_DEFINE_TEST_CONFIG();
+
+// Benchmarking Approach:
+//
+// ML-DSA signing performance is probabilistic due to rejection sampling in
+// Algorithm 2 (ML-DSA.Sign). The number of iterations varies per signature.
+//
+// To estimate expected signing time without extensive statistical sampling:
+// 1. Measure signing time for messages requiring exactly 1 iteration
+// 2. Measure signing time for messages requiring exactly 2 iterations
+// 3. Calculate per-iteration cost: time_per_iter = time_2iter - time_1iter
+// 4. Extrapolate to FIPS 204 expected iterations via linear interpolation:
+//    expected_time = time_1iter + (FIPS204_expected - 1) * time_per_iter
+//
+// The test messages below were selected to deterministically produce
+// 1 or 2 iterations when signing with the fixed test seed and randomness.
+//
+// The benchmark results are an approximation of the actual expected signing
+// time as there are multiple rejection conditions resulting in varying
+// iteration timing. We mitigate this by picking the messages resulting in 2
+// iteration such that it in the first iteration the siganture is rejected
+// due to the z-norm check which accounts for the vast majority of rejections
+// (see Section 3.4 of the round-3 Dilithium specification).
+
+// Optimized test messages for each parameter set (1 iteration each)
+#define TEST_MSG_44 "Test message 12"
+#define TEST_MSG_44_LEN (sizeof(TEST_MSG_44) - 1)
+#define TEST_MSG_65 "Test message 5"
+#define TEST_MSG_65_LEN (sizeof(TEST_MSG_65) - 1)
+#define TEST_MSG_87 "Test message 2"
+#define TEST_MSG_87_LEN (sizeof(TEST_MSG_87) - 1)
+
+// Messages that result in 2 iterations (for benchmarking)
+#define TEST_MSG_44_2ITER "Test message 3"
+#define TEST_MSG_44_2ITER_LEN (sizeof(TEST_MSG_44_2ITER) - 1)
+#define TEST_MSG_65_2ITER "Test message 56"
+#define TEST_MSG_65_2ITER_LEN (sizeof(TEST_MSG_65_2ITER) - 1)
+#define TEST_MSG_87_2ITER "Test message 24"
+#define TEST_MSG_87_2ITER_LEN (sizeof(TEST_MSG_87_2ITER) - 1)
+
+// FIPS 204 expected iteration counts for signing (scaled by 100)
+// From FIPS 204 Table 1: Expected number of iterations of the
+// main loop in Algorithm 2 (ML-DSA.Sign)
+#define FIPS204_EXPECTED_ITERS_44 425  // 4.25
+#define FIPS204_EXPECTED_ITERS_65 510  // 5.1
+#define FIPS204_EXPECTED_ITERS_87 385  // 3.85
+
+#define TEST_MSG_LEN (sizeof(TEST_MSG) - 1)
+
+#define TEST_CTX "test_context_123"
+#define TEST_CTX_LEN (sizeof(TEST_CTX) - 1)
+
+static const uint8_t kKeypairSeed[32] = {
+    0x93, 0x4d, 0x60, 0xb3, 0x56, 0x24, 0xd7, 0x40, 0xb3, 0x0a, 0x7f,
+    0x22, 0x7a, 0xf2, 0xae, 0x7c, 0x67, 0x8e, 0x4e, 0x04, 0xe1, 0x3c,
+    0x5f, 0x50, 0x9e, 0xad, 0xe2, 0xb7, 0x9a, 0xea, 0x77, 0xe2};
+
+static const uint8_t kSignRnd[32] = {
+    0x3e, 0x2a, 0x2e, 0xa6, 0xc9, 0xc4, 0x76, 0xfc, 0x49, 0x37, 0xb0,
+    0x13, 0xc9, 0x93, 0xa7, 0x93, 0xd6, 0xc0, 0xab, 0x99, 0x60, 0x69,
+    0x5b, 0xa8, 0x38, 0xf6, 0x49, 0xda, 0x53, 0x9c, 0xa3, 0xd0};
+
+// Static work buffer for all ML-DSA operations
+// Use the maximum size across all ML-DSA-87 operations
+#define MAX(a, b) ((a) > (b) ? (a) : (b))
+#define MLDSA_MAX_WORK_BUFFER_WORDS               \
+  MAX(MAX(kOtcryptoMldsa87WorkBufferKeypairWords, \
+          kOtcryptoMldsa87WorkBufferSignWords),   \
+      kOtcryptoMldsa87WorkBufferVerifyWords)
+static uint32_t mldsa_work_buffer[MLDSA_MAX_WORK_BUFFER_WORDS];
+
+// Static buffers for all ML-DSA test operations (sized for ML-DSA-87)
+static uint32_t mldsa_public_key_data[(kOtcryptoMldsa87PublicKeyBytes +
+                                       (sizeof(uint32_t) - 1)) /
+                                      sizeof(uint32_t)];
+static uint32_t mldsa_secret_key_data[2 * ((kOtcryptoMldsa87SecretKeyBytes +
+                                            (sizeof(uint32_t) - 1)) /
+                                           sizeof(uint32_t))];
+static uint32_t
+    mldsa_signature[(kOtcryptoMldsa87SignatureBytes + (sizeof(uint32_t) - 1)) /
+                    sizeof(uint32_t)];
+static uint32_t mldsa_test_msg_buf[(TEST_MSG_87_LEN + (sizeof(uint32_t) - 1)) /
+                                   sizeof(uint32_t)];
+static uint32_t mldsa_test_ctx_buf[(TEST_CTX_LEN + (sizeof(uint32_t) - 1)) /
+                                   sizeof(uint32_t)];
+
+// SHA3-256 hash of expected ML-DSA-44 signature
+static const uint8_t kMldsa44ExpectedSignatureHash[32] = {
+    0xf5, 0x46, 0x33, 0x14, 0x02, 0xee, 0x16, 0x4b, 0xe1, 0x91, 0x5e,
+    0xd5, 0x55, 0x4e, 0xf7, 0x35, 0x24, 0xb6, 0x30, 0x5b, 0xdc, 0x32,
+    0xb5, 0x57, 0x15, 0xd1, 0x33, 0x2c, 0xf4, 0xd1, 0x9e, 0x46};
+
+// SHA3-256 hash of expected ML-DSA-65 signature
+static const uint8_t kMldsa65ExpectedSignatureHash[32] = {
+    0x09, 0xa1, 0xbe, 0xaa, 0x0e, 0x8d, 0xa6, 0xab, 0x94, 0xd5, 0xf0,
+    0x1e, 0x3d, 0xae, 0x2e, 0x11, 0x52, 0x86, 0x4c, 0xc4, 0x6a, 0xfd,
+    0xea, 0x0f, 0x78, 0xec, 0x6d, 0x62, 0xcf, 0x39, 0xb3, 0x6d};
+
+// SHA3-256 hash of expected ML-DSA-87 signature
+static const uint8_t kMldsa87ExpectedSignatureHash[32] = {
+    0x06, 0x10, 0x69, 0x43, 0x52, 0xf3, 0xe7, 0x58, 0xae, 0xb4, 0x5e,
+    0x97, 0x0a, 0x87, 0x7f, 0x1b, 0x42, 0x7f, 0xc2, 0xcb, 0x0f, 0xbf,
+    0x96, 0xa7, 0xeb, 0xd1, 0xed, 0x6d, 0x9c, 0x0a, 0xd6, 0x7c};
+
+/**
+ * Verify signature by comparing its SHA3-256 hash with expected hash.
+ *
+ * @param signature Pointer to signature buffer
+ * @param signature_len Length of signature in bytes
+ * @param expected_hash Expected SHA3-256 hash (32 bytes)
+ */
+static void verify_signature_hash(const uint8_t *signature,
+                                  size_t signature_len,
+                                  const uint8_t *expected_hash) {
+  uint32_t digest[8];
+  otcrypto_const_byte_buf_t sig_msg = {.data = signature, .len = signature_len};
+  otcrypto_hash_digest_t hash_digest = {
+      .data = digest, .len = 8, .mode = kOtcryptoHashModeSha3_256};
+  CHECK_STATUS_OK(otcrypto_sha3_256(sig_msg, &hash_digest));
+  CHECK_ARRAYS_EQ((uint8_t *)digest, expected_hash, 32);
+}
+
+static void test_mldsa44_derand(void) {
+  // Set up public key struct
+  otcrypto_unblinded_key_t public_key = {
+      .key_mode = kOtcryptoKeyModeMldsa44,
+      .key_length = kOtcryptoMldsa44PublicKeyBytes,
+      .key = mldsa_public_key_data,
+      .checksum = 0,
+  };
+
+  // Set up secret key struct
+  otcrypto_key_config_t secret_key_config = {
+      .version = kOtcryptoLibVersion1,
+      .key_mode = kOtcryptoKeyModeMldsa44,
+      .key_length = kOtcryptoMldsa44SecretKeyBytes,
+      .hw_backed = kHardenedBoolFalse,
+      .exportable = kHardenedBoolFalse,
+      .security_level = kOtcryptoKeySecurityLevelLow,
+  };
+  otcrypto_blinded_key_t secret_key = {
+      .config = secret_key_config,
+      .keyblob_length =
+          2 * ceil_div(kOtcryptoMldsa44SecretKeyBytes, sizeof(uint32_t)) *
+          sizeof(uint32_t),
+      .keyblob = mldsa_secret_key_data,
+      .checksum = 0,
+  };
+
+  otcrypto_const_byte_buf_t seed = {.data = kKeypairSeed,
+                                    .len = sizeof(kKeypairSeed)};
+
+  LOG_INFO("Generating keypair...");
+  uint64_t t0 = profile_start();
+  CHECK_STATUS_OK(otcrypto_mldsa44_keypair_derand(
+      seed, &public_key, &secret_key, mldsa_work_buffer));
+  profile_end_and_print(t0, "otcrypto_mldsa44_keypair_derand");
+
+  LOG_INFO("Signing...");
+  memcpy(mldsa_test_msg_buf, TEST_MSG_44, TEST_MSG_44_LEN);
+  memcpy(mldsa_test_ctx_buf, TEST_CTX, TEST_CTX_LEN);
+
+  otcrypto_const_byte_buf_t ctx = {.data = (const uint8_t *)mldsa_test_ctx_buf,
+                                   .len = TEST_CTX_LEN};
+  otcrypto_const_byte_buf_t rnd = {.data = kSignRnd, .len = sizeof(kSignRnd)};
+  otcrypto_byte_buf_t sig_buf = {.data = (uint8_t *)mldsa_signature,
+                                 .len = sizeof(mldsa_signature)};
+
+#ifdef MLDSA_BENCHMARK_MODE
+  // Benchmark 2-iteration message first
+  uint64_t time_2iter;
+  memcpy(mldsa_test_msg_buf, TEST_MSG_44_2ITER, TEST_MSG_44_2ITER_LEN);
+  otcrypto_const_byte_buf_t msg_2iter = {
+      .data = (const uint8_t *)mldsa_test_msg_buf,
+      .len = TEST_MSG_44_2ITER_LEN};
+  time_2iter = profile_start();
+  CHECK_STATUS_OK(otcrypto_mldsa44_sign_derand(&secret_key, msg_2iter, ctx,
+                                               kOtcryptoMldsaSignModeMldsa, rnd,
+                                               sig_buf, mldsa_work_buffer));
+  time_2iter = profile_end(time_2iter);
+  LOG_INFO("2-iteration message signing time: %u cycles", (uint32_t)time_2iter);
+#endif
+
+  // Sign 1-iteration message
+  memcpy(mldsa_test_msg_buf, TEST_MSG_44, TEST_MSG_44_LEN);
+  otcrypto_const_byte_buf_t msg = {.data = (const uint8_t *)mldsa_test_msg_buf,
+                                   .len = TEST_MSG_44_LEN};
+  t0 = profile_start();
+  CHECK_STATUS_OK(otcrypto_mldsa44_sign_derand(&secret_key, msg, ctx,
+                                               kOtcryptoMldsaSignModeMldsa, rnd,
+                                               sig_buf, mldsa_work_buffer));
+  uint64_t time_1iter = profile_end(t0);
+
+  verify_signature_hash((uint8_t *)mldsa_signature,
+                        kOtcryptoMldsa44SignatureBytes,
+                        kMldsa44ExpectedSignatureHash);
+
+  LOG_INFO("1-iteration message signing time: %u cycles", (uint32_t)time_1iter);
+
+#ifdef MLDSA_BENCHMARK_MODE
+  // Calculate expected runtime for expected iterations (4.25)
+  uint32_t time_per_iter = (uint32_t)(time_2iter - time_1iter);
+  uint64_t expected_time =
+      time_1iter + ((FIPS204_EXPECTED_ITERS_44 - 100) * time_per_iter) / 100;
+  LOG_INFO("Expected signing time (4.25 iterations): %u cycles",
+           (uint32_t)expected_time);
+#endif
+
+  LOG_INFO("Verifying...");
+  hardened_bool_t verification_result;
+  otcrypto_const_byte_buf_t sig_const = {.data = (uint8_t *)mldsa_signature,
+                                         .len = kOtcryptoMldsa44SignatureBytes};
+  t0 = profile_start();
+  CHECK_STATUS_OK(otcrypto_mldsa44_verify(
+      &public_key, msg, ctx, kOtcryptoMldsaSignModeMldsa, sig_const,
+      &verification_result, mldsa_work_buffer));
+  profile_end_and_print(t0, "otcrypto_mldsa44_verify");
+  CHECK(verification_result == kHardenedBoolTrue,
+        "Signature verification failed");
+}
+
+static void test_mldsa65_derand(void) {
+  // Set up public key struct
+  otcrypto_unblinded_key_t public_key = {
+      .key_mode = kOtcryptoKeyModeMldsa65,
+      .key_length = kOtcryptoMldsa65PublicKeyBytes,
+      .key = mldsa_public_key_data,
+      .checksum = 0,
+  };
+
+  // Set up secret key struct
+  otcrypto_key_config_t secret_key_config = {
+      .version = kOtcryptoLibVersion1,
+      .key_mode = kOtcryptoKeyModeMldsa65,
+      .key_length = kOtcryptoMldsa65SecretKeyBytes,
+      .hw_backed = kHardenedBoolFalse,
+      .exportable = kHardenedBoolFalse,
+      .security_level = kOtcryptoKeySecurityLevelLow,
+  };
+  otcrypto_blinded_key_t secret_key = {
+      .config = secret_key_config,
+      .keyblob_length =
+          2 * ceil_div(kOtcryptoMldsa65SecretKeyBytes, sizeof(uint32_t)) *
+          sizeof(uint32_t),
+      .keyblob = mldsa_secret_key_data,
+      .checksum = 0,
+  };
+
+  otcrypto_const_byte_buf_t seed = {.data = kKeypairSeed,
+                                    .len = sizeof(kKeypairSeed)};
+
+  LOG_INFO("Generating keypair...");
+  uint64_t t0 = profile_start();
+  CHECK_STATUS_OK(otcrypto_mldsa65_keypair_derand(
+      seed, &public_key, &secret_key, mldsa_work_buffer));
+  profile_end_and_print(t0, "otcrypto_mldsa65_keypair_derand");
+
+  LOG_INFO("Signing...");
+  memcpy(mldsa_test_msg_buf, TEST_MSG_65, TEST_MSG_65_LEN);
+  memcpy(mldsa_test_ctx_buf, TEST_CTX, TEST_CTX_LEN);
+
+  otcrypto_const_byte_buf_t ctx = {.data = (const uint8_t *)mldsa_test_ctx_buf,
+                                   .len = TEST_CTX_LEN};
+  otcrypto_const_byte_buf_t rnd = {.data = kSignRnd, .len = sizeof(kSignRnd)};
+  otcrypto_byte_buf_t sig_buf = {.data = (uint8_t *)mldsa_signature,
+                                 .len = sizeof(mldsa_signature)};
+
+#ifdef MLDSA_BENCHMARK_MODE
+  // Benchmark 2-iteration message first
+  uint64_t time_2iter;
+  memcpy(mldsa_test_msg_buf, TEST_MSG_65_2ITER, TEST_MSG_65_2ITER_LEN);
+  otcrypto_const_byte_buf_t msg_2iter = {
+      .data = (const uint8_t *)mldsa_test_msg_buf,
+      .len = TEST_MSG_65_2ITER_LEN};
+  time_2iter = profile_start();
+  CHECK_STATUS_OK(otcrypto_mldsa65_sign_derand(&secret_key, msg_2iter, ctx,
+                                               kOtcryptoMldsaSignModeMldsa, rnd,
+                                               sig_buf, mldsa_work_buffer));
+  time_2iter = profile_end(time_2iter);
+  LOG_INFO("2-iteration message signing time: %u cycles", (uint32_t)time_2iter);
+#endif
+
+  // Sign 1-iteration message
+  memcpy(mldsa_test_msg_buf, TEST_MSG_65, TEST_MSG_65_LEN);
+  otcrypto_const_byte_buf_t msg = {.data = (const uint8_t *)mldsa_test_msg_buf,
+                                   .len = TEST_MSG_65_LEN};
+  t0 = profile_start();
+  CHECK_STATUS_OK(otcrypto_mldsa65_sign_derand(&secret_key, msg, ctx,
+                                               kOtcryptoMldsaSignModeMldsa, rnd,
+                                               sig_buf, mldsa_work_buffer));
+  uint64_t time_1iter = profile_end(t0);
+
+  verify_signature_hash((uint8_t *)mldsa_signature,
+                        kOtcryptoMldsa65SignatureBytes,
+                        kMldsa65ExpectedSignatureHash);
+
+  LOG_INFO("1-iteration message signing time: %u cycles", (uint32_t)time_1iter);
+
+#ifdef MLDSA_BENCHMARK_MODE
+  // Calculate expected runtime for expected iterations (5.1)
+  uint32_t time_per_iter = (uint32_t)(time_2iter - time_1iter);
+  uint64_t expected_time =
+      time_1iter + ((FIPS204_EXPECTED_ITERS_65 - 100) * time_per_iter) / 100;
+  LOG_INFO("Expected signing time (5.1 iterations): %u cycles",
+           (uint32_t)expected_time);
+#endif
+
+  LOG_INFO("Verifying...");
+  hardened_bool_t verification_result;
+  otcrypto_const_byte_buf_t sig_const = {.data = (uint8_t *)mldsa_signature,
+                                         .len = kOtcryptoMldsa65SignatureBytes};
+  t0 = profile_start();
+  CHECK_STATUS_OK(otcrypto_mldsa65_verify(
+      &public_key, msg, ctx, kOtcryptoMldsaSignModeMldsa, sig_const,
+      &verification_result, mldsa_work_buffer));
+  profile_end_and_print(t0, "otcrypto_mldsa65_verify");
+  CHECK(verification_result == kHardenedBoolTrue,
+        "Signature verification failed");
+}
+
+static void test_mldsa87_derand(void) {
+  // Set up public key struct
+  otcrypto_unblinded_key_t public_key = {
+      .key_mode = kOtcryptoKeyModeMldsa87,
+      .key_length = kOtcryptoMldsa87PublicKeyBytes,
+      .key = mldsa_public_key_data,
+      .checksum = 0,
+  };
+
+  // Set up secret key struct
+  otcrypto_key_config_t secret_key_config = {
+      .version = kOtcryptoLibVersion1,
+      .key_mode = kOtcryptoKeyModeMldsa87,
+      .key_length = kOtcryptoMldsa87SecretKeyBytes,
+      .hw_backed = kHardenedBoolFalse,
+      .exportable = kHardenedBoolFalse,
+      .security_level = kOtcryptoKeySecurityLevelLow,
+  };
+  otcrypto_blinded_key_t secret_key = {
+      .config = secret_key_config,
+      .keyblob_length =
+          2 * ceil_div(kOtcryptoMldsa87SecretKeyBytes, sizeof(uint32_t)) *
+          sizeof(uint32_t),
+      .keyblob = mldsa_secret_key_data,
+      .checksum = 0,
+  };
+
+  otcrypto_const_byte_buf_t seed = {.data = kKeypairSeed,
+                                    .len = sizeof(kKeypairSeed)};
+
+  LOG_INFO("Generating keypair...");
+  uint64_t t0 = profile_start();
+  CHECK_STATUS_OK(otcrypto_mldsa87_keypair_derand(
+      seed, &public_key, &secret_key, mldsa_work_buffer));
+  profile_end_and_print(t0, "otcrypto_mldsa87_keypair_derand");
+
+  LOG_INFO("Signing...");
+  memcpy(mldsa_test_msg_buf, TEST_MSG_87, TEST_MSG_87_LEN);
+  memcpy(mldsa_test_ctx_buf, TEST_CTX, TEST_CTX_LEN);
+
+  otcrypto_const_byte_buf_t ctx = {.data = (const uint8_t *)mldsa_test_ctx_buf,
+                                   .len = TEST_CTX_LEN};
+  otcrypto_const_byte_buf_t rnd = {.data = kSignRnd, .len = sizeof(kSignRnd)};
+  otcrypto_byte_buf_t sig_buf = {.data = (uint8_t *)mldsa_signature,
+                                 .len = sizeof(mldsa_signature)};
+
+#ifdef MLDSA_BENCHMARK_MODE
+  // Benchmark 2-iteration message first
+  uint64_t time_2iter;
+  memcpy(mldsa_test_msg_buf, TEST_MSG_87_2ITER, TEST_MSG_87_2ITER_LEN);
+  otcrypto_const_byte_buf_t msg_2iter = {
+      .data = (const uint8_t *)mldsa_test_msg_buf,
+      .len = TEST_MSG_87_2ITER_LEN};
+  time_2iter = profile_start();
+  CHECK_STATUS_OK(otcrypto_mldsa87_sign_derand(&secret_key, msg_2iter, ctx,
+                                               kOtcryptoMldsaSignModeMldsa, rnd,
+                                               sig_buf, mldsa_work_buffer));
+  time_2iter = profile_end(time_2iter);
+  LOG_INFO("2-iteration message signing time: %u cycles", (uint32_t)time_2iter);
+#endif
+
+  // Sign 1-iteration message
+  memcpy(mldsa_test_msg_buf, TEST_MSG_87, TEST_MSG_87_LEN);
+  otcrypto_const_byte_buf_t msg = {.data = (const uint8_t *)mldsa_test_msg_buf,
+                                   .len = TEST_MSG_87_LEN};
+  t0 = profile_start();
+  CHECK_STATUS_OK(otcrypto_mldsa87_sign_derand(&secret_key, msg, ctx,
+                                               kOtcryptoMldsaSignModeMldsa, rnd,
+                                               sig_buf, mldsa_work_buffer));
+  uint64_t time_1iter = profile_end(t0);
+
+  verify_signature_hash((uint8_t *)mldsa_signature,
+                        kOtcryptoMldsa87SignatureBytes,
+                        kMldsa87ExpectedSignatureHash);
+
+  LOG_INFO("1-iteration message signing time: %u cycles", (uint32_t)time_1iter);
+
+#ifdef MLDSA_BENCHMARK_MODE
+  // Calculate expected runtime for expected iterations (3.85)
+  uint32_t time_per_iter = (uint32_t)(time_2iter - time_1iter);
+  uint64_t expected_time =
+      time_1iter + ((FIPS204_EXPECTED_ITERS_87 - 100) * time_per_iter) / 100;
+  LOG_INFO("Expected signing time (3.85 iterations): %u cycles",
+           (uint32_t)expected_time);
+#endif
+
+  LOG_INFO("Verifying...");
+  hardened_bool_t verification_result;
+  otcrypto_const_byte_buf_t sig_const = {.data = (uint8_t *)mldsa_signature,
+                                         .len = kOtcryptoMldsa87SignatureBytes};
+  t0 = profile_start();
+  CHECK_STATUS_OK(otcrypto_mldsa87_verify(
+      &public_key, msg, ctx, kOtcryptoMldsaSignModeMldsa, sig_const,
+      &verification_result, mldsa_work_buffer));
+  profile_end_and_print(t0, "otcrypto_mldsa87_verify");
+  CHECK(verification_result == kHardenedBoolTrue,
+        "Signature verification failed");
+}
+
+bool test_main(void) {
+  test_mldsa44_derand();
+  test_mldsa65_derand();
+  test_mldsa87_derand();
+  return true;
+}

--- a/third_party/mldsa_native/BUILD
+++ b/third_party/mldsa_native/BUILD
@@ -1,0 +1,8 @@
+# Copyright The mldsa-native project authors
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# This file marks the directory as a Bazel package.
+
+package(default_visibility = ["//visibility:public"])

--- a/third_party/mldsa_native/BUILD.mldsa_native.bazel
+++ b/third_party/mldsa_native/BUILD.mldsa_native.bazel
@@ -1,0 +1,38 @@
+# Copyright The mldsa-native project authors
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "mldsa_native_sources",
+    hdrs = [
+        "mldsa/mldsa_native.c",
+        "mldsa/mldsa_native.h",
+        "mldsa/src/cbmc.h",
+        "mldsa/src/common.h",
+        "mldsa/src/randombytes.h",
+        "mldsa/src/debug.h",
+        "mldsa/src/debug.c",
+        "mldsa/src/ct.c",
+        "mldsa/src/ct.h",
+        "mldsa/src/packing.c",
+        "mldsa/src/packing.h",
+        "mldsa/src/params.h",
+        "mldsa/src/poly.c",
+        "mldsa/src/poly.h",
+        "mldsa/src/poly_kl.c",
+        "mldsa/src/poly_kl.h",
+        "mldsa/src/polyvec.c",
+        "mldsa/src/polyvec.h",
+        "mldsa/src/reduce.h",
+        "mldsa/src/rounding.h",
+        "mldsa/src/sign.c",
+        "mldsa/src/sign.h",
+        "mldsa/src/symmetric.h",
+        "mldsa/src/sys.h",
+        "mldsa/src/zetas.inc",
+    ],
+    includes = ["mldsa"],
+)

--- a/third_party/mldsa_native/extensions.bzl
+++ b/third_party/mldsa_native/extensions.bzl
@@ -1,0 +1,21 @@
+# Copyright The mldsa-native project authors
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+mldsa_native = module_extension(
+    implementation = lambda _: _mldsa_native_repos(),
+)
+
+def _mldsa_native_repos():
+    http_archive(
+        name = "mldsa_native",
+        build_file = Label("//third_party/mldsa_native:BUILD.mldsa_native.bazel"),
+        sha256 = "23bcd38bc9d91e93c39df47189d6c4e5eb7172334700579c32951ff31857b9e5",
+        strip_prefix = "mldsa-native-421e6622f250f99da5b57660572e921c91cbfcf4",
+        urls = [
+            "https://github.com/pq-code-package/mldsa-native/archive/421e6622f250f99da5b57660572e921c91cbfcf4.tar.gz",
+        ],
+    )


### PR DESCRIPTION
This commit adds an integration of mldsa-native into OpenTitan, following the same integration pattern as ML-KEM. mldsa-native is a high-speed high-assurance C90 implementation of ML-DSA (FIPS 204); mldsa-native also has native code for AArch64 and x86_64, but that is unrelated to this integration.

The C code in mldsa-native has been proved to be memory-safe (no buffer overflow) and type-safe (no integer overflow) using the C Bounded Model Checker (CBMC), with the exception of the small portion of code paths enabled by `MLD_CONFIG_REDUCE_RAM` - we are working to remedy this, see below. C code is hardened against compiler-introduced timing side-channels through suitable barriers and constant-time patterns.

mldsa-native is currently in alpha release stage: production-ready, but some parts of the API may still change. Feedback is welcome. For more information, see https://github.com/pq-code-package/mldsa-native

Integration is achieved through a bazel dependency using mldsa-native's multi-level monobuild. A wrapper using OT cryptolib conventions is added. Tests are added comparing against known test vectors for the deterministic (derand) APIs for all three ML-DSA parameter sets (ML-DSA-44, ML-DSA-65, ML-DSA-87).

Similar to ML-KEM, the integration leverages OpenTitan's KMAC unit for massive performance gains. This required setting
`MLD_CONFIG_SERIAL_FIPS202_ONLY` to ensure only one SHAKE context is active at any time, as the KMAC accelerator holds only a single state.

Due to OpenTitan's memory constraints, this integration enables `MLD_CONFIG_REDUCE_RAM`, which streams the matrix A during signing operations instead of expanding it in full. This significantly impacts signing performance compared to the default configuration. The configuration option also uses unions to reduce overall memory footprint. CBMC proofs for code paths enabled by `MLD_CONFIG_REDUCE_RAM` are still facing some issues and will be completed at a later point (tracked at https://github.com/pq-code-package/mldsa-native/issues/826).

Stack Management:

To address OpenTitan's 16KB stack limit, this integration implements a custom bump allocator for ML-DSA's internal memory allocations. The allocator is enabled via `MLD_CONFIG_CUSTOM_ALLOC_FREE` and configured through `MLD_CONFIG_CONTEXT_PARAMETER`.

The bump allocator uses a simple linear allocation strategy with bounds checking. A context structure tracks the base pointer, total size, and current offset into a caller-provided work buffer. Allocations increment the offset; frees decrement it. If an allocation would exceed the buffer size, NULL is returned, triggering mldsa-native's built-in error handling. With correctly sized buffers, this should never occur in practice.

All ML-DSA API functions accept work buffer parameters sized according to the operation (keypair, sign, or verify). Buffer sizes are verified at compile time using static assertions against mldsa-native's `MLD_TOTAL_ALLOC_*` constants. The test suite allocates a single static work buffer sized to the maximum of all operations (62688 bytes for ML-DSA-87), resulting in peak stack usage well within the 16KB limit.

This approach moves the bulk of ML-DSA's internal allocations from stack to caller-provided buffers. A few kilobytes of allocations remain on the stack and will be addressed in future work (tracked at https://github.com/pq-code-package/mldsa-native/issues/867).

Benchmarking:

Benchmarking ML-DSA signature generation is challenging due to rejection sampling, which results in variable execution time. We cannot afford to benchmark enough signatures to obtain a statistical estimate, particularly when benchmarking using verilator. To estimate expected performance, the tests use the following trick. They benchmark signing with a message that requires 1 iteration in the rejection sampling loop, then benchmark signing with a message that requires 2 iterations in the rejection sampling loop, and linearly extrapolate to FIPS 204 expected iteration counts: 4.25 iterations for ML-DSA-44, 5.1 iterations for ML-DSA-65, and 3.85 iterations for ML-DSA-87. Note that this is an approximation as there are multiple rejection conditions with varying iteration costs. The benchmark mitigates this by selecting messages where rejection occurs due to the z-norm check, which accounts for the vast majority of rejections.

Hash ML-DSA mode is not yet integrated, but provisions are made in the API (`otcrypto_mldsa_sign_mode_t` enum) to add this in a follow-up PR.