### PR TITLE
[crypto] Harden RSA key import CRT checks with random mask 

### DIFF
--- a/sw/acc/crypto/rsa_keygen.s
+++ b/sw/acc/crypto/rsa_keygen.s
@@ -144,17 +144,21 @@ rsa_keygen:
  *  (d) the CRT coefficient in the private key is the inverse of the second
  *      modulus cofactor modulo the first.
  *
+ * A random mask r is generated and multiplied into the d_p, d_q, and i_q
+ * checks to avoid having the multi-limb value 1 as an intermediate or
+ * comparison target (hardening against fault injection).
+ *
  * After this function executes, the processor can verify validity of the
  * private key by checking the following values:
  *
  *   - The n check value (in rsa_n) will be computed as p * q and should equal
  *     the public modulus (n).
- *   - The d_p check value (in rsa_d_p) will be computed as e * d_p mod (p - 1)
- *     and should equal 1.
- *   - The d_q check value (in rsa_d_q) will be computed as e * d_q mod (q - 1)
- *     and should equal 1.
- *   - The i_q check value (in rsa_i_q) will be computed as q * i_q mod p and
- *     should equal 1.
+ *   - The d_p check value (in rsa_d_p) will be computed as
+ *     r * e * d_p mod (p - 1) and should equal r (in rsa_check_mask).
+ *   - The d_q check value (in rsa_d_q) will be computed as
+ *     r * e * d_q mod (q - 1) and should equal r (in rsa_check_mask).
+ *   - The i_q check value (in rsa_i_q) will be computed as
+ *     r * q * i_q mod p and should equal r (in rsa_check_mask).
  *   - The d check value (in rsa_e) will be equal to (1 << 256) - 1 if at least
  *     one of the upper `plen` bits of the reconstructed private exponent (d) is
  *     nonzero, otherwise 0. It should equal (1 << 256) - 1.
@@ -176,6 +180,7 @@ rsa_keygen:
  * @param[in]  dmem[rsa_e..rsa_e+4] RSA public exponent (e)
  * @param[in]  x30: plen, number of 256-bit limbs for p and q
  * @param[in]  w31: all-zero
+ * @param[out] dmem[rsa_check_mask..rsa_check_mask+32] random mask r
  * @param[out] dmem[rsa_n..rsa_n+(plen*2*32)] RSA public key modulus (n)
        check value
  * @param[out]  dmem[rsa_d_p..rsa_d_p+(plen*32)] first RSA private key private
@@ -214,17 +219,25 @@ rsa_check_key:
   /* Recompute p - 1 and q - 1 for later use in several steps. */
   jal      x1, prepare_pm1qm1
 
-  /* Compute e * d_p mod (p - 1) to check validity of d_p. */
+  /* Generate a random masking parameter for hardening CRT checks.
+       w20 <= URND(255) + 1 */
+  bn.wsrr  w20, URND
+  bn.rshi  w20, w31, w20 >> 1
+  bn.addi  w20, w20, 1
+  la       x15, rsa_check_mask
+  bn.sid   x20, 0(x15)
+
+  /* Compute r * e * d_p mod (p - 1) to check validity of d_p. */
   la       x13, rsa_d_p
   la       x14, rsa_pm1
   jal      x1, check_crt_component
 
-  /* Compute e * d_q mod (q - 1) to check validity of d_q. */
+  /* Compute r * e * d_q mod (q - 1) to check validity of d_q. */
   la       x13, rsa_d_q
   la       x14, rsa_qm1
   jal      x1, check_crt_component
 
-  /* Compute q * i_q mod p to check validity of i_q. */
+  /* Compute r * q * i_q mod p to check validity of i_q. */
   jal      x1, check_crt_coeff
 
   /* Compute the OR of the upper limbs of the reocvere d. */
@@ -242,26 +255,62 @@ rsa_check_key:
 /**
  * Perform a check of the validity of a single private key exponent CRT component.
  *
- * Given a public exponent e and a private exponent CRT component d_p, computes
- * the value e * d_p mod (p - 1).
+ * Given a public exponent e, a private exponent CRT component d_p, and a
+ * random mask r, computes e * (r * d_p mod (p - 1)) mod (p - 1).
  *
- * If the provided value of d_p is consistent with the provided cofactor and
- * public exponent, this computed value should be 1.
+ * If d_p is valid (e * d_p == 1 mod (p - 1)), this equals r.
+ * The caller provides the mask and compares the result against it.
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
  * @param[in]  x13: dptr_d_p, pointer to buffer to store result in DMEM
  * @param[in]  x14: dptr_pm1, pointer to (p - 1) to reduce modulo in DMEM
+ * @param[in]  x15: dptr_mask, pointer to 256-bit mask in DMEM
  * @param[in]  x20: 20, constant
  * @param[in]  x30: plen, number of 256-bit limbs for p and q
  * @param[in]  w31: all-zero
- * @param[out] dmem[dptr_d_p..dptr_d_p+(plen*32)]: result, equal to 1 when valid
+ * @param[out] dmem[dptr_d_p..dptr_d_p+(plen*32)]: r * e * d_p mod (p - 1)
  *
  * clobbered registers: x2 to x5, x8, x10 to x12, x21 to x23, w20 to w25, w27
  * clobbered flag groups: FG0
  */
 check_crt_component:
-  /* Multiply e * d_p, storing result in tmp_scratchpad. */
+  /* Multiply mask * d_p, storing result in tmp_scratchpad. */
+  addi     x10, x13, 0
+  addi     x11, x15, 0
+  la       x12, tmp_scratchpad
+  jal      x1, bignum_mul256
+
+  /* Copy p - 1, using rsa_n as a temporary buffer. */
+  addi     x10, x14, 0
+  la       x11, rsa_n
+  loop     x30, 2
+    bn.lid   x20, 0(x10++)
+    bn.sid   x20, 0(x11++)
+
+  /* Zero out one additional word to zero-extend. */
+  li       x2, 31
+  bn.sid   x2, 0(x11)
+
+  /* Add one to the limb count. */
+  addi     x30, x30, 1
+
+  /* Perform a modular reduction: (mask * d_p) mod (p - 1). */
+  la       x10, tmp_scratchpad
+  la       x11, rsa_n
+  jal      x1, mod
+
+  /* Subtract one back from the limb count. */
+  addi     x30, x30, -1
+
+  /* Copy reduced (mask * d_p) back to d_p. */
+  la       x10, tmp_scratchpad
+  addi     x11, x13, 0
+  loop     x30, 2
+    bn.lid   x20, 0(x10++)
+    bn.sid   x20, 0(x11++)
+
+  /* Multiply e * (mask * d_p mod (p-1)), storing in tmp_scratchpad. */
   addi     x10, x13, 0
   la       x11, rsa_e
   la       x12, tmp_scratchpad
@@ -281,7 +330,7 @@ check_crt_component:
   /* Add one to the limb count. */
   addi     x30, x30, 1
 
-  /* Perform a modular reduction. */
+  /* Perform a modular reduction: (e * mask * d_p) mod (p - 1). */
   la       x10, tmp_scratchpad
   la       x11, rsa_n
   jal      x1, mod
@@ -301,28 +350,63 @@ check_crt_component:
 /**
  * Perform a check of the validity of a CRT coefficient.
  *
- * Computes i_q * q modulo p, storing the result over i_q. This value will be 1
- * exactly when the provided i_q is valid.
+ * Given a CRT coefficient i_q and a random mask r, computes
+ * q * (r * i_q mod p) mod p.
+ *
+ * If i_q is valid (q * i_q == 1 mod p), this equals r.
+ * The caller provides the mask and compares the result against it.
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
  * @param[in]  dmem[rsa_i_q..rsa_i_q+(plen*32)] CRT coefficient (i_q)
  * @param[in]  dmem[rsa_p..rsa_p+(plen*32)] first RSA prime (p)
  * @param[in]  dmem[rsa_q..rsa_q+(plen*32)] second RSA prime (q)
- * @param[in]  dmem[rsa_d_p..rsa_d_p+(plen*32)] first RSA private key
-       private exponent CRT component (d_p)
- * @param[in]  dmem[rsa_d_q..rsa_d_q+(plen*32)] second RSA private key
-       private exponent CRT component (d_q)
+ * @param[in]  x15: dptr_mask, pointer to 256-bit mask in DMEM
  * @param[in]  x20: 20, constant
  * @param[in]  x30: plen, number of 256-bit limbs for p and q
  * @param[in]  w31: all-zero
- * @param[out] dmem[rsa_i_q..rsa_i_q+(plen*32)]: result, equal to 1 when valid
+ * @param[out] dmem[rsa_i_q..rsa_i_q+(plen*32)]: r * q * i_q mod p
  *
  * clobbered registers: x2 to x8, x10 to x12, x21 to x23, w20 to w25, w27
  * clobbered flag groups: FG0
  */
 check_crt_coeff:
-  /* Multiply q * i_q, storing result in tmp_scratchpad. */
+  /* Multiply mask * i_q, storing result in tmp_scratchpad. */
+  la       x10, rsa_i_q
+  addi     x11, x15, 0
+  la       x12, tmp_scratchpad
+  jal      x1, bignum_mul256
+
+  /* Copy p, using rsa_n as a temporary buffer. */
+  la       x10, rsa_p
+  la       x11, rsa_n
+  loop     x30, 2
+    bn.lid   x20, 0(x10++)
+    bn.sid   x20, 0(x11++)
+
+  /* Zero out one additional word to zero-extend. */
+  li       x2, 31
+  bn.sid   x2, 0(x11)
+
+  /* Add one to the limb count. */
+  addi     x30, x30, 1
+
+  /* Perform a modular reduction: (mask * i_q) mod p. */
+  la       x10, tmp_scratchpad
+  la       x11, rsa_n
+  jal      x1, mod
+
+  /* Subtract one back from the limb count. */
+  addi     x30, x30, -1
+
+  /* Copy reduced (mask * i_q mod p) back to i_q. */
+  la       x10, tmp_scratchpad
+  la       x11, rsa_i_q
+  loop     x30, 2
+    bn.lid   x20, 0(x10++)
+    bn.sid   x20, 0(x11++)
+
+  /* Multiply q * (mask * i_q mod p), storing result in tmp_scratchpad. */
   la       x10, rsa_q
   la       x11, rsa_i_q
   la       x12, tmp_scratchpad
@@ -2380,6 +2464,12 @@ rsa_d_q:
 .globl rsa_i_q
 rsa_i_q:
 .zero 256
+
+/* Random mask for hardening key import checks (256 bits). */
+.balign 32
+.globl rsa_check_mask
+rsa_check_mask:
+.zero 32
 
 /* Prime cofactor for n for `rsa_key_from_cofactor`; also used as a temporary
    work buffer containing `rsa_pm1` and `rsa_pm2`. */

--- a/sw/device/lib/crypto/impl/rsa/rsa_keygen.c
+++ b/sw/device/lib/crypto/impl/rsa/rsa_keygen.c
@@ -32,6 +32,7 @@ ACC_DECLARE_SYMBOL_ADDR(run_rsa_keygen,
 ACC_DECLARE_SYMBOL_ADDR(run_rsa_keygen, rsa_i_q);       // CRT coefficient i_p.
 ACC_DECLARE_SYMBOL_ADDR(run_rsa_keygen, rsa_cofactor);  // Cofactor p or q.
 ACC_DECLARE_SYMBOL_ADDR(run_rsa_keygen, rsa_e);         // Public exponent e.
+ACC_DECLARE_SYMBOL_ADDR(run_rsa_keygen, rsa_check_mask);  // Check mask.
 
 static const acc_addr_t kAccVarRsaMode = ACC_ADDR_T_INIT(run_rsa_keygen, mode);
 static const acc_addr_t kAccVarRsaSessionToken =
@@ -45,6 +46,8 @@ static const acc_addr_t kAccVarRsaIq = ACC_ADDR_T_INIT(run_rsa_keygen, rsa_i_q);
 static const acc_addr_t kAccVarRsaCofactor =
     ACC_ADDR_T_INIT(run_rsa_keygen, rsa_cofactor);
 static const acc_addr_t kAccVarRsaE = ACC_ADDR_T_INIT(run_rsa_keygen, rsa_e);
+static const acc_addr_t kAccVarRsaCheckMask =
+    ACC_ADDR_T_INIT(run_rsa_keygen, rsa_check_mask);
 
 // Declare mode constants.
 ACC_DECLARE_SYMBOL_ADDR(run_rsa_keygen, MODE_GEN_RSA_2048);
@@ -442,10 +445,11 @@ status_t rsa_key_check_2048_finalize(const rsa_2048_public_key_t *public_key,
   }
   HARDENED_CHECK_EQ(act_mode, exp_mode);
 
-  // Prepare a multi-limb constant of 1 for comparing to in validity checks.
-  uint32_t one[kRsa2048NumWords / 2];
-  memset(&one, 0, sizeof(one));
-  one[0] = 1;
+  // Read the 256-bit random mask used to harden d_p, d_q, and i_q checks.
+  // Zero-extend to full width for comparison.
+  uint32_t mask[kRsa2048NumWords / 2];
+  memset(&mask, 0, sizeof(mask));
+  ACC_WIPE_IF_ERROR(acc_dmem_read(8, kAccVarRsaCheckMask, mask));
 
   // Read the value of the first CRT component (d_p) validity check value
   // from ACC dmem.
@@ -453,9 +457,9 @@ status_t rsa_key_check_2048_finalize(const rsa_2048_public_key_t *public_key,
   ACC_WIPE_IF_ERROR(
       acc_dmem_read(kRsa2048NumWords / 2, kAccVarRsaDp, dp_check));
 
-  // Check that this matches the expected value of 1, and update the
-  // validity.
-  hardened_bool_t dp_valid = hardened_memeq(one, dp_check, ARRAYSIZE(dp_check));
+  // Check that this matches the mask (valid if r * e * d_p == r mod (p-1)).
+  hardened_bool_t dp_valid =
+      hardened_memeq(mask, dp_check, ARRAYSIZE(dp_check));
 
   // Read the value of the second CRT component (d_q) validity check value
   // from ACC dmem.
@@ -463,9 +467,9 @@ status_t rsa_key_check_2048_finalize(const rsa_2048_public_key_t *public_key,
   ACC_WIPE_IF_ERROR(
       acc_dmem_read(kRsa2048NumWords / 2, kAccVarRsaDq, dq_check));
 
-  // Check that this matches the expected value of 1, and update the
-  // validity.
-  hardened_bool_t dq_valid = hardened_memeq(one, dq_check, ARRAYSIZE(dq_check));
+  // Check that this matches the mask (valid if r * e * d_q == r mod (q-1)).
+  hardened_bool_t dq_valid =
+      hardened_memeq(mask, dq_check, ARRAYSIZE(dq_check));
 
   // Read the value of the CRT coefficient (i_q) validity check value
   // from ACC dmem.
@@ -473,9 +477,9 @@ status_t rsa_key_check_2048_finalize(const rsa_2048_public_key_t *public_key,
   ACC_WIPE_IF_ERROR(
       acc_dmem_read(kRsa2048NumWords / 2, kAccVarRsaIq, iq_check));
 
-  // Check that this matches the expected value of 1, and update the
-  // validity.
-  hardened_bool_t iq_valid = hardened_memeq(one, iq_check, ARRAYSIZE(iq_check));
+  // Check that this matches the mask (valid if r * q * i_q == r mod p).
+  hardened_bool_t iq_valid =
+      hardened_memeq(mask, iq_check, ARRAYSIZE(iq_check));
 
   // Read the recovered public modulus (n) from ACC dmem.
   uint32_t recovered_n[kRsa2048NumWords];
@@ -587,10 +591,11 @@ status_t rsa_key_check_3072_finalize(const rsa_3072_public_key_t *public_key,
   }
   HARDENED_CHECK_EQ(act_mode, exp_mode);
 
-  // Prepare a multi-limb constant of 1 for comparing to in validity checks.
-  uint32_t one[kRsa3072NumWords / 2];
-  memset(&one, 0, sizeof(one));
-  one[0] = 1;
+  // Read the 256-bit random mask used to harden d_p, d_q, and i_q checks.
+  // Zero-extend to full width for comparison.
+  uint32_t mask[kRsa3072NumWords / 2];
+  memset(&mask, 0, sizeof(mask));
+  ACC_WIPE_IF_ERROR(acc_dmem_read(8, kAccVarRsaCheckMask, mask));
 
   // Read the value of the first CRT component (d_p) validity check value
   // from ACC dmem.
@@ -598,9 +603,9 @@ status_t rsa_key_check_3072_finalize(const rsa_3072_public_key_t *public_key,
   ACC_WIPE_IF_ERROR(
       acc_dmem_read(kRsa3072NumWords / 2, kAccVarRsaDp, dp_check));
 
-  // Check that this matches the expected value of 1, and update the
-  // validity.
-  hardened_bool_t dp_valid = hardened_memeq(one, dp_check, ARRAYSIZE(dp_check));
+  // Check that this matches the mask (valid if r * e * d_p == r mod (p-1)).
+  hardened_bool_t dp_valid =
+      hardened_memeq(mask, dp_check, ARRAYSIZE(dp_check));
 
   // Read the value of the second CRT component (d_q) validity check value
   // from ACC dmem.
@@ -608,9 +613,9 @@ status_t rsa_key_check_3072_finalize(const rsa_3072_public_key_t *public_key,
   ACC_WIPE_IF_ERROR(
       acc_dmem_read(kRsa3072NumWords / 2, kAccVarRsaDq, dq_check));
 
-  // Check that this matches the expected value of 1, and update the
-  // validity.
-  hardened_bool_t dq_valid = hardened_memeq(one, dq_check, ARRAYSIZE(dq_check));
+  // Check that this matches the mask (valid if r * e * d_q == r mod (q-1)).
+  hardened_bool_t dq_valid =
+      hardened_memeq(mask, dq_check, ARRAYSIZE(dq_check));
 
   // Read the value of the CRT coefficient (i_q) validity check value
   // from ACC dmem.
@@ -618,9 +623,9 @@ status_t rsa_key_check_3072_finalize(const rsa_3072_public_key_t *public_key,
   ACC_WIPE_IF_ERROR(
       acc_dmem_read(kRsa3072NumWords / 2, kAccVarRsaIq, iq_check));
 
-  // Check that this matches the expected value of 1, and update the
-  // validity.
-  hardened_bool_t iq_valid = hardened_memeq(one, iq_check, ARRAYSIZE(iq_check));
+  // Check that this matches the mask (valid if r * q * i_q == r mod p).
+  hardened_bool_t iq_valid =
+      hardened_memeq(mask, iq_check, ARRAYSIZE(iq_check));
 
   // Read the recovered public modulus (n) from ACC dmem.
   uint32_t recovered_n[kRsa3072NumWords];
@@ -732,10 +737,11 @@ status_t rsa_key_check_4096_finalize(const rsa_4096_public_key_t *public_key,
   }
   HARDENED_CHECK_EQ(act_mode, exp_mode);
 
-  // Prepare a multi-limb constant of 1 for comparing to in validity checks.
-  uint32_t one[kRsa4096NumWords / 2];
-  memset(&one, 0, sizeof(one));
-  one[0] = 1;
+  // Read the 256-bit random mask used to harden d_p, d_q, and i_q checks.
+  // Zero-extend to full width for comparison.
+  uint32_t mask[kRsa4096NumWords / 2];
+  memset(&mask, 0, sizeof(mask));
+  ACC_WIPE_IF_ERROR(acc_dmem_read(8, kAccVarRsaCheckMask, mask));
 
   // Read the value of the first CRT component (d_p) validity check value
   // from ACC dmem.
@@ -743,9 +749,9 @@ status_t rsa_key_check_4096_finalize(const rsa_4096_public_key_t *public_key,
   ACC_WIPE_IF_ERROR(
       acc_dmem_read(kRsa4096NumWords / 2, kAccVarRsaDp, dp_check));
 
-  // Check that this matches the expected value of 1, and update the
-  // validity.
-  hardened_bool_t dp_valid = hardened_memeq(one, dp_check, ARRAYSIZE(dp_check));
+  // Check that this matches the mask (valid if r * e * d_p == r mod (p-1)).
+  hardened_bool_t dp_valid =
+      hardened_memeq(mask, dp_check, ARRAYSIZE(dp_check));
 
   // Read the value of the second CRT component (d_q) validity check value
   // from ACC dmem.
@@ -753,9 +759,9 @@ status_t rsa_key_check_4096_finalize(const rsa_4096_public_key_t *public_key,
   ACC_WIPE_IF_ERROR(
       acc_dmem_read(kRsa4096NumWords / 2, kAccVarRsaDq, dq_check));
 
-  // Check that this matches the expected value of 1, and update the
-  // validity.
-  hardened_bool_t dq_valid = hardened_memeq(one, dq_check, ARRAYSIZE(dq_check));
+  // Check that this matches the mask (valid if r * e * d_q == r mod (q-1)).
+  hardened_bool_t dq_valid =
+      hardened_memeq(mask, dq_check, ARRAYSIZE(dq_check));
 
   // Read the value of the CRT coefficient (i_q) validity check value
   // from ACC dmem.
@@ -763,9 +769,9 @@ status_t rsa_key_check_4096_finalize(const rsa_4096_public_key_t *public_key,
   ACC_WIPE_IF_ERROR(
       acc_dmem_read(kRsa4096NumWords / 2, kAccVarRsaIq, iq_check));
 
-  // Check that this matches the expected value of 1, and update the
-  // validity.
-  hardened_bool_t iq_valid = hardened_memeq(one, iq_check, ARRAYSIZE(iq_check));
+  // Check that this matches the mask (valid if r * q * i_q == r mod p).
+  hardened_bool_t iq_valid =
+      hardened_memeq(mask, iq_check, ARRAYSIZE(iq_check));
 
   // Read the recovered public modulus (n) from ACC dmem.
   uint32_t recovered_n[kRsa4096NumWords];

--- a/sw/device/tests/crypto/rsa_2048_key_construct_functest.c
+++ b/sw/device/tests/crypto/rsa_2048_key_construct_functest.c
@@ -88,6 +88,24 @@ static uint32_t kTestInvalidPrivateExponentComponentP[kRsa2048NumWords / 2] = {
     0x7b1d095d, 0xacc9ede5,
 };
 
+static uint32_t kTestInvalidPrivateExponentComponentQ[kRsa2048NumWords / 2] = {
+    0x1294bbf7, 0x8b2919b9, 0x19e6e6bb, 0x5bac57cf, 0x94878d05, 0xdd0297c9,
+    0xc2fa4a31, 0x250dbc5d, 0xa6e04af3, 0xc4f6deb7, 0x5d21fd5f, 0x6e02cdea,
+    0xb967b151, 0x1324bb70, 0xe7c7e19a, 0x93faa85b, 0xcea179ee, 0xda7b268f,
+    0xb4953e88, 0x5da887cf, 0xf3475b09, 0xf0f59bd2, 0xd783b40b, 0x871df1f6,
+    0x7781156f, 0x2d8a9b67, 0xf1555281, 0xdf14b659, 0x85d12616, 0x28f80092,
+    0x50663f6f, 0xb2191d7f,
+};
+
+static uint32_t kTestInvalidCrtCoefficient[kRsa2048NumWords / 2] = {
+    0x8678e23f, 0x208181a5, 0x4c846651, 0xd7015b89, 0x75c82ec3, 0x9ab976a8,
+    0xdc502277, 0xe354d4f1, 0x57b4eedb, 0x347c059,  0xf98ab29f, 0x38b694ec,
+    0x8ef8acf0, 0xd530b8a6, 0x36cf279f, 0xacdb1beb, 0xc89e371d, 0xe9080f0f,
+    0x05f32291, 0x4c4cc843, 0x4f7bd2e4, 0xa158cc81, 0x2b3fdadf, 0x20b88f37,
+    0x5e424f2a, 0x41794ace, 0x86297642, 0x1472ceaa, 0xeedce93a, 0xad62154d,
+    0xae949fc6, 0x267d8cbc,
+};
+
 static uint32_t kTestPublicExponent = 65537;
 
 // Key mode for testing.
@@ -326,7 +344,9 @@ status_t private_key_check_valid_roundtrip_test(void) {
   return OK_STATUS();
 }
 
-status_t private_key_check_invalid(void) {
+status_t private_key_check_invalid_inner(const uint32_t *d_p_data,
+                                         const uint32_t *d_q_data,
+                                         const uint32_t *i_q_data) {
   // Construct the public key.
   otcrypto_const_word32_buf_t modulus = {
       .data = kTestModulus,
@@ -342,8 +362,6 @@ status_t private_key_check_invalid(void) {
   TRY(otcrypto_rsa_public_key_construct(kOtcryptoRsaSize2048, modulus,
                                         kTestPublicExponent, &public_key));
 
-  // Attempt to construct the private key, providing an invalid value for d_p
-  // with a single bit changed.
   otcrypto_const_word32_buf_t p = {
       .data = kTestCofactorP,
       .len = ARRAYSIZE(kTestCofactorP),
@@ -353,15 +371,15 @@ status_t private_key_check_invalid(void) {
       .len = ARRAYSIZE(kTestCofactorQ),
   };
   otcrypto_const_word32_buf_t d_p = {
-      .data = kTestInvalidPrivateExponentComponentP,
+      .data = d_p_data,
       .len = ARRAYSIZE(kTestPrivateExponentComponentP),
   };
   otcrypto_const_word32_buf_t d_q = {
-      .data = kTestPrivateExponentComponentQ,
+      .data = d_q_data,
       .len = ARRAYSIZE(kTestPrivateExponentComponentQ),
   };
   otcrypto_const_word32_buf_t i_q = {
-      .data = kTestCrtCoefficient,
+      .data = i_q_data,
       .len = ARRAYSIZE(kTestCrtCoefficient),
   };
   otcrypto_key_config_t private_key_config = {
@@ -388,6 +406,24 @@ status_t private_key_check_invalid(void) {
   return OK_STATUS();
 }
 
+status_t private_key_check_invalid_dp(void) {
+  return private_key_check_invalid_inner(kTestInvalidPrivateExponentComponentP,
+                                         kTestPrivateExponentComponentQ,
+                                         kTestCrtCoefficient);
+}
+
+status_t private_key_check_invalid_dq(void) {
+  return private_key_check_invalid_inner(kTestPrivateExponentComponentP,
+                                         kTestInvalidPrivateExponentComponentQ,
+                                         kTestCrtCoefficient);
+}
+
+status_t private_key_check_invalid_iq(void) {
+  return private_key_check_invalid_inner(kTestPrivateExponentComponentP,
+                                         kTestPrivateExponentComponentQ,
+                                         kTestInvalidCrtCoefficient);
+}
+
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
@@ -396,6 +432,8 @@ bool test_main(void) {
   EXECUTE_TEST(test_result, public_key_roundtrip_test);
   EXECUTE_TEST(test_result, private_key_roundtrip_test);
   EXECUTE_TEST(test_result, private_key_check_valid_roundtrip_test);
-  EXECUTE_TEST(test_result, private_key_check_invalid);
+  EXECUTE_TEST(test_result, private_key_check_invalid_dp);
+  EXECUTE_TEST(test_result, private_key_check_invalid_dq);
+  EXECUTE_TEST(test_result, private_key_check_invalid_iq);
   return status_ok(test_result);
 }

--- a/sw/device/tests/crypto/rsa_3072_key_construct_functest.c
+++ b/sw/device/tests/crypto/rsa_3072_key_construct_functest.c
@@ -105,6 +105,28 @@ static uint32_t kTestInvalidPrivateExponentComponentP[kRsa3072NumWords / 2] = {
     0x454af9,   0xcff6d9cd, 0xac279129, 0x351b6fb4, 0x85357c74, 0x866381de,
 };
 
+static uint32_t kTestInvalidPrivateExponentComponentQ[kRsa3072NumWords / 2] = {
+    0x4f94d00b, 0xcaacdde0, 0x81aa7fd7, 0xc265ae41, 0x326c9940, 0x8b427abf,
+    0x3a8f513a, 0x35580c14, 0xebfa05c1, 0x52b27b33, 0x7619c80c, 0xa5e076dc,
+    0xdef8c89c, 0xd42498c4, 0x753d842c, 0x44858361, 0x7e0b2e5f, 0x9da6b987,
+    0x9868b4ce, 0xb7ecb1ac, 0x381254c5, 0xa273df4f, 0x29aa3f66, 0xe8fd5603,
+    0xd6fe3210, 0x24041fe2, 0xf4c60024, 0x42cb4edf, 0x94713c64, 0xd3f5212c,
+    0x10f126,   0xad37458f, 0x820f1d42, 0x5a0b1136, 0xe000246d, 0x77fdaca4,
+    0xf244711b, 0xdceeefad, 0xc968d70a, 0xb73ee87d, 0xc0e913b3, 0x70629c,
+    0xdbf9ea12, 0xeeb64955, 0x3d24759f, 0x2ec3bd38, 0xd0def2f7, 0x8d57af0b,
+};
+
+static uint32_t kTestInvalidCrtCoefficient[kRsa3072NumWords / 2] = {
+    0x95932eaa, 0x59702111, 0x2ac49f32, 0x294792d7, 0x8ad3e891, 0x5b5a0c15,
+    0x2b6e7c2d, 0x56e13332, 0xe2a6188e, 0x4062dc8d, 0xdaa62268, 0xf28f7c86,
+    0x959632bd, 0xb85a7f81, 0xa5885ac,  0x44a95688, 0x871011f5, 0xd5fae09d,
+    0xd18a788a, 0x17dc874f, 0x1c9367f2, 0x94ba8be9, 0xdcd7ea3c, 0xd872e83e,
+    0x58690c6c, 0xf7f17944, 0x5b7a09ef, 0x2c9440e6, 0x98a67461, 0xc0ffe122,
+    0x17a3638,  0x733a43ea, 0x78476d0d, 0xaf954cab, 0x687da12f, 0x7480080e,
+    0xd573ce7c, 0xdc8e3c64, 0xa740368d, 0x17af4d83, 0xc45af0e2, 0xdd51be35,
+    0xfe85d4f0, 0xa0871757, 0xda54186d, 0x9b3ed119, 0xfe9b64d6, 0x66f89262,
+};
+
 static uint32_t kTestPublicExponent = 65537;
 
 // Key mode for testing.
@@ -343,7 +365,9 @@ status_t private_key_check_valid_roundtrip_test(void) {
   return OK_STATUS();
 }
 
-status_t private_key_check_invalid(void) {
+status_t private_key_check_invalid_inner(const uint32_t *d_p_data,
+                                         const uint32_t *d_q_data,
+                                         const uint32_t *i_q_data) {
   // Construct the public key.
   otcrypto_const_word32_buf_t modulus = {
       .data = kTestModulus,
@@ -359,8 +383,6 @@ status_t private_key_check_invalid(void) {
   TRY(otcrypto_rsa_public_key_construct(kOtcryptoRsaSize3072, modulus,
                                         kTestPublicExponent, &public_key));
 
-  // Attempt to construct the private key, providing an invalid value for d_p
-  // with a single bit changed.
   otcrypto_const_word32_buf_t p = {
       .data = kTestCofactorP,
       .len = ARRAYSIZE(kTestCofactorP),
@@ -370,15 +392,15 @@ status_t private_key_check_invalid(void) {
       .len = ARRAYSIZE(kTestCofactorQ),
   };
   otcrypto_const_word32_buf_t d_p = {
-      .data = kTestInvalidPrivateExponentComponentP,
+      .data = d_p_data,
       .len = ARRAYSIZE(kTestPrivateExponentComponentP),
   };
   otcrypto_const_word32_buf_t d_q = {
-      .data = kTestPrivateExponentComponentQ,
+      .data = d_q_data,
       .len = ARRAYSIZE(kTestPrivateExponentComponentQ),
   };
   otcrypto_const_word32_buf_t i_q = {
-      .data = kTestCrtCoefficient,
+      .data = i_q_data,
       .len = ARRAYSIZE(kTestCrtCoefficient),
   };
   otcrypto_key_config_t private_key_config = {
@@ -405,6 +427,24 @@ status_t private_key_check_invalid(void) {
   return OK_STATUS();
 }
 
+status_t private_key_check_invalid_dp(void) {
+  return private_key_check_invalid_inner(kTestInvalidPrivateExponentComponentP,
+                                         kTestPrivateExponentComponentQ,
+                                         kTestCrtCoefficient);
+}
+
+status_t private_key_check_invalid_dq(void) {
+  return private_key_check_invalid_inner(kTestPrivateExponentComponentP,
+                                         kTestInvalidPrivateExponentComponentQ,
+                                         kTestCrtCoefficient);
+}
+
+status_t private_key_check_invalid_iq(void) {
+  return private_key_check_invalid_inner(kTestPrivateExponentComponentP,
+                                         kTestPrivateExponentComponentQ,
+                                         kTestInvalidCrtCoefficient);
+}
+
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
@@ -413,6 +453,8 @@ bool test_main(void) {
   EXECUTE_TEST(test_result, public_key_roundtrip_test);
   EXECUTE_TEST(test_result, private_key_roundtrip_test);
   EXECUTE_TEST(test_result, private_key_check_valid_roundtrip_test);
-  EXECUTE_TEST(test_result, private_key_check_invalid);
+  EXECUTE_TEST(test_result, private_key_check_invalid_dp);
+  EXECUTE_TEST(test_result, private_key_check_invalid_dq);
+  EXECUTE_TEST(test_result, private_key_check_invalid_iq);
   return status_ok(test_result);
 }

--- a/sw/device/tests/crypto/rsa_4096_key_construct_functest.c
+++ b/sw/device/tests/crypto/rsa_4096_key_construct_functest.c
@@ -129,6 +129,34 @@ static uint32_t kTestInvalidPrivateExponentComponentP[kRsa4096NumWords / 2] = {
     0x3efcafc4, 0xd2e1d9f7, 0xcfc2e0e1, 0x524173bc,
 };
 
+static uint32_t kTestInvalidPrivateExponentComponentQ[kRsa4096NumWords / 2] = {
+    0x5810f281, 0xdd044ece, 0x921b9c1c, 0xb0b4f9f3, 0x1cd91924, 0x1af81c8e,
+    0xd68d49df, 0x3dedb354, 0xd58402f2, 0x53714747, 0x5e2f11a6, 0xb1b9a30c,
+    0x14cd48a8, 0x6d94c42d, 0xd6809127, 0x5dfb7702, 0x18c16eaf, 0xf6295fc6,
+    0xf407d458, 0x79324b14, 0x67dfe161, 0x649b91f2, 0x47917651, 0xebbb6cc6,
+    0x67809985, 0xbb20ba18, 0x789b8860, 0xe976be9f, 0x5d172695, 0x5e86663,
+    0xf142d3af, 0xedf383d0, 0x63f4f32b, 0x285c57a9, 0x566b2441, 0xc642effa,
+    0x70952e2a, 0x760614fb, 0xe96375dc, 0x3b842975, 0x1a41a281, 0xa064d0ef,
+    0x19045944, 0x743dadf3, 0x70454d0b, 0x2bc1dcd0, 0xdb507ab8, 0xbe7437fd,
+    0x70d8e461, 0x75d09c24, 0x32840920, 0xbbf27036, 0x84a8939a, 0x390cd63f,
+    0xc6b36b7,  0x2f2f19ab, 0x708b63f8, 0xe3688a08, 0xb101ff93, 0x8b8db1d2,
+    0xafc8a9f,  0xc28deac3, 0xc593a10a, 0x21fdb940,
+};
+
+static uint32_t kTestInvalidCrtCoefficient[kRsa4096NumWords / 2] = {
+    0xd2d24361, 0x91dd5ca9, 0x83c0e47b, 0x94ec892b, 0x652a48c3, 0xfaca1c9b,
+    0xf4edb448, 0xa67fae42, 0x36f2871c, 0xd10a8426, 0x4155eccf, 0x7238be69,
+    0x544410aa, 0x93f34c6e, 0x42c22223, 0xf392befa, 0x63466b4b, 0xea3ad8c0,
+    0xa541b3f0, 0xeef32c4d, 0x54662925, 0x56b407e9, 0x320bda91, 0x6f106dc2,
+    0xcd8f5e30, 0x96693547, 0xc4133d08, 0xd9adb683, 0x857bc942, 0x42c54d7e,
+    0x36f927a4, 0xb3243a6c, 0x614de345, 0x158b2a23, 0xb56229ae, 0x7a3c5311,
+    0x16a39fe1, 0x104e3cd3, 0xa264825d, 0xeab97e2b, 0x56ba7f27, 0x76e5e942,
+    0xd13146b1, 0x1cc6da68, 0xd2e9a365, 0x1e120c65, 0x3524be6,  0x34394c2,
+    0x67a3a94e, 0x2849824e, 0x540c18dd, 0xee4c8498, 0x8bbf5867, 0x68760f54,
+    0x107bf54e, 0xc4801efe, 0x500f1e6,  0x2735f8a6, 0xae9e2f6b, 0x367e6f4d,
+    0xfdfece3f, 0xd89234df, 0x22642014, 0x72406ade,
+};
+
 static uint32_t kTestPublicExponent = 65537;
 
 // Key mode for testing.
@@ -367,7 +395,9 @@ status_t private_key_check_valid_roundtrip_test(void) {
   return OK_STATUS();
 }
 
-status_t private_key_check_invalid(void) {
+status_t private_key_check_invalid_inner(const uint32_t *d_p_data,
+                                         const uint32_t *d_q_data,
+                                         const uint32_t *i_q_data) {
   // Construct the public key.
   otcrypto_const_word32_buf_t modulus = {
       .data = kTestModulus,
@@ -383,8 +413,6 @@ status_t private_key_check_invalid(void) {
   TRY(otcrypto_rsa_public_key_construct(kOtcryptoRsaSize4096, modulus,
                                         kTestPublicExponent, &public_key));
 
-  // Attempt to construct the private key, providing an invalid value for d_p
-  // with a single bit changed.
   otcrypto_const_word32_buf_t p = {
       .data = kTestCofactorP,
       .len = ARRAYSIZE(kTestCofactorP),
@@ -394,15 +422,15 @@ status_t private_key_check_invalid(void) {
       .len = ARRAYSIZE(kTestCofactorQ),
   };
   otcrypto_const_word32_buf_t d_p = {
-      .data = kTestInvalidPrivateExponentComponentP,
+      .data = d_p_data,
       .len = ARRAYSIZE(kTestPrivateExponentComponentP),
   };
   otcrypto_const_word32_buf_t d_q = {
-      .data = kTestPrivateExponentComponentQ,
+      .data = d_q_data,
       .len = ARRAYSIZE(kTestPrivateExponentComponentQ),
   };
   otcrypto_const_word32_buf_t i_q = {
-      .data = kTestCrtCoefficient,
+      .data = i_q_data,
       .len = ARRAYSIZE(kTestCrtCoefficient),
   };
   otcrypto_key_config_t private_key_config = {
@@ -429,6 +457,24 @@ status_t private_key_check_invalid(void) {
   return OK_STATUS();
 }
 
+status_t private_key_check_invalid_dp(void) {
+  return private_key_check_invalid_inner(kTestInvalidPrivateExponentComponentP,
+                                         kTestPrivateExponentComponentQ,
+                                         kTestCrtCoefficient);
+}
+
+status_t private_key_check_invalid_dq(void) {
+  return private_key_check_invalid_inner(kTestPrivateExponentComponentP,
+                                         kTestInvalidPrivateExponentComponentQ,
+                                         kTestCrtCoefficient);
+}
+
+status_t private_key_check_invalid_iq(void) {
+  return private_key_check_invalid_inner(kTestPrivateExponentComponentP,
+                                         kTestPrivateExponentComponentQ,
+                                         kTestInvalidCrtCoefficient);
+}
+
 OTTF_DEFINE_TEST_CONFIG();
 
 bool test_main(void) {
@@ -437,6 +483,8 @@ bool test_main(void) {
   EXECUTE_TEST(test_result, public_key_roundtrip_test);
   EXECUTE_TEST(test_result, private_key_roundtrip_test);
   EXECUTE_TEST(test_result, private_key_check_valid_roundtrip_test);
-  EXECUTE_TEST(test_result, private_key_check_invalid);
+  EXECUTE_TEST(test_result, private_key_check_invalid_dp);
+  EXECUTE_TEST(test_result, private_key_check_invalid_dq);
+  EXECUTE_TEST(test_result, private_key_check_invalid_iq);
   return status_ok(test_result);
 }


### PR DESCRIPTION
- Resolves https://github.com/zerorisc/expo/issues/170

As proposed in #170, this PR
multiplies a nonzero random mask into the d_p, d_q, and i_q
validity checks. Instead of computing e * d_p mod (p-1) and
comparing to 1, we now computes r * e * d_p mod (p-1) and
the C side compares against r.
    
This avoids the multi-limb value 1 as an intermediate or
comparison target, hardening the check against fault injection.

I have also added additional negative tests that test these failures cases for invalid d_q and i_q.