### PR TITLE
[entropy_source,rtl] Changed sha3_squeezing net to MuBi4 to match sha3 port

### DIFF
--- a/hw/ip/entropy_src/rtl/entropy_src_core.sv
+++ b/hw/ip/entropy_src/rtl/entropy_src_core.sv
@@ -452,7 +452,7 @@ module entropy_src_core import entropy_src_pkg::*; #(
   logic                         sha3_block_processed;
   prim_mubi_pkg::mubi4_t        sha3_done;
   prim_mubi_pkg::mubi4_t        sha3_absorbed;
-  logic                         sha3_squeezing;
+  prim_mubi_pkg::mubi4_t        sha3_squeezing;
   logic [2:0]                   sha3_fsm;
   logic [32:0]                  sha3_err;
   logic                         cs_aes_halt_req;
@@ -1043,7 +1043,8 @@ module entropy_src_core import entropy_src_pkg::*; #(
   assign hw2reg.debug_status.entropy_fifo_depth.d = sfifo_esfinal_depth;
   assign hw2reg.debug_status.sha3_fsm.d = sha3_fsm;
   assign hw2reg.debug_status.sha3_block_pr.d = sha3_block_processed;
-  assign hw2reg.debug_status.sha3_squeezing.d = sha3_squeezing;
+  assign hw2reg.debug_status.sha3_squeezing.d =
+    prim_mubi_pkg::mubi4_test_true_strict(sha3_squeezing) ? 1'b 1 : 1'b 0;
   assign hw2reg.debug_status.sha3_absorbed.d =
     prim_mubi_pkg::mubi4_test_true_strict(sha3_absorbed) ? 1'b 1 : 1'b 0;
   assign hw2reg.debug_status.sha3_err.d = sha3_err_q;


### PR DESCRIPTION
The sha3_squeezing_o port in sha3 was previously made a MuBi4 but was not updated in entropy source. This caused CSR reads to entropy source to misinterpret the instantiated sha3 squeezing status.