### PR TITLE
[crypto] Update `otcrypto_interface.h` and backport map file analysis 

### DIFF
--- a/sw/device/silicon_owner/bare_metal/BUILD
+++ b/sw/device/silicon_owner/bare_metal/BUILD
@@ -9,6 +9,11 @@ load("//rules/opentitan:defs.bzl", "fpga_params", "opentitan_binary", "opentitan
 
 package(default_visibility = ["//visibility:public"])
 
+filegroup(
+    name = "bare_metal_start",
+    srcs = ["bare_metal_start.S"],
+)
+
 ld_library(
     name = "ld_common",
     includes = ["bare_metal_common.ld"],

--- a/sw/device/silicon_owner/bare_metal/bare_metal_common.ld
+++ b/sw/device/silicon_owner/bare_metal/bare_metal_common.ld
@@ -104,12 +104,6 @@ SECTIONS {
   } > owner_flash
 
   /**
-   * Critical static data that is accessible by both the ROM and the ROM
-   * extension.
-   */
-  INCLUDE sw/device/silicon_creator/lib/base/static_critical.ld
-
-  /**
    * Mutable data section, at the bottom of ram_main. This will be initialized
    * from flash at runtime by the CRT.
    *

--- a/sw/device/tests/crypto/BUILD
+++ b/sw/device/tests/crypto/BUILD
@@ -42,14 +42,24 @@ cc_library(
     ],
 )
 
-cc_binary(
+opentitan_binary(
     name = "otcrypto_export_size",
-    srcs = ["otcrypto_export_size.c"],
+    testonly = True,
+    srcs = [
+        "otcrypto_export_size.c",
+        "//sw/device/silicon_owner/bare_metal:bare_metal_start",
+    ],
     # Disable link-time optimization to preserve unused cryptolib functions.
     copts = ["-fno-lto"],
+    exec_env = [
+        "//hw/top_earlgrey:fpga_cw310_rom_ext",
+    ],
+    linker_script = "//sw/device/silicon_owner/bare_metal:ld_slot_a",
+    manifest = "//sw/device/silicon_owner/bare_metal:manifest",
     deps = [
         ":otcrypto_interface",
-        "//sw/device/lib/arch:silicon",
+        "//sw/device/lib/crt",
+        "//sw/device/silicon_creator/lib:manifest_def",
     ],
 )
 

--- a/sw/device/tests/crypto/otcrypto_export_size.c
+++ b/sw/device/tests/crypto/otcrypto_export_size.c
@@ -5,12 +5,4 @@
 #include "sw/device/tests/crypto/otcrypto_interface.h"
 
 // Simple main function so the linker doesn't discard the inerface struct.
-int main(void) {
-  uint32_t digest_data[8];
-  otcrypto_hash_digest_t digest = {.data = digest_data, .len = 8};
-  otcrypto.sha2_256((otcrypto_const_byte_buf_t){.data = NULL, .len = 0},
-                    &digest);
-
-  // SHA256('') is a constant value; this will always be 0.
-  return digest_data[0] & 1;
-}
+void bare_metal_main(void) { (void)otcrypto; }

--- a/sw/device/tests/crypto/otcrypto_interface.c
+++ b/sw/device/tests/crypto/otcrypto_interface.c
@@ -5,7 +5,7 @@
 
 #include "sw/device/tests/crypto/otcrypto_interface.h"
 
-const otcrypto_interface_t otcrypto = {
+volatile otcrypto_interface_t otcrypto = {
     // Symmetric key generation.
     .symmetric_keygen = &otcrypto_symmetric_keygen,
     .hw_backed_key = &otcrypto_hw_backed_key,

--- a/sw/device/tests/crypto/otcrypto_interface.h
+++ b/sw/device/tests/crypto/otcrypto_interface.h
@@ -19,7 +19,7 @@ typedef struct otcrypto_interface_t {
   // Key utilities
   otcrypto_status_t (*symmetric_keygen)(otcrypto_const_byte_buf_t,
                                         otcrypto_blinded_key_t *);
-  otcrypto_status_t (*hw_backed_key)(uint32_t, const uint32_t salt[7],
+  otcrypto_status_t (*hw_backed_key)(uint32_t, otcrypto_const_word32_buf_t,
                                      otcrypto_blinded_key_t *);
   otcrypto_status_t (*wrapped_key_len)(const otcrypto_key_config_t, size_t *);
   otcrypto_status_t (*key_wrap)(const otcrypto_blinded_key_t *,
@@ -180,21 +180,23 @@ typedef struct otcrypto_interface_t {
                                       otcrypto_const_word32_buf_t,
                                       hardened_bool_t *);
   otcrypto_status_t (*ed25519_keygen_async_start)(
-      const otcrypto_blinded_key_t *);
+      const otcrypto_blinded_key_t *, otcrypto_session_token_t *);
   otcrypto_status_t (*ed25519_keygen_async_finalize)(
-      otcrypto_blinded_key_t *, otcrypto_unblinded_key_t *);
+      otcrypto_session_token_t, otcrypto_blinded_key_t *,
+      otcrypto_unblinded_key_t *);
   otcrypto_status_t (*ed25519_sign_async_start)(const otcrypto_blinded_key_t *,
                                                 otcrypto_const_byte_buf_t,
                                                 otcrypto_const_byte_buf_t,
                                                 otcrypto_eddsa_sign_mode_t,
-                                                otcrypto_word32_buf_t);
-  otcrypto_status_t (*ed25519_sign_async_finalize)(otcrypto_word32_buf_t);
+                                                otcrypto_session_token_t *);
+  otcrypto_status_t (*ed25519_sign_async_finalize)(otcrypto_session_token_t,
+                                                   otcrypto_word32_buf_t);
   otcrypto_status_t (*ed25519_verify_async_start)(
       const otcrypto_unblinded_key_t *, otcrypto_const_byte_buf_t,
       otcrypto_const_byte_buf_t, otcrypto_eddsa_sign_mode_t,
-      otcrypto_const_word32_buf_t);
+      otcrypto_const_word32_buf_t, otcrypto_session_token_t *);
   otcrypto_status_t (*ed25519_verify_async_finalize)(
-      otcrypto_const_word32_buf_t, hardened_bool_t *);
+      otcrypto_const_word32_buf_t, otcrypto_session_token_t, hardened_bool_t *);
 
   // X25519
   otcrypto_status_t (*x25519_keygen)(otcrypto_blinded_key_t *,
@@ -232,14 +234,14 @@ typedef struct otcrypto_interface_t {
       otcrypto_const_word32_buf_t, otcrypto_const_word32_buf_t,
       otcrypto_const_word32_buf_t, otcrypto_const_word32_buf_t,
       otcrypto_const_word32_buf_t, const otcrypto_unblinded_key_t *,
-      hardened_bool_t, otcrypto_blinded_key_t *, hardened_bool_t *);
+      otcrypto_blinded_key_t *, hardened_bool_t *);
   otcrypto_status_t (*rsa_private_key_construct_and_check_async_start)(
       otcrypto_const_word32_buf_t, otcrypto_const_word32_buf_t,
       otcrypto_const_word32_buf_t, otcrypto_const_word32_buf_t,
       otcrypto_const_word32_buf_t, const otcrypto_unblinded_key_t *,
-      hardened_bool_t, otcrypto_blinded_key_t *, hardened_bool_t *);
+      otcrypto_blinded_key_t *, hardened_bool_t *, otcrypto_session_token_t *);
   otcrypto_status_t (*rsa_private_key_construct_and_check_async_finalize)(
-      const otcrypto_unblinded_key_t *, hardened_bool_t,
+      const otcrypto_unblinded_key_t *, otcrypto_session_token_t,
       otcrypto_blinded_key_t *, hardened_bool_t *);
   otcrypto_status_t (*rsa_private_key_deconstruct)(
       otcrypto_blinded_key_t *, otcrypto_word32_buf_t, otcrypto_word32_buf_t,
@@ -266,34 +268,44 @@ typedef struct otcrypto_interface_t {
                                    otcrypto_const_word32_buf_t,
                                    otcrypto_const_byte_buf_t,
                                    otcrypto_byte_buf_t, size_t *);
-  otcrypto_status_t (*rsa_keygen_async_start)(otcrypto_rsa_size_t);
-  otcrypto_status_t (*rsa_keygen_async_finalize)(otcrypto_unblinded_key_t *,
+  otcrypto_status_t (*rsa_keygen_async_start)(otcrypto_rsa_size_t,
+                                              otcrypto_session_token_t *);
+  otcrypto_status_t (*rsa_keygen_async_finalize)(otcrypto_session_token_t,
+                                                 otcrypto_unblinded_key_t *,
                                                  otcrypto_blinded_key_t *);
   otcrypto_status_t (*rsa_keypair_from_cofactor_async_start)(
       otcrypto_rsa_size_t, otcrypto_const_word32_buf_t, uint32_t,
-      otcrypto_const_word32_buf_t cofactor_share0,
-      otcrypto_const_word32_buf_t cofactor_share1);
+      otcrypto_const_word32_buf_t, otcrypto_const_word32_buf_t,
+      otcrypto_session_token_t *);
   otcrypto_status_t (*rsa_keypair_from_cofactor_async_finalize)(
-      otcrypto_unblinded_key_t *, otcrypto_blinded_key_t *);
+      otcrypto_session_token_t, otcrypto_unblinded_key_t *,
+      otcrypto_blinded_key_t *);
   otcrypto_status_t (*rsa_sign_async_start)(const otcrypto_blinded_key_t *,
                                             const otcrypto_hash_digest_t,
-                                            otcrypto_rsa_padding_t);
-  otcrypto_status_t (*rsa_sign_async_finalize)(otcrypto_word32_buf_t);
+                                            otcrypto_rsa_padding_t,
+                                            otcrypto_session_token_t *);
+  otcrypto_status_t (*rsa_sign_async_finalize)(otcrypto_session_token_t,
+                                               otcrypto_word32_buf_t);
   otcrypto_status_t (*rsa_verify_async_start)(const otcrypto_unblinded_key_t *,
-                                              otcrypto_const_word32_buf_t);
+                                              otcrypto_const_word32_buf_t,
+                                              otcrypto_session_token_t *);
   otcrypto_status_t (*rsa_verify_async_finalize)(
       const otcrypto_unblinded_key_t *, const otcrypto_hash_digest_t,
-      otcrypto_rsa_padding_t, hardened_bool_t *);
+      otcrypto_rsa_padding_t, otcrypto_session_token_t, hardened_bool_t *);
   otcrypto_status_t (*rsa_encrypt_async_start)(const otcrypto_unblinded_key_t *,
                                                const otcrypto_hash_mode_t,
                                                otcrypto_const_byte_buf_t,
-                                               otcrypto_const_byte_buf_t);
+                                               otcrypto_const_byte_buf_t,
+                                               otcrypto_session_token_t *);
   otcrypto_status_t (*rsa_encrypt_async_finalize)(
-      const otcrypto_unblinded_key_t *, otcrypto_word32_buf_t);
+      const otcrypto_unblinded_key_t *, otcrypto_session_token_t,
+      otcrypto_word32_buf_t);
   otcrypto_status_t (*rsa_decrypt_async_start)(const otcrypto_blinded_key_t *,
-                                               otcrypto_const_word32_buf_t);
+                                               otcrypto_const_word32_buf_t,
+                                               otcrypto_session_token_t *);
   otcrypto_status_t (*rsa_decrypt_async_finalize)(const otcrypto_hash_mode_t,
                                                   otcrypto_const_byte_buf_t,
+                                                  otcrypto_session_token_t,
                                                   otcrypto_byte_buf_t,
                                                   size_t *);
   // P-256
@@ -316,24 +328,30 @@ typedef struct otcrypto_interface_t {
                                  const otcrypto_unblinded_key_t *,
                                  otcrypto_blinded_key_t *);
   otcrypto_status_t (*ecdsa_p256_keygen_async_start)(
-      const otcrypto_blinded_key_t *);
+      const otcrypto_blinded_key_t *, otcrypto_session_token_t *);
   otcrypto_status_t (*ecdsa_p256_keygen_async_finalize)(
-      otcrypto_blinded_key_t *, otcrypto_unblinded_key_t *);
+      otcrypto_session_token_t, otcrypto_blinded_key_t *,
+      otcrypto_unblinded_key_t *);
   otcrypto_status_t (*ecdsa_p256_sign_async_start)(
-      const otcrypto_blinded_key_t *, const otcrypto_hash_digest_t);
-  otcrypto_status_t (*ecdsa_p256_sign_async_finalize)(otcrypto_word32_buf_t);
+      const otcrypto_blinded_key_t *, const otcrypto_hash_digest_t,
+      otcrypto_session_token_t *);
+  otcrypto_status_t (*ecdsa_p256_sign_async_finalize)(otcrypto_session_token_t,
+                                                      otcrypto_word32_buf_t);
   otcrypto_status_t (*ecdsa_p256_verify_async_start)(
       const otcrypto_unblinded_key_t *, const otcrypto_hash_digest_t,
-      otcrypto_const_word32_buf_t);
+      otcrypto_const_word32_buf_t, otcrypto_session_token_t *);
   otcrypto_status_t (*ecdsa_p256_verify_async_finalize)(
-      otcrypto_const_word32_buf_t, hardened_bool_t *);
+      otcrypto_const_word32_buf_t, otcrypto_session_token_t, hardened_bool_t *);
   otcrypto_status_t (*ecdh_p256_keygen_async_start)(
-      const otcrypto_blinded_key_t *);
+      const otcrypto_blinded_key_t *, otcrypto_session_token_t *);
   otcrypto_status_t (*ecdh_p256_keygen_async_finalize)(
-      otcrypto_blinded_key_t *, otcrypto_unblinded_key_t *);
+      otcrypto_session_token_t, otcrypto_blinded_key_t *,
+      otcrypto_unblinded_key_t *);
   otcrypto_status_t (*ecdh_p256_async_start)(const otcrypto_blinded_key_t *,
-                                             const otcrypto_unblinded_key_t *);
+                                             const otcrypto_unblinded_key_t *,
+                                             otcrypto_session_token_t *);
   otcrypto_status_t (*ecdh_p256_async_finalize)(const otcrypto_blinded_key_t *,
+                                                otcrypto_session_token_t,
                                                 otcrypto_blinded_key_t *);
 
   // P-384
@@ -356,24 +374,30 @@ typedef struct otcrypto_interface_t {
                                  const otcrypto_unblinded_key_t *,
                                  otcrypto_blinded_key_t *);
   otcrypto_status_t (*ecdsa_p384_keygen_async_start)(
-      const otcrypto_blinded_key_t *);
+      const otcrypto_blinded_key_t *, otcrypto_session_token_t *);
   otcrypto_status_t (*ecdsa_p384_keygen_async_finalize)(
-      otcrypto_blinded_key_t *, otcrypto_unblinded_key_t *);
+      otcrypto_session_token_t, otcrypto_blinded_key_t *,
+      otcrypto_unblinded_key_t *);
   otcrypto_status_t (*ecdsa_p384_sign_async_start)(
-      const otcrypto_blinded_key_t *, const otcrypto_hash_digest_t);
-  otcrypto_status_t (*ecdsa_p384_sign_async_finalize)(otcrypto_word32_buf_t);
+      const otcrypto_blinded_key_t *, const otcrypto_hash_digest_t,
+      otcrypto_session_token_t *);
+  otcrypto_status_t (*ecdsa_p384_sign_async_finalize)(otcrypto_session_token_t,
+                                                      otcrypto_word32_buf_t);
   otcrypto_status_t (*ecdsa_p384_verify_async_start)(
       const otcrypto_unblinded_key_t *, const otcrypto_hash_digest_t,
-      otcrypto_const_word32_buf_t);
+      otcrypto_const_word32_buf_t, otcrypto_session_token_t *);
   otcrypto_status_t (*ecdsa_p384_verify_async_finalize)(
-      otcrypto_const_word32_buf_t, hardened_bool_t *);
+      otcrypto_const_word32_buf_t, otcrypto_session_token_t, hardened_bool_t *);
   otcrypto_status_t (*ecdh_p384_keygen_async_start)(
-      const otcrypto_blinded_key_t *);
+      const otcrypto_blinded_key_t *, otcrypto_session_token_t *);
   otcrypto_status_t (*ecdh_p384_keygen_async_finalize)(
-      otcrypto_blinded_key_t *, otcrypto_unblinded_key_t *);
+      otcrypto_session_token_t, otcrypto_blinded_key_t *,
+      otcrypto_unblinded_key_t *);
   otcrypto_status_t (*ecdh_p384_async_start)(const otcrypto_blinded_key_t *,
-                                             const otcrypto_unblinded_key_t *);
+                                             const otcrypto_unblinded_key_t *,
+                                             otcrypto_session_token_t *);
   otcrypto_status_t (*ecdh_p384_async_finalize)(const otcrypto_blinded_key_t *,
+                                                otcrypto_session_token_t,
                                                 otcrypto_blinded_key_t *);
 
 } otcrypto_interface_t;

--- a/sw/device/tests/crypto/otcrypto_interface.h
+++ b/sw/device/tests/crypto/otcrypto_interface.h
@@ -402,7 +402,7 @@ typedef struct otcrypto_interface_t {
 
 } otcrypto_interface_t;
 
-extern const otcrypto_interface_t otcrypto;
+extern volatile otcrypto_interface_t otcrypto;
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/util/py/scripts/mapfile_to_json.py
+++ b/util/py/scripts/mapfile_to_json.py
@@ -23,7 +23,10 @@ parser.add_argument('--html',
 parser.add_argument('--regions',
                     default='rom,ram_main,eflash',
                     help='Which memory regions to analyze')
-parser.add_argument('mapfile',
+parser.add_argument('--target',
+                    default='',
+                    help='Bazel target to generate map file')
+parser.add_argument('--mapfile',
                     metavar='MAPFILE',
                     type=str,
                     help='Mapfile to process')
@@ -424,9 +427,35 @@ class Mapfile(object):
         return csz
 
 
+def generate_map(target):
+    # Define the Bazel command as a list of arguments
+    # bazel_cmd = ["bazel", "build", "//sw/device/tests/crypto:otcrypto_export_size"]
+    map_file = None
+    bazel_cmd = ["bazel", "build", target]
+    try:
+        result = subprocess.run(bazel_cmd, check=True, capture_output=True, text=True)
+        print(result)
+        # Search output for the .map file line
+        for line in result.stderr.splitlines():
+            print(line)
+            if line.strip().endswith('.map'):
+                # The file path is the whole line or first token
+                map_file = line.strip().split()[0]
+        print("Generate map file from target succeeded:\n", result.stdout)
+    except subprocess.CalledProcessError as e:
+        print("Generate map file from target failed:\n", e.stderr)
+
+    return map_file
+
+
 def main(args):
     m = Mapfile(regions=args.regions.split(','),
                 ignore_debug=args.ignore_debug)
+
+    if args.mapfile is None:
+        # If no mapfile is provided generate the map file from a bazel target.
+        args.mapfile = generate_map(args.target)
+
     m.parse(args.mapfile)
     if args.arrangement == 'region':
         regions = m.by_memory_region()


### PR DESCRIPTION
Our  `otcrypto_interface.h` is outdated (e.g., it was not updated in https://github.com/zerorisc/expo/pull/204) - `otcrypto_export_size`, hence, fails to compile.
This fixes that and also backports a changes to allow cryptolib map file analysis which as a side effect also causes this test to be picked up by our CI (at least that is what I hope - testing now). 