### PR TITLE
[cryptotest] Add Ed25519 tests using ACVP test vectors 

### DIFF
--- a/sw/device/lib/crypto/impl/ecc/BUILD
+++ b/sw/device/lib/crypto/impl/ecc/BUILD
@@ -53,6 +53,7 @@ cc_library(
         "//sw/acc/crypto:run_ed25519",
         "//sw/device/lib/base:hardened",
         "//sw/device/lib/base:hardened_memory",
+        "//sw/device/lib/base:math",
         "//sw/device/lib/crypto/drivers:acc",
         "//sw/device/lib/crypto/drivers:rv_core_ibex",
         "//sw/device/lib/crypto/impl:status",

--- a/sw/device/lib/crypto/impl/ecc/ed25519.c
+++ b/sw/device/lib/crypto/impl/ecc/ed25519.c
@@ -4,6 +4,7 @@
 
 #include "sw/device/lib/crypto/impl/ecc/ed25519.h"
 
+#include "sw/device/lib/base/math.h"
 #include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/drivers/rv_core_ibex.h"
 #include "sw/device/lib/crypto/impl/ecc/ed25519_insn_counts.h"
@@ -84,8 +85,15 @@ static status_t set_context(const uint32_t context[kEd25519ContextWords],
   }
   HARDENED_CHECK_LE(context_length, kEd25519ContextBytes);
 
-  // Write the full context string.
-  HARDENED_TRY(acc_dmem_write(context_length, context, kAccVarEd25519Ctx));
+  // Write the context string. If the context length is not a multiple of
+  // 32 bytes, the bytes up to the next multiple of 32 must be initialized
+  // to prevent read errors.
+  size_t padded_words =
+      ceil_div(context_length, kAccWideWordNumBytes) * kAccWideWordNumWords;
+  uint32_t padded_ctx[padded_words];
+  memset(padded_ctx, 0, sizeof(padded_ctx));
+  memcpy(padded_ctx, context, context_length);
+  HARDENED_TRY(acc_dmem_write(padded_words, padded_ctx, kAccVarEd25519Ctx));
 
   // Set the context length.
   return acc_dmem_write(1, &context_length, kAccVarEd25519CtxLen);

--- a/sw/device/lib/crypto/impl/ecc/ed25519.c
+++ b/sw/device/lib/crypto/impl/ecc/ed25519.c
@@ -79,10 +79,10 @@ OT_WARN_UNUSED_RESULT
 static status_t set_context(const uint32_t context[kEd25519ContextWords],
                             const uint32_t context_length) {
   // Ensure that our context length is valid; if not, fail early.
-  if (context_length > kEd25519ContextWords) {
+  if (context_length > kEd25519ContextBytes) {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_LE(context_length, kEd25519ContextWords);
+  HARDENED_CHECK_LE(context_length, kEd25519ContextBytes);
 
   // Write the full context string.
   HARDENED_TRY(acc_dmem_write(context_length, context, kAccVarEd25519Ctx));

--- a/sw/device/lib/crypto/impl/ecc/ed25519.c
+++ b/sw/device/lib/crypto/impl/ecc/ed25519.c
@@ -74,6 +74,7 @@ enum {
  * Set the context for signature generation or verification.
  *
  * @param context Context to set (little-endian).
+ * @param context_length Length of the provided context in bytes.
  * @return OK or error.
  */
 OT_WARN_UNUSED_RESULT

--- a/sw/device/lib/crypto/impl/ecc/ed25519.h
+++ b/sw/device/lib/crypto/impl/ecc/ed25519.h
@@ -77,17 +77,14 @@ enum {
    */
   kEd25519PointWords = kEd25519PointBytes / sizeof(uint32_t),
   /**
-   * Length of Ed25519 context in bits, including the flag.
+   * Max length of Ed25519 context in bytes.
    */
-  kEd25519ContextBits = 2048,
+  kEd25519ContextBytes = 255,
   /**
-   * Length of Ed25519 context in bytes, including the flag.
+   * Max length of Ed25519 context buffer in words (rounded up).
    */
-  kEd25519ContextBytes = kEd25519ContextBits / 8,
-  /**
-   * Length of Ed25519 context in words, including the flag.
-   */
-  kEd25519ContextWords = kEd25519ContextBytes / sizeof(uint32_t),
+  kEd25519ContextWords =
+      (kEd25519ContextBytes + sizeof(uint32_t) - 1) / sizeof(uint32_t),
   /**
    * A successful Ed25519 signature verification result.
    */

--- a/sw/device/lib/crypto/impl/ecc/ed25519.h
+++ b/sw/device/lib/crypto/impl/ecc/ed25519.h
@@ -139,7 +139,7 @@ typedef struct ed25519_signature {
  * @param prehashed_message Prehashed (SHA-512) message to sign.
  * @param hash_h SHA-512 hash of the Ed25519 private key to sign with.
  * @param context Context to use for signing.
- * @param context_length Length of the provided context.
+ * @param context_length Length of the provided context in bytes.
  * @param[out] session_token ACC session token for the operation.
  * @return Result of the operation (OK or error).
  */
@@ -176,7 +176,7 @@ status_t ed25519_sign_finalize(uint32_t session_token,
  * @param prehashed_message Prehashed (SHA-512) message to sign.
  * @param hash_k Pre-computed scalar value k for verification.
  * @param context Context to use for signing.
- * @param context_length Length of the provided context.
+ * @param context_length Length of the provided context in bytes.
  * @param[out] session_token ACC session token for the operation.
  * @return Result of the operation (OK or error).
  */

--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -520,6 +520,24 @@ cryptotest(
     test_vectors = KMAC_TESTVECTOR_TARGETS,
 )
 
+ED25519_TESTVECTOR_TARGETS = [
+    "//sw/host/cryptotest/testvectors/data:acvp_eddsa_sigver_json",
+    "//sw/host/cryptotest/testvectors/data:acvp_eddsa_siggen_json",
+]
+
+ED25519_TESTVECTOR_ARGS = " ".join([
+    "--ed25519-json=\"$(rootpath {})\"".format(target)
+    for target in ED25519_TESTVECTOR_TARGETS
+])
+
+cryptotest(
+    name = "ed25519_kat",
+    slow_test = True,
+    test_args = ED25519_TESTVECTOR_ARGS,
+    test_harness = "//sw/host/tests/crypto/ed25519_kat:harness",
+    test_vectors = ED25519_TESTVECTOR_TARGETS,
+)
+
 SPHINCSPLUS_TESTVECTOR_TARGETS = [
     "//sw/host/cryptotest/testvectors/data:{}".format(target)
     for target in [
@@ -558,6 +576,7 @@ test_suite(
         ":drbg_kat",
         ":ecdh_kat",
         ":ecdsa_kat",
+        ":ed25519_kat",
         ":hmac_sha256_kat",
         ":hmac_sha384_kat",
         ":hmac_sha512_kat",

--- a/sw/device/tests/crypto/cryptotest/cryptotest.bzl
+++ b/sw/device/tests/crypto/cryptotest/cryptotest.bzl
@@ -39,6 +39,7 @@ FIRMWARE_DEPS = [
     "//sw/device/tests/crypto/cryptotest/firmware:mlkem",
     "//sw/device/tests/crypto/cryptotest/firmware:rsa",
     "//sw/device/tests/crypto/cryptotest/firmware:sphincsplus",
+    "//sw/device/tests/crypto/cryptotest/firmware:ed25519",
     "//sw/device/lib/base:csr",
     "//sw/device/lib/base:status",
     "//sw/device/lib/crypto/drivers:entropy",

--- a/sw/device/tests/crypto/cryptotest/firmware/BUILD
+++ b/sw/device/tests/crypto/cryptotest/firmware/BUILD
@@ -253,6 +253,23 @@ cc_library(
     ],
 )
 
+cc_library(
+    name = "ed25519",
+    srcs = ["ed25519.c"],
+    hdrs = ["ed25519.h"],
+    deps = [
+        "//sw/device/lib/base:memory",
+        "//sw/device/lib/base:status",
+        "//sw/device/lib/crypto/impl:ed25519",
+        "//sw/device/lib/crypto/impl:integrity",
+        "//sw/device/lib/crypto/include:datatypes",
+        "//sw/device/lib/runtime:log",
+        "//sw/device/lib/testing/test_framework:ujson_ottf",
+        "//sw/device/lib/ujson",
+        "//sw/device/tests/crypto/cryptotest/json:ed25519_commands",
+    ],
+)
+
 FIRMWARE_DEPS = [
     ":aes",
     ":aes_gcm",
@@ -262,6 +279,7 @@ FIRMWARE_DEPS = [
     ":mldsa",
     ":mlkem",
     ":ecdsa",
+    ":ed25519",
     ":hash",
     ":hmac",
     ":kmac",

--- a/sw/device/tests/crypto/cryptotest/firmware/ed25519.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/ed25519.c
@@ -1,0 +1,173 @@
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ed25519.h"
+
+#include "sw/device/lib/base/memory.h"
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/crypto/impl/integrity.h"
+#include "sw/device/lib/crypto/include/datatypes.h"
+#include "sw/device/lib/crypto/include/ed25519.h"
+#include "sw/device/lib/runtime/log.h"
+#include "sw/device/lib/testing/test_framework/ujson_ottf.h"
+#include "sw/device/lib/ujson/ujson.h"
+#include "sw/device/tests/crypto/cryptotest/json/ed25519_commands.h"
+
+#define MODULE_ID MAKE_MODULE_ID('e', 'd', 'v')
+
+enum {
+  kEd25519PublicKeyBytes = 32,
+  kEd25519PrivateKeyBytes = 32,
+  kEd25519SignatureWords = 512 / 32,
+};
+
+static const otcrypto_key_config_t kEd25519PrivateKeyConfig = {
+    .version = kOtcryptoLibVersion1,
+    .key_mode = kOtcryptoKeyModeEd25519,
+    .key_length = kEd25519PrivateKeyBytes,
+    .hw_backed = kHardenedBoolFalse,
+    .security_level = kOtcryptoKeySecurityLevelPassiveRemote,
+};
+
+static status_t handle_ed25519_sigver(ujson_t *uj) {
+  cryptotest_ed25519_message_t uj_message;
+  cryptotest_ed25519_signature_t uj_signature;
+  cryptotest_ed25519_public_key_t uj_public_key;
+
+  TRY(ujson_deserialize_cryptotest_ed25519_message_t(uj, &uj_message));
+  TRY(ujson_deserialize_cryptotest_ed25519_signature_t(uj, &uj_signature));
+  TRY(ujson_deserialize_cryptotest_ed25519_public_key_t(uj, &uj_public_key));
+
+  // Set up the public key.
+  uint32_t pk_data[kEd25519PublicKeyBytes / sizeof(uint32_t)];
+  memset(pk_data, 0, sizeof(pk_data));
+  memcpy(pk_data, uj_public_key.pk, uj_public_key.pk_len);
+  otcrypto_unblinded_key_t public_key = {
+      .key_mode = kOtcryptoKeyModeEd25519,
+      .key_length = uj_public_key.pk_len,
+      .key = pk_data,
+  };
+  public_key.checksum = integrity_unblinded_checksum(&public_key);
+
+  otcrypto_const_byte_buf_t message = {
+      .data = uj_message.input,
+      .len = uj_message.input_len,
+  };
+
+  otcrypto_const_byte_buf_t context = {
+      .data = NULL,
+      .len = 0,
+  };
+
+  // Set up the signature.
+  uint32_t sig_data[kEd25519SignatureWords];
+  memset(sig_data, 0, sizeof(sig_data));
+  memcpy(sig_data, uj_signature.signature, uj_signature.signature_len);
+  otcrypto_const_word32_buf_t signature = {
+      .data = sig_data,
+      .len = kEd25519SignatureWords,
+  };
+
+  // Verify.
+  hardened_bool_t verification_result = kHardenedBoolFalse;
+  otcrypto_status_t status = otcrypto_ed25519_verify(
+      &public_key, message, context, kOtcryptoEddsaSignModeHashEddsa, signature,
+      &verification_result);
+
+  cryptotest_ed25519_verify_output_t uj_output =
+      (status_ok(status) && verification_result == kHardenedBoolTrue)
+          ? kCryptotestEd25519VerifyOutputSuccess
+          : kCryptotestEd25519VerifyOutputFailure;
+
+  RESP_OK(ujson_serialize_cryptotest_ed25519_verify_output_t, uj, &uj_output);
+  return OK_STATUS();
+}
+
+static status_t handle_ed25519_siggen(ujson_t *uj) {
+  cryptotest_ed25519_siggen_data_t uj_data;
+  TRY(ujson_deserialize_cryptotest_ed25519_siggen_data_t(uj, &uj_data));
+
+  // Set up the private key.
+  uint32_t sk_data[kEd25519PrivateKeyBytes / sizeof(uint32_t)];
+  memset(sk_data, 0, sizeof(sk_data));
+  memcpy(sk_data, uj_data.sk, uj_data.sk_len);
+  otcrypto_blinded_key_t private_key = {
+      .config = kEd25519PrivateKeyConfig,
+      .keyblob_length = sizeof(sk_data),
+      .keyblob = sk_data,
+  };
+  private_key.checksum = integrity_blinded_checksum(&private_key);
+
+  // Set up the pre-hashed message.
+  otcrypto_const_byte_buf_t message = {
+      .data = uj_data.message,
+      .len = uj_data.message_len,
+  };
+
+  // Set up the context.
+  otcrypto_const_byte_buf_t context = {
+      .data = uj_data.context,
+      .len = uj_data.context_len,
+  };
+
+  // Allocate space for the signature.
+  uint32_t sig[kEd25519SignatureWords] = {0};
+  otcrypto_word32_buf_t sig_buf = {
+      .data = sig,
+      .len = kEd25519SignatureWords,
+  };
+
+  // Sign.
+  otcrypto_status_t status = otcrypto_ed25519_sign(
+      &private_key, message, context, kOtcryptoEddsaSignModeHashEddsa, sig_buf);
+
+  // Verify the signature we just produced.
+  if (status_ok(status)) {
+    uint32_t pk_data[kEd25519PublicKeyBytes / sizeof(uint32_t)];
+    memset(pk_data, 0, sizeof(pk_data));
+    memcpy(pk_data, uj_data.pk, uj_data.pk_len);
+    otcrypto_unblinded_key_t public_key = {
+        .key_mode = kOtcryptoKeyModeEd25519,
+        .key_length = uj_data.pk_len,
+        .key = pk_data,
+    };
+    public_key.checksum = integrity_unblinded_checksum(&public_key);
+
+    hardened_bool_t verification_result = kHardenedBoolFalse;
+    otcrypto_const_word32_buf_t sig_const = {.data = sig,
+                                             .len = ARRAYSIZE(sig)};
+    TRY(otcrypto_ed25519_verify(&public_key, message, context,
+                                kOtcryptoEddsaSignModeHashEddsa, sig_const,
+                                &verification_result));
+    if (verification_result != kHardenedBoolTrue) {
+      LOG_ERROR("Ed25519 signature verification failed after signing");
+      return INTERNAL();
+    }
+  }
+
+  cryptotest_ed25519_siggen_output_t uj_output;
+  memset(&uj_output, 0, sizeof(uj_output));
+  uj_output.success = status_ok(status);
+  if (uj_output.success) {
+    memcpy(uj_output.signature, sig, sizeof(sig));
+  }
+  uj_output.signature_len = sizeof(sig);
+  RESP_OK(ujson_serialize_cryptotest_ed25519_siggen_output_t, uj, &uj_output);
+  return OK_STATUS();
+}
+
+status_t handle_ed25519(ujson_t *uj) {
+  ed25519_subcommand_t subcmd;
+  TRY(ujson_deserialize_ed25519_subcommand_t(uj, &subcmd));
+
+  switch (subcmd) {
+    case kEd25519SubcommandEd25519Sigver:
+      return handle_ed25519_sigver(uj);
+    case kEd25519SubcommandEd25519Siggen:
+      return handle_ed25519_siggen(uj);
+    default:
+      LOG_ERROR("Unrecognized Ed25519 subcommand: %d", subcmd);
+      return INVALID_ARGUMENT();
+  }
+}

--- a/sw/device/tests/crypto/cryptotest/firmware/ed25519.h
+++ b/sw/device/tests/crypto/cryptotest/firmware/ed25519.h
@@ -1,0 +1,13 @@
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_ED25519_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_ED25519_H_
+
+#include "sw/device/lib/base/status.h"
+#include "sw/device/lib/ujson/ujson.h"
+
+status_t handle_ed25519(ujson_t *uj);
+
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_FIRMWARE_ED25519_H_

--- a/sw/device/tests/crypto/cryptotest/firmware/firmware.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/firmware.c
@@ -20,6 +20,7 @@
 #include "sw/device/tests/crypto/cryptotest/json/drbg_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/ecdh_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/ecdsa_commands.h"
+#include "sw/device/tests/crypto/cryptotest/json/ed25519_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/hash_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/hmac_commands.h"
 #include "sw/device/tests/crypto/cryptotest/json/kmac_commands.h"
@@ -35,6 +36,7 @@
 #include "drbg.h"
 #include "ecdh.h"
 #include "ecdsa.h"
+#include "ed25519.h"
 #include "hash.h"
 #include "hmac.h"
 #include "kmac.h"
@@ -97,6 +99,9 @@ status_t process_cmd(ujson_t *uj) {
         break;
       case kCryptotestCommandSphincsPlus:
         RESP_ERR(uj, handle_sphincsplus(uj));
+        break;
+      case kCryptotestCommandEd25519:
+        RESP_ERR(uj, handle_ed25519(uj));
         break;
       default:
         LOG_ERROR("Unrecognized command: %d", cmd);

--- a/sw/device/tests/crypto/cryptotest/json/BUILD
+++ b/sw/device/tests/crypto/cryptotest/json/BUILD
@@ -15,6 +15,7 @@ cc_library(
         ":drbg_commands",
         ":ecdh_commands",
         ":ecdsa_commands",
+        ":ed25519_commands",
         ":hash_commands",
         ":hmac_commands",
         ":kmac_commands",
@@ -23,6 +24,13 @@ cc_library(
         ":rsa_commands",
         "//sw/device/lib/ujson",
     ],
+)
+
+cc_library(
+    name = "ed25519_commands",
+    srcs = ["ed25519_commands.c"],
+    hdrs = ["ed25519_commands.h"],
+    deps = ["//sw/device/lib/ujson"],
 )
 
 cc_library(

--- a/sw/device/tests/crypto/cryptotest/json/commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/commands.h
@@ -24,7 +24,8 @@ extern "C" {
     value(_, Mldsa) \
     value(_, Mlkem) \
     value(_, Rsa) \
-    value(_, SphincsPlus)
+    value(_, SphincsPlus) \
+    value(_, Ed25519)
 UJSON_SERDE_ENUM(CryptotestCommand, cryptotest_cmd_t, COMMAND);
 
 // clang-format on

--- a/sw/device/tests/crypto/cryptotest/json/ed25519_commands.c
+++ b/sw/device/tests/crypto/cryptotest/json/ed25519_commands.c
@@ -1,0 +1,6 @@
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#define UJSON_SERDE_IMPL 1
+#include "ed25519_commands.h"

--- a/sw/device/tests/crypto/cryptotest/json/ed25519_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/ed25519_commands.h
@@ -1,0 +1,73 @@
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+#ifndef OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_ED25519_COMMANDS_H_
+#define OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_ED25519_COMMANDS_H_
+#include "sw/device/lib/ujson/ujson_derive.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MODULE_ID MAKE_MODULE_ID('j', 'e', 'd')
+
+// Signature and public key buffers are oversized to accommodate
+// invalid test vectors.
+#define ED25519_CMD_MAX_MESSAGE_BYTES 1024
+#define ED25519_CMD_MAX_SIGNATURE_BYTES 128  // valid: 64
+#define ED25519_CMD_MAX_PUBLIC_KEY_BYTES 64  // valid: 32
+#define ED25519_CMD_MAX_PRIVATE_KEY_BYTES 32
+#define ED25519_CMD_MAX_CONTEXT_BYTES 256  // max: 255
+
+// clang-format off
+
+#define ED25519_SUBCOMMAND(_, value) \
+    value(_, Ed25519Sigver) \
+    value(_, Ed25519Siggen)
+UJSON_SERDE_ENUM(Ed25519Subcommand, ed25519_subcommand_t, ED25519_SUBCOMMAND);
+
+#define ED25519_MESSAGE(field, string) \
+    field(input, uint8_t, ED25519_CMD_MAX_MESSAGE_BYTES) \
+    field(input_len, size_t)
+UJSON_SERDE_STRUCT(CryptotestEd25519Message, cryptotest_ed25519_message_t, ED25519_MESSAGE);
+
+#define ED25519_SIGNATURE(field, string) \
+    field(signature, uint8_t, ED25519_CMD_MAX_SIGNATURE_BYTES) \
+    field(signature_len, size_t)
+UJSON_SERDE_STRUCT(CryptotestEd25519Signature, cryptotest_ed25519_signature_t, ED25519_SIGNATURE);
+
+#define ED25519_PUBLIC_KEY(field, string) \
+    field(pk, uint8_t, ED25519_CMD_MAX_PUBLIC_KEY_BYTES) \
+    field(pk_len, size_t)
+UJSON_SERDE_STRUCT(CryptotestEd25519PublicKey, cryptotest_ed25519_public_key_t, ED25519_PUBLIC_KEY);
+
+#define ED25519_SIGGEN_DATA(field, string) \
+    field(sk, uint8_t, ED25519_CMD_MAX_PRIVATE_KEY_BYTES) \
+    field(sk_len, size_t) \
+    field(pk, uint8_t, ED25519_CMD_MAX_PUBLIC_KEY_BYTES) \
+    field(pk_len, size_t) \
+    field(message, uint8_t, ED25519_CMD_MAX_MESSAGE_BYTES) \
+    field(message_len, size_t) \
+    field(context, uint8_t, ED25519_CMD_MAX_CONTEXT_BYTES) \
+    field(context_len, size_t)
+UJSON_SERDE_STRUCT(CryptotestEd25519SiggenData, cryptotest_ed25519_siggen_data_t, ED25519_SIGGEN_DATA);
+
+#define ED25519_SIGGEN_OUTPUT(field, string) \
+    field(signature, uint8_t, ED25519_CMD_MAX_SIGNATURE_BYTES) \
+    field(signature_len, size_t) \
+    field(success, bool)
+UJSON_SERDE_STRUCT(CryptotestEd25519SiggenOutput, cryptotest_ed25519_siggen_output_t, ED25519_SIGGEN_OUTPUT);
+
+#define ED25519_VERIFY_OUTPUT(_, value) \
+    value(_, Success) \
+    value(_, Failure)
+UJSON_SERDE_ENUM(CryptotestEd25519VerifyOutput, cryptotest_ed25519_verify_output_t, ED25519_VERIFY_OUTPUT);
+
+#undef MODULE_ID
+
+// clang-format on
+
+#ifdef __cplusplus
+}
+#endif
+#endif  // OPENTITAN_SW_DEVICE_TESTS_CRYPTO_CRYPTOTEST_JSON_ED25519_COMMANDS_H_

--- a/sw/device/tests/crypto/ed25519_functest.c
+++ b/sw/device/tests/crypto/ed25519_functest.c
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0, see LICENSE for details.
 // SPDX-License-Identifier: Apache-2.0
 
+#include "sw/device/lib/base/memory.h"
 #include "sw/device/lib/crypto/drivers/acc.h"
 #include "sw/device/lib/crypto/drivers/entropy.h"
 #include "sw/device/lib/crypto/impl/integrity.h"
@@ -50,7 +51,8 @@ static const otcrypto_key_config_t kPrivateKeyConfig = {
     .security_level = kOtcryptoKeySecurityLevelPassiveRemote,
 };
 
-status_t sign_then_verify_test(hardened_bool_t *verification_result) {
+status_t sign_then_verify_test(hardened_bool_t *verification_result,
+                               const uint8_t *ctx, size_t ctx_len) {
   // Set up private key.
   otcrypto_blinded_key_t private_key = {
       .config = kPrivateKeyConfig,
@@ -90,23 +92,18 @@ status_t sign_then_verify_test(hardened_bool_t *verification_result) {
   // Allocate space for the signature.
   uint32_t sig[kEd25519SignatureWords] = {0};
 
-  // Allocate a zero-size buffer for context
-  uint8_t context[0];
+  otcrypto_const_byte_buf_t context = {.data = ctx, .len = ctx_len};
 
   // Generate a signature for the message.
-  LOG_INFO("Signing...");
+  LOG_INFO("Signing (ctx_len=%d)...", ctx_len);
   CHECK_STATUS_OK(otcrypto_ed25519_sign(
-      &private_key, msg_digest_buf,
-      (otcrypto_const_byte_buf_t){.data = context, .len = 0},
-      kOtcryptoEddsaSignModeHashEddsa,
+      &private_key, msg_digest_buf, context, kOtcryptoEddsaSignModeHashEddsa,
       (otcrypto_word32_buf_t){.data = sig, .len = ARRAYSIZE(sig)}));
 
   // Verify the signature.
   LOG_INFO("Verifying...");
   CHECK_STATUS_OK(otcrypto_ed25519_verify(
-      &public_key, msg_digest_buf,
-      (otcrypto_const_byte_buf_t){.data = context, .len = 0},
-      kOtcryptoEddsaSignModeHashEddsa,
+      &public_key, msg_digest_buf, context, kOtcryptoEddsaSignModeHashEddsa,
       (otcrypto_const_word32_buf_t){.data = sig, .len = ARRAYSIZE(sig)},
       verification_result));
 
@@ -118,21 +115,24 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
 
-  hardened_bool_t verificationResult;
-  status_t err = sign_then_verify_test(&verificationResult);
-  if (!status_ok(err)) {
-    // If there was an error, print the ACC error bits and instruction count.
-    LOG_INFO("ACC error bits: 0x%08x", acc_err_bits_get());
-    LOG_INFO("ACC instruction count: 0x%08x", acc_instruction_count_get());
-    // Print the error.
-    CHECK_STATUS_OK(err);
-    return false;
-  }
+  // Test with various context lengths.
+  uint8_t ctx_buf[160];
+  memset(ctx_buf, 0x42, sizeof(ctx_buf));
+  size_t ctx_lens[] = {0, 8, 96, 160, 8, 32};
 
-  // Signature verification is expected to succeed.
-  if (verificationResult != kHardenedBoolTrue) {
-    LOG_ERROR("Signature failed to pass verification!");
-    return false;
+  for (size_t i = 0; i < ARRAYSIZE(ctx_lens); i++) {
+    hardened_bool_t result;
+    status_t err = sign_then_verify_test(&result, ctx_buf, ctx_lens[i]);
+    if (!status_ok(err)) {
+      LOG_INFO("ACC error bits: 0x%08x", acc_err_bits_get());
+      LOG_INFO("ACC instruction count: 0x%08x", acc_instruction_count_get());
+      CHECK_STATUS_OK(err);
+      return false;
+    }
+    if (result != kHardenedBoolTrue) {
+      LOG_ERROR("Verification failed (ctx_len=%d)!", ctx_lens[i]);
+      return false;
+    }
   }
 
   return true;

--- a/sw/host/cryptotest/testvectors/data/BUILD
+++ b/sw/host/cryptotest/testvectors/data/BUILD
@@ -137,6 +137,46 @@ run_binary(
     tool = "//sw/host/cryptotest/testvectors/parsers:wycheproof_ed25519_parser",
 )
 
+run_binary(
+    name = "acvp_eddsa_sigver_json",
+    srcs = [
+        "//sw/host/cryptotest/testvectors/data/schemas:ed25519_schema.json",
+        "@acvp_testvectors//EDDSA-SigVer-1.0:internalProjection.json",
+    ],
+    outs = [":acvp_eddsa_sigver.json"],
+    args = [
+        "--src",
+        "$(location @acvp_testvectors//EDDSA-SigVer-1.0:internalProjection.json)",
+        "--dst",
+        "$(location :acvp_eddsa_sigver.json)",
+        "--schema",
+        "$(location //sw/host/cryptotest/testvectors/data/schemas:ed25519_schema.json)",
+        "--test-type",
+        "sigver",
+    ],
+    tool = "//sw/host/cryptotest/testvectors/parsers:nist_acvp_eddsa_parser",
+)
+
+run_binary(
+    name = "acvp_eddsa_siggen_json",
+    srcs = [
+        "//sw/host/cryptotest/testvectors/data/schemas:ed25519_schema.json",
+        "@acvp_testvectors//EDDSA-SigGen-1.0:internalProjection.json",
+    ],
+    outs = [":acvp_eddsa_siggen.json"],
+    args = [
+        "--src",
+        "$(location @acvp_testvectors//EDDSA-SigGen-1.0:internalProjection.json)",
+        "--dst",
+        "$(location :acvp_eddsa_siggen.json)",
+        "--schema",
+        "$(location //sw/host/cryptotest/testvectors/data/schemas:ed25519_schema.json)",
+        "--test-type",
+        "siggen",
+    ],
+    tool = "//sw/host/cryptotest/testvectors/parsers:nist_acvp_eddsa_parser",
+)
+
 # Number of tests per configuration (e.g. Verify P-256 SHA-256)
 ECDSA_RANDOM_COUNT = 128
 

--- a/sw/host/cryptotest/testvectors/data/schemas/ed25519_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/ed25519_schema.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/lowRISC/opentitan/master/sw/host/cryptotest/testvectors/data/schemas/ed25519_schema.json",
-  "title": "Cryptotest Ed25519 Signature Verification Test Vector",
-  "description": "A list of testvectors for Ed25519 Signature Verification testing",
+  "title": "Cryptotest Ed25519 Test Vector",
+  "description": "A list of testvectors for Ed25519 testing",
   "$defs": {
     "byte_array": {
       "type": "array",
@@ -19,6 +19,14 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
+      "vendor": {
+        "description": "Source of the test vector",
+        "type": "string"
+      },
+      "test_case_id": {
+        "description": "Test case identifier from the source",
+        "type": "integer"
+      },
       "algorithm": {
         "description": "Should be ed25519",
         "type": "string",
@@ -27,22 +35,34 @@
       "operation": {
         "description": "Ed25519 operation",
         "type": "string",
-        "enum": ["verify"]
+        "enum": ["verify", "sign"]
       },
       "message": {
-        "description": "Message to be verified",
+        "description": "Pre-hashed message (SHA-512 digest)",
         "$ref": "#/$defs/byte_array"
       },
       "public_key": {
-        "description": "Public key to use for verification",
+        "description": "Public key for verification",
+        "$ref": "#/$defs/byte_array"
+      },
+      "private_key": {
+        "description": "Private key seed for signing",
+        "$ref": "#/$defs/byte_array"
+      },
+      "context": {
+        "description": "Context string for Ed25519ctx/Ed25519ph",
         "$ref": "#/$defs/byte_array"
       },
       "signature": {
         "description": "Signature to verify",
         "$ref": "#/$defs/byte_array"
       },
+      "expected_signature": {
+        "description": "Expected signature from signing",
+        "$ref": "#/$defs/byte_array"
+      },
       "result": {
-        "description": "Verification result",
+        "description": "Expected test result",
         "type": "boolean"
       }
     }

--- a/sw/host/cryptotest/testvectors/parsers/BUILD
+++ b/sw/host/cryptotest/testvectors/parsers/BUILD
@@ -199,6 +199,14 @@ py_binary(
 )
 
 py_binary(
+    name = "nist_acvp_eddsa_parser",
+    srcs = ["nist_acvp_eddsa_parser.py"],
+    deps = [
+        requirement("jsonschema"),
+    ],
+)
+
+py_binary(
     name = "wycheproof_rsa_parser",
     srcs = ["wycheproof_rsa_parser.py"],
     deps = [

--- a/sw/host/cryptotest/testvectors/parsers/nist_acvp_eddsa_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/nist_acvp_eddsa_parser.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parser for converting ACVP EdDSA testvectors to JSON.
+
+Uses the internalProjection files from the NIST ACVP-Server repo.
+Only Ed25519ph (preHash=true) is supported, since the cryptolib only
+implements HashEdDSA mode.
+
+For SigVer, the parser pre-hashes the message with SHA-512 so the
+firmware receives the 64-byte digest directly.
+
+For SigGen, the parser pre-hashes the message and emits the private
+key, context, and expected signature.
+"""
+
+import argparse
+import hashlib
+import json
+import sys
+
+import jsonschema
+
+
+def parse_sigver(data):
+    """Parse EDDSA-SigVer internalProjection.
+
+    Only Ed25519 with preHash=true (Ed25519ph / HashEdDSA) is selected.
+    The message is pre-hashed with SHA-512 before output.
+    """
+    test_vectors = []
+    for group in data["testGroups"]:
+        if group["curve"] != "ED-25519":
+            continue
+        if not group.get("preHash", False):
+            continue
+
+        for test in group["tests"]:
+            msg_bytes = bytes.fromhex(test["message"])
+            prehash = hashlib.sha512(msg_bytes).digest()
+            test_vectors.append({
+                "vendor": "acvp",
+                "test_case_id": test["tcId"],
+                "algorithm": "ed25519",
+                "operation": "verify",
+                "message": list(prehash),
+                "public_key": list(bytes.fromhex(test["q"])),
+                "signature": list(bytes.fromhex(test["signature"])),
+                "result": test["testPassed"],
+            })
+    return test_vectors
+
+
+def parse_siggen(data):
+    """Parse EDDSA-SigGen internalProjection.
+
+    Only Ed25519 with preHash=true (Ed25519ph / HashEdDSA) is selected.
+    The message is pre-hashed with SHA-512 before output.
+    """
+    test_vectors = []
+    for group in data["testGroups"]:
+        if group["curve"] != "ED-25519":
+            continue
+        if not group.get("preHash", False):
+            continue
+
+        d = list(bytes.fromhex(group["d"]))
+        q = list(bytes.fromhex(group["q"]))
+        for test in group["tests"]:
+            msg_bytes = bytes.fromhex(test["message"])
+            prehash = hashlib.sha512(msg_bytes).digest()
+            context = list(bytes.fromhex(test.get("context", "")))
+            test_vectors.append({
+                "vendor": "acvp",
+                "test_case_id": test["tcId"],
+                "algorithm": "ed25519",
+                "operation": "sign",
+                "private_key": d,
+                "public_key": q,
+                "message": list(prehash),
+                "context": context,
+                "expected_signature": list(bytes.fromhex(test["signature"])),
+                "result": True,
+            })
+    return test_vectors
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--src",
+        metavar="FILE",
+        type=argparse.FileType("r"),
+        help="Read test vectors from this JSON file.",
+    )
+    parser.add_argument(
+        "--dst",
+        metavar="FILE",
+        type=argparse.FileType("w"),
+        help="Write output to this file.",
+    )
+    parser.add_argument(
+        "--schema",
+        type=str,
+        help="Testvector schema file",
+    )
+    parser.add_argument(
+        "--test-type",
+        type=str,
+        choices=["sigver", "siggen"],
+        required=True,
+        help="Type of test vectors to parse",
+    )
+    args = parser.parse_args()
+
+    data = json.load(args.src)
+    args.src.close()
+
+    if args.test_type == "sigver":
+        testvecs = parse_sigver(data)
+    elif args.test_type == "siggen":
+        testvecs = parse_siggen(data)
+
+    # Validate generated JSON
+    with open(args.schema) as schema_file:
+        schema = json.load(schema_file)
+    jsonschema.validate(testvecs, schema)
+
+    print(f"Created {len(testvecs)} tests", file=sys.stderr)
+    json.dump(testvecs, args.dst)
+    args.dst.close()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sw/host/cryptotest/ujson_lib/BUILD
+++ b/sw/host/cryptotest/ujson_lib/BUILD
@@ -77,6 +77,11 @@ ujson_rust(
     srcs = ["//sw/device/tests/crypto/cryptotest/json:sphincsplus_commands"],
 )
 
+ujson_rust(
+    name = "ed25519_commands_rust",
+    srcs = ["//sw/device/tests/crypto/cryptotest/json:ed25519_commands"],
+)
+
 rust_library(
     name = "cryptotest_commands",
     srcs = [
@@ -87,6 +92,7 @@ rust_library(
         "src/drbg_commands.rs",
         "src/ecdh_commands.rs",
         "src/ecdsa_commands.rs",
+        "src/ed25519_commands.rs",
         "src/hash_commands.rs",
         "src/hmac_commands.rs",
         "src/kmac_commands.rs",
@@ -111,6 +117,7 @@ rust_library(
         ":mlkem_commands_rust",
         ":rsa_commands_rust",
         ":sphincsplus_commands_rust",
+        ":ed25519_commands_rust",
     ],
     rustc_env = {
         "commands_loc": "$(execpath :commands_rust)",
@@ -127,6 +134,7 @@ rust_library(
         "mlkem_commands_loc": "$(execpath :mlkem_commands_rust)",
         "rsa_commands_loc": "$(execpath :rsa_commands_rust)",
         "sphincsplus_commands_loc": "$(execpath :sphincsplus_commands_rust)",
+        "ed25519_commands_loc": "$(execpath :ed25519_commands_rust)",
     },
     deps = [
         "//sw/host/opentitanlib",

--- a/sw/host/cryptotest/ujson_lib/src/ed25519_commands.rs
+++ b/sw/host/cryptotest/ujson_lib/src/ed25519_commands.rs
@@ -1,0 +1,4 @@
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+include!(env!("ed25519_commands_loc"));

--- a/sw/host/cryptotest/ujson_lib/src/lib.rs
+++ b/sw/host/cryptotest/ujson_lib/src/lib.rs
@@ -8,6 +8,7 @@ pub mod commands;
 pub mod drbg_commands;
 pub mod ecdh_commands;
 pub mod ecdsa_commands;
+pub mod ed25519_commands;
 pub mod hash_commands;
 pub mod hmac_commands;
 pub mod kmac_commands;

--- a/sw/host/tests/crypto/ed25519_kat/BUILD
+++ b/sw/host/tests/crypto/ed25519_kat/BUILD
@@ -1,0 +1,23 @@
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+load("@rules_rust//rust:defs.bzl", "rust_binary")
+
+package(default_visibility = ["//visibility:public"])
+
+rust_binary(
+    name = "harness",
+    srcs = ["src/main.rs"],
+    deps = [
+        "//sw/host/cryptotest/ujson_lib:cryptotest_commands",
+        "//sw/host/opentitanlib",
+        "@crate_index//:anyhow",
+        "@crate_index//:arrayvec",
+        "@crate_index//:clap",
+        "@crate_index//:humantime",
+        "@crate_index//:log",
+        "@crate_index//:serde",
+        "@crate_index//:serde_json",
+    ],
+)

--- a/sw/host/tests/crypto/ed25519_kat/src/main.rs
+++ b/sw/host/tests/crypto/ed25519_kat/src/main.rs
@@ -1,0 +1,207 @@
+// Copyright zeroRISC Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use arrayvec::ArrayVec;
+use clap::Parser;
+use serde::Deserialize;
+use std::fs;
+use std::time::Duration;
+
+use cryptotest_commands::commands::CryptotestCommand;
+use cryptotest_commands::ed25519_commands::{
+    CryptotestEd25519Message, CryptotestEd25519PublicKey, CryptotestEd25519SiggenData,
+    CryptotestEd25519SiggenOutput, CryptotestEd25519Signature, CryptotestEd25519VerifyOutput,
+    Ed25519Subcommand,
+};
+
+use opentitanlib::app::TransportWrapper;
+use opentitanlib::console::spi::SpiConsoleDevice;
+use opentitanlib::execute_test;
+use opentitanlib::test_utils::init::InitializeTest;
+use opentitanlib::test_utils::rpc::{ConsoleRecv, ConsoleSend};
+use opentitanlib::uart::console::UartConsole;
+
+#[derive(Debug, Parser)]
+struct Opts {
+    #[command(flatten)]
+    init: InitializeTest,
+
+    // Console receive timeout.
+    #[arg(long, value_parser = humantime::parse_duration, default_value = "10s")]
+    timeout: Duration,
+
+    #[arg(long, num_args = 1..)]
+    ed25519_json: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Ed25519TestCase {
+    #[serde(default)]
+    vendor: String,
+    #[serde(default)]
+    test_case_id: usize,
+    algorithm: String,
+    operation: String,
+    message: Vec<u8>,
+    #[serde(default)]
+    public_key: Vec<u8>,
+    #[serde(default)]
+    signature: Vec<u8>,
+    #[serde(default)]
+    private_key: Vec<u8>,
+    #[serde(default)]
+    context: Vec<u8>,
+    #[serde(default)]
+    expected_signature: Vec<u8>,
+    result: bool,
+}
+
+fn run_ed25519_verify(
+    test_case: &Ed25519TestCase,
+    opts: &Opts,
+    spi_console: &SpiConsoleDevice,
+) -> Result<bool> {
+    Ed25519Subcommand::Ed25519Sigver.send(spi_console)?;
+
+    let mut input = ArrayVec::new();
+    input.try_extend_from_slice(&test_case.message)?;
+    CryptotestEd25519Message {
+        input,
+        input_len: test_case.message.len(),
+    }
+    .send(spi_console)?;
+
+    let mut signature = ArrayVec::new();
+    signature.try_extend_from_slice(&test_case.signature)?;
+    CryptotestEd25519Signature {
+        signature,
+        signature_len: test_case.signature.len(),
+    }
+    .send(spi_console)?;
+
+    let mut pk = ArrayVec::new();
+    pk.try_extend_from_slice(&test_case.public_key)?;
+    CryptotestEd25519PublicKey {
+        pk,
+        pk_len: test_case.public_key.len(),
+    }
+    .send(spi_console)?;
+
+    let output = CryptotestEd25519VerifyOutput::recv(spi_console, opts.timeout, false)?;
+    Ok(match output {
+        CryptotestEd25519VerifyOutput::Success => true,
+        CryptotestEd25519VerifyOutput::Failure => false,
+        CryptotestEd25519VerifyOutput::IntValue(i) => {
+            panic!("Invalid Ed25519 verify result: {}", i)
+        }
+    })
+}
+
+fn run_ed25519_sign(
+    test_case: &Ed25519TestCase,
+    opts: &Opts,
+    spi_console: &SpiConsoleDevice,
+) -> Result<bool> {
+    Ed25519Subcommand::Ed25519Siggen.send(spi_console)?;
+
+    let mut sk = ArrayVec::new();
+    sk.try_extend_from_slice(&test_case.private_key)?;
+    let mut pk = ArrayVec::new();
+    pk.try_extend_from_slice(&test_case.public_key)?;
+    let mut message = ArrayVec::new();
+    message.try_extend_from_slice(&test_case.message)?;
+    let mut context = ArrayVec::new();
+    context.try_extend_from_slice(&test_case.context)?;
+    CryptotestEd25519SiggenData {
+        sk,
+        sk_len: test_case.private_key.len(),
+        pk,
+        pk_len: test_case.public_key.len(),
+        message,
+        message_len: test_case.message.len(),
+        context,
+        context_len: test_case.context.len(),
+    }
+    .send(spi_console)?;
+
+    let output = CryptotestEd25519SiggenOutput::recv(spi_console, opts.timeout, false)?;
+    Ok(output.success == test_case.result
+        && output.signature[..output.signature_len] == *test_case.expected_signature)
+}
+
+fn run_ed25519_testcase(
+    test_case: &Ed25519TestCase,
+    opts: &Opts,
+    spi_console: &SpiConsoleDevice,
+    failures: &mut Vec<String>,
+) -> Result<()> {
+    log::info!(
+        "vendor: {}, test case: {}, operation: {}",
+        test_case.vendor,
+        test_case.test_case_id,
+        test_case.operation
+    );
+    assert_eq!(test_case.algorithm.as_str(), "ed25519");
+
+    CryptotestCommand::Ed25519.send(spi_console)?;
+
+    let success = match test_case.operation.as_str() {
+        "verify" => run_ed25519_verify(test_case, opts, spi_console)?,
+        "sign" => run_ed25519_sign(test_case, opts, spi_console)?,
+        _ => panic!("Unsupported Ed25519 operation: {}", test_case.operation),
+    };
+
+    if test_case.result != success {
+        log::info!(
+            "FAILED test #{}: expected = {}, actual = {}",
+            test_case.test_case_id,
+            test_case.result,
+            success
+        );
+        failures.push(format!(
+            "ed25519 {} #{}",
+            test_case.operation, test_case.test_case_id
+        ));
+    }
+    Ok(())
+}
+
+fn test_ed25519(opts: &Opts, transport: &TransportWrapper) -> Result<()> {
+    let spi = transport.spi("BOOTSTRAP")?;
+    let spi_console_device = SpiConsoleDevice::new(&*spi, None)?;
+    let _ = UartConsole::wait_for(&spi_console_device, r"Running ", opts.timeout)?;
+
+    let mut test_counter = 0u32;
+    let mut failures = vec![];
+    let test_vector_files = &opts.ed25519_json;
+    for file in test_vector_files {
+        let raw_json = fs::read_to_string(file)?;
+        let ed25519_tests: Vec<Ed25519TestCase> = serde_json::from_str(&raw_json)?;
+
+        for ed25519_test in &ed25519_tests {
+            test_counter += 1;
+            log::info!("Test counter: {}", test_counter);
+            run_ed25519_testcase(ed25519_test, opts, &spi_console_device, &mut failures)?;
+        }
+    }
+    assert_eq!(
+        0,
+        failures.len(),
+        "Failed {} out of {} tests. Failures: {:?}",
+        failures.len(),
+        test_counter,
+        failures
+    );
+    Ok(())
+}
+
+fn main() -> Result<()> {
+    let opts = Opts::parse();
+    opts.init.init_logging();
+
+    let transport = opts.init.init_target()?;
+    execute_test!(test_ed25519, &opts, &transport);
+    Ok(())
+}


### PR DESCRIPTION
This PR adds ACVP-based Ed25519 tests. As of now the cryptolib only implements HashEd25519.
ACVP has testvectors for both pure Ed25519 and HashEd25519, while Wycheproof only has pure Ed25519 vectors.

The ACVP testvectors revealed two minor bugs regarding the context strings that the cryptolib could handle; those are fixed in separate commits.
See individual commit messages for the details.
