### PR TITLE
[acc] Add clobbered-register annotation checker

### DIFF
--- a/hw/ip/acc/util/BUILD
+++ b/hw/ip/acc/util/BUILD
@@ -40,6 +40,17 @@ py_binary(
 )
 
 py_binary(
+    name = "check_clobbered_regs",
+    srcs = ["check_clobbered_regs.py"],
+    deps = [
+        "//hw/ip/acc/util/shared:control_flow",
+        "//hw/ip/acc/util/shared:decode",
+        "//hw/ip/acc/util/shared:information_flow_analysis",
+        requirement("pyelftools"),
+    ],
+)
+
+py_binary(
     name = "check_const_time",
     srcs = ["check_const_time.py"],
     deps = [

--- a/hw/ip/acc/util/check_clobbered_regs.py
+++ b/hw/ip/acc/util/check_clobbered_regs.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# Copyright zeroRISC Inc.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+'''Check that clobbered-register annotations match actual writes.
+
+Runs the information-flow analysis on a single subroutine to generate the
+correct clobbered-register annotation, then compares against the docstring
+in the assembly source file.
+'''
+
+import argparse
+import re
+import sys
+from typing import Optional, Tuple
+
+from shared.control_flow import subroutine_control_graph
+from shared.decode import decode_elf
+from shared.information_flow_analysis import get_subroutine_iflow
+
+
+def _find_docstring(source_path: str, symbol: str) -> Optional[str]:
+    '''Find the /** ... */ docstring for a symbol in a source file.'''
+    with open(source_path, 'r') as f:
+        content = f.read()
+
+    label_m = re.search(
+        r'^' + re.escape(symbol) + r'\s*:', content, re.MULTILINE)
+    if label_m is None:
+        return None
+
+    before = content[:label_m.start()]
+    doc_m = None
+    for m in re.finditer(r'/\*\*.*?\*/', before, re.DOTALL):
+        doc_m = m
+    if doc_m is None or 'clobbered registers:' not in doc_m.group(0):
+        return None
+
+    between = content[doc_m.end():label_m.start()]
+    if re.search(r'^[a-zA-Z_]\w*\s*:', between, re.MULTILINE):
+        return None
+
+    return doc_m.group(0)
+
+
+def _extract_declared(doc: str) -> Tuple[str, str]:
+    '''Extract declared clobbered registers and flags from a docstring.'''
+    m = re.search(r'clobbered registers:\s*(.+)', doc)
+    regs = m.group(1).strip() if m else ''
+    m = re.search(r'clobbered flag groups:\s*(.+)', doc, re.IGNORECASE)
+    flags = m.group(1).strip() if m else ''
+    return regs, flags
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description='Check clobbered-register annotations in ACC assembly.')
+    parser.add_argument('elf', help='Path to the ACC ELF binary.')
+    parser.add_argument('--subroutine', required=True,
+                        help='Subroutine to check.')
+    parser.add_argument('--source', '-s', required=True,
+                        help='Assembly source file (.s).')
+    args = parser.parse_args()
+
+    program = decode_elf(args.elf)
+
+    doc = _find_docstring(args.source, args.subroutine)
+    if doc is None:
+        print('No clobbered-registers docstring found for {}'.format(
+            args.subroutine), file=sys.stderr)
+        return 1
+
+    declared_regs, declared_flags = _extract_declared(doc)
+
+    # Generate actual clobbers via information-flow analysis.
+    graph = subroutine_control_graph(program, args.subroutine)
+    ret_iflow, _, _ = get_subroutine_iflow(
+        program, graph, args.subroutine, {})
+    if not ret_iflow.exists:
+        print('No return paths found for {}'.format(
+            args.subroutine), file=sys.stderr)
+        return 1
+
+    lines = ret_iflow.clobbered().split('\n')
+    gen_regs = lines[0].replace('* clobbered registers: ', '')
+    gen_flags = lines[1].replace('* clobbered flag groups: ', '')
+
+    regs_match = gen_regs == declared_regs
+    flags_match = gen_flags == declared_flags
+    if not (regs_match and flags_match):
+        print('{}:'.format(args.subroutine))
+        if not regs_match:
+            print('  declared: clobbered registers: {}'.format(declared_regs))
+            print('  actual:   clobbered registers: {}'.format(gen_regs))
+        if not flags_match:
+            print('  declared: clobbered flag groups: {}'.format(
+                declared_flags))
+            print('  actual:   clobbered flag groups: {}'.format(gen_flags))
+        return 1
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/rules/acc.bzl
+++ b/rules/acc.bzl
@@ -581,6 +581,46 @@ acc_consttime_test = rule(
     },
 )
 
+def _acc_clobbered_regs_test_impl(ctx):
+    """Check that a subroutine's clobbered-register annotation is correct."""
+    elf = [f for t in ctx.attr.deps for f in t[OutputGroupInfo].elf.to_list()]
+    if len(elf) != 1:
+        fail("Expected only one .elf file in dependencies, got: " + str(elf))
+    elf = elf[0]
+
+    if len(ctx.files.srcs) != 1:
+        fail("Expected exactly one source file, got: " + str(ctx.files.srcs))
+    src = ctx.files.srcs[0]
+    script_content = "{checker} {elf} --subroutine {sub} --source {src}".format(
+        checker = ctx.executable._checker.short_path,
+        elf = elf.short_path,
+        sub = ctx.attr.subroutine,
+        src = src.short_path,
+    )
+    ctx.actions.write(
+        output = ctx.outputs.executable,
+        content = script_content,
+    )
+
+    runfiles = ctx.runfiles(files = [elf] + ctx.files.srcs)
+    runfiles = runfiles.merge(ctx.attr._checker[DefaultInfo].default_runfiles)
+    return [DefaultInfo(runfiles = runfiles)]
+
+acc_clobbered_regs_test = rule(
+    implementation = _acc_clobbered_regs_test_impl,
+    test = True,
+    attrs = {
+        "srcs": attr.label_list(allow_files = True),
+        "deps": attr.label_list(providers = [OutputGroupInfo]),
+        "subroutine": attr.string(mandatory = True),
+        "_checker": attr.label(
+            default = "//hw/ip/acc/util:check_clobbered_regs",
+            executable = True,
+            cfg = "exec",
+        ),
+    },
+)
+
 acc_insn_count_range = rule(
     implementation = _acc_insn_count_range,
     attrs = {

--- a/sw/acc/crypto/boot.s
+++ b/sw/acc/crypto/boot.s
@@ -258,7 +258,7 @@ attestation_key_save:
  * @param[out]  w10: Lower 256 bits of first share of secret key (d1)
  * @param[out]  w11: Upper 64 bits of second share of secret key (d1)
  *
- * clobbered registers: x2, x3, x20, w1 to w4, w10, w11, w20 to w29
+ * clobbered registers: x2 to x3, w1 to w4, w10 to w11, w20 to w29, w31
  * clobbered flag groups: FG0
  */
 attestation_secret_key_from_seed:

--- a/sw/acc/crypto/ed25519.s
+++ b/sw/acc/crypto/ed25519.s
@@ -71,7 +71,7 @@
  * @param[in]  dmem[ed25519_public_key]: encoded public key A_, 256 bits
  * @param[out] dmem[ed25519_verify_result]: SUCCESS or FAILURE
  *
- * clobbered registers: x2 to x4, x20 to x23, w1 to w30
+ * clobbered registers: x2 to x4, x20 to x23, w1 to w30, acc, mod
  * clobbered flag groups: FG0
  */
 .globl ed25519_verify_var
@@ -266,7 +266,7 @@ ed25519_verify_var:
  * @param[out] dmem[ed25519_sig_R]: R component of signature (256 bits)
  * @param[out] dmem[ed25519_sig_S]: S component of signature (256 bits)
  *
- * clobbered registers: x2 to x4, x20 to x23, w1 to w30
+ * clobbered registers: x2 to x5, x10 to x23, x28, w0 to w31, acc, mod
  * clobbered flag groups: FG0
  */
 .globl ed25519_sign_prehashed
@@ -518,7 +518,7 @@ ed25519_sign_prehashed:
  * @param[in]  w31: all-zero
  * @param[out] w16: output s
  *
- * clobbered registers: w16, w17
+ * clobbered registers: w16 to w17
  * clobbered flag groups: FG0
  */
 sc_clamp:
@@ -572,7 +572,7 @@ sc_clamp:
  * @param[out] w8: output Z (Z < p)
  * @param[out] w9: output T (T < p)
  *
- * clobbered registers: w6 to w9, w18, w20 to w23
+ * clobbered registers: w8 to w9, w18, w20, w22 to w23, acc
  * clobbered flag groups: FG0
  */
 affine_to_ext:
@@ -618,7 +618,7 @@ affine_to_ext:
  * @param[out] w10: output x (x < p)
  * @param[out] w11: output y (y < p)
  *
- * clobbered registers: w10, w11, w14 to w18, w20 to w23
+ * clobbered registers: w10 to w11, w14 to w18, w20 to w23, acc
  * clobbered flag groups: FG0
  */
 ext_to_affine:
@@ -666,7 +666,7 @@ ext_to_affine:
  * @param[in]  w31: all-zero
  * @param[out] w11: enc, resulting encoded point
  *
- * clobbered registers: w10, w11
+ * clobbered registers: w10 to w11
  * clobbered flag groups: FG0
  */
 .globl affine_encode
@@ -711,7 +711,7 @@ affine_encode:
  * @param[out] w10: output x (x < p) (only valid if x20=SUCCESS)
  * @param[out] w11: output y (y < p) (only valid if x20=SUCCESS)
  *
- * clobbered registers: w10, w11, w14 to w18, w20 to w28
+ * clobbered registers: x2 to x3, x20, w10 to w11, w14 to w18, w20 to w28, acc
  * clobbered flag groups: FG0
  */
 .globl affine_decode_var
@@ -1001,7 +1001,7 @@ affine_decode_var:
  * @param[out] w12: output Z2
  * @param[out] w13: output T2
  *
- * clobbered registers: w10 to w18, w20 to w28
+ * clobbered registers: w6 to w18, w20 to w28, acc
  * clobbered flag groups: FG0
  */
 .globl ext_scmul
@@ -1105,7 +1105,7 @@ ext_scmul:
  * @param[out] w12: output Z2
  * @param[out] w13: output T2
  *
- * clobbered registers: w10 to w18, w20 to w28
+ * clobbered registers: x2, w10 to w18, w20 to w28, acc
  * clobbered flag groups: FG0
  */
 .globl ext_scmul_var
@@ -1200,7 +1200,7 @@ ext_scmul_var:
  * @param[in,out] w12: input Z1 (Z1 < p), output Z3
  * @param[in,out] w13: input T1 (T1 < p), output T3
  *
- * clobbered registers: w10 to w18, w20 to w27
+ * clobbered registers: w10 to w13, w17 to w18, w20 to w25, w27, acc
  * clobbered flag groups: FG0
  */
 .globl ext_double
@@ -1303,7 +1303,7 @@ ext_double:
  * @param[in]     w16: input Z2 (Z2 < p)
  * @param[in]     w17: input T2 (T2 < p)
  *
- * clobbered registers: w10 to w13, w18, w20 to w23, w24 to w27
+ * clobbered registers: w10 to w13, w18, w20, w22 to w27, acc
  * clobbered flag groups: FG0
  */
 .globl ext_add
@@ -1430,7 +1430,7 @@ ext_add:
  * @param[in]  MOD: p, modulus = 2^255 - 19
  * @param[out] dmem[ed25519_verify_result]: result, SUCCESS or FAILURE
  *
- * clobbered registers: w14 to w17
+ * clobbered registers: x2 to x4, x22 to x23, w16, w18, w20, w22 to w23, acc
  * clobbered flag groups: FG0
  */
 ext_equal_var:
@@ -1546,7 +1546,7 @@ ext_equal_var:
  * @param[in]  w31: all-zero
  * @param[out] w22: c, result
  *
- * clobbered registers: w14, w15, w17, w18, w20 to w23
+ * clobbered registers: w14 to w15, w17 to w18, w20 to w23, acc
  * clobbered flag groups: FG0
  */
 fe_pow_2252m3:

--- a/sw/acc/crypto/ed25519_scalar.s
+++ b/sw/acc/crypto/ed25519_scalar.s
@@ -26,7 +26,7 @@
  * @param[out] [w15:w14]: mu = floor(2^512 / L) (precomputed constant)
  * @param[out] MOD: L, modulus
  *
- * clobbered registers: x2, x3, w14, w15, MOD
+ * clobbered registers: x2 to x3, w14 to w15, mod
  * clobbered flag groups: FG0
  */
 .globl sc_init
@@ -122,7 +122,7 @@ sc_init:
  * @param[in]  w31: all-zero
  * @param[out] w18: c, result = a mod L
  *
- * clobbered registers: w10 to w13, w18
+ * clobbered registers: w10 to w13, w18, acc
  * clobbered flag groups: FG0
  */
 .globl sc_reduce
@@ -253,7 +253,7 @@ sc_reduce:
  * @param[in]  w31: all-zero
  * @param[out] w18: c, result = (a * b) mod L
  *
- * clobbered registers: w10 to w13, w16 to w18
+ * clobbered registers: w10 to w13, w16 to w18, acc
  * clobbered flag groups: FG0
  */
 .globl sc_mul

--- a/sw/acc/crypto/field25519.s
+++ b/sw/acc/crypto/field25519.s
@@ -21,7 +21,7 @@
  * @param[out] w30: 38, constant
  * @param[out] MOD: p=2^255-19, modulus
  *
- * clobbered registers: x2, x3, w19, MOD
+ * clobbered registers: x2 to x3, w19, w30, mod
  * clobbered flag groups: FG0
  */
 .globl fe_init
@@ -55,7 +55,7 @@ fe_init:
  * @param[in]  MOD: p, modulus = 2^255 - 19
  * @param[out] w22: c, result
  *
- * clobbered registers: w18, w20 to w22
+ * clobbered registers: w18, w20, w22, acc
  * clobbered flag groups: FG0
  */
 .globl fe_mul
@@ -167,7 +167,7 @@ fe_mul:
  * @param[in]  MOD: p, modulus = 2^255 - 19
  * @param[out] w22: c, result
  *
- * clobbered registers: w17, w18, w20 to w22
+ * clobbered registers: w17 to w18, w20 to w22, acc
  * clobbered flag groups: FG0
  */
 .globl fe_square
@@ -295,7 +295,7 @@ fe_square:
  * @param[in]  w31: all-zero
  * @param[out] w22: c, result
  *
- * clobbered registers: w14, w15, w17, w18, w20 to w23
+ * clobbered registers: w14 to w15, w17 to w18, w20 to w23, acc
  * clobbered flag groups: FG0
  */
 .globl fe_inv

--- a/sw/acc/crypto/montmul.s
+++ b/sw/acc/crypto/montmul.s
@@ -41,7 +41,7 @@
  * @param[in]  w31: all-zero.
  * @param[out] w29: m0', negative of inverse of m0 in GF(2^256)
  *
- * clobbered registers: w0, w1, w29
+ * clobbered registers: w0 to w1, w29, acc
  * clobbered flag groups: FG0
  */
 m0inv:
@@ -268,8 +268,8 @@ compute_rr:
  * @param[in] w25: b, second operand
  * @param[out] [w26, w27]: c, result
  *
- * clobbered registers: w26, w27
- * clobbered flag groups: none
+ * clobbered registers: w26 to w27, acc
+ * clobbered flag groups: FG0
  */
 mul256_w30xw25:
   bn.mulqacc.z          w30.0, w25.0,  0
@@ -303,8 +303,8 @@ mul256_w30xw25:
  * @param[in] w2: b, second operand
  * @param[out] [w26, w27]: c, result
  *
- * clobbered registers: w26, w27
- * clobbered flag groups: none
+ * clobbered registers: w26 to w27, acc
+ * clobbered flag groups: FG0
  */
 mul256_w30xw2:
   bn.mulqacc.z          w30.0, w2.0,  0

--- a/sw/acc/crypto/mul.s
+++ b/sw/acc/crypto/mul.s
@@ -209,8 +209,8 @@ bignum_mul256:
  * @param[in] w21: b, second operand
  * @param[out] [w22, w23]: c, result
  *
- * clobbered registers: w22, w23
- * clobbered flag groups: None
+ * clobbered registers: w22 to w23, acc
+ * clobbered flag groups: FG0
  */
 mul256_w20xw21:
   bn.mulqacc.z          w20.0, w21.0,  0

--- a/sw/acc/crypto/p256_base.s
+++ b/sw/acc/crypto/p256_base.s
@@ -47,8 +47,8 @@
  * @param[in]    w31: all-zero
  * @param[in]  FG0.Z: boolean indicating fault condition
  *
- * clobbered registers: x2
- * clobbered flag groups: none
+ * clobbered registers: x2 to x3, w31
+ * clobbered flag groups: FG0
  */
 trigger_fault_if_fg0_z:
   /* Read the FG0.Z flag (position 3).
@@ -88,8 +88,8 @@ trigger_fault_if_fg0_z:
  * @param[in]    w31: all-zero
  * @param[in]  FG0.Z: boolean indicating (complement of) fault condition
  *
- * clobbered registers: x2
- * clobbered flag groups: none
+ * clobbered registers: x2 to x3, w31
+ * clobbered flag groups: FG0
  */
 trigger_fault_if_fg0_not_z:
   /* Read the FG0.Z flag (position 3).
@@ -158,7 +158,7 @@ trigger_fault_if_fg0_not_z:
  * @param[in]  MOD: m, modulus
  * @param[out]  w19: c, result
  *
- * clobbered registers: w19, w20, w21, w22, w23, w24, w25
+ * clobbered registers: w19 to w25, w31, acc
  * clobbered flag groups: FG0
  */
 p256_reduce:
@@ -303,7 +303,7 @@ p256_reduce:
  * @param[in]  MOD: p, modulus of P-256 underlying finite field
  * @param[out]  w19: c, result
  *
- * clobbered registers: w19, w20, w21, w22, w23, w24, w25
+ * clobbered registers: w19 to w25, w31, acc
  * clobbered flag groups: FG0
  */
 mod_mul_256x256:
@@ -364,7 +364,7 @@ mod_mul_256x256:
  * @param[in]  MOD: p, modulus of P-256 underlying finite field
  * @param[out]  w19: c, result
  *
- * clobbered registers: w19, w20, w21, w22, w23, w24, w25
+ * clobbered registers: w19 to w25, w31, acc
  * clobbered flag groups: FG0
  */
 mod_mul_320x128:
@@ -425,7 +425,7 @@ mod_mul_320x128:
  * @param[in]  MOD: p, modulus of P-256 underlying finite field
  * @param[out]  w19: c, result
  *
- * clobbered registers: w19, w20, w21, w22, w23, w24, w25
+ * clobbered registers: w19 to w25, acc
  * clobbered flag groups: FG0
  */
 mul_modp:
@@ -586,7 +586,7 @@ mul_modp:
  * @param[out] w28: r256, constant, 2^256 mod p = 2^256 - p
  * @param[out] w29: r448, constant, 2^448 mod p
  *
- * clobbered registers: w28, w29
+ * clobbered registers: x2 to x3, w28 to w29, mod
  * clobbered flag groups: FG0
  */
 setup_modp:
@@ -648,7 +648,7 @@ setup_modp:
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
- * clobbered registers: w11 to w25
+ * clobbered registers: w11 to w25, acc
  * clobbered flag groups: FG0
  */
 proj_add:
@@ -864,7 +864,7 @@ proj_add:
  * @param[out]  w12: y_a, y-coordinate of curve point (affine)
  * @param[out]  w14: z^-1, modular inverse of the projective z-coordinate
  *
- * clobbered registers: w10 to w19, w24, w25
+ * clobbered registers: w10 to w25, acc
  * clobbered flag groups: FG0
  */
 proj_to_affine:
@@ -1029,7 +1029,7 @@ proj_to_affine:
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
- * clobbered registers: w1, w2, w3, w19, w24, w25
+ * clobbered registers: x2, w1 to w3, w19 to w25, w31, acc
  * clobbered flag groups: FG0
  */
 mod_inv:
@@ -1180,7 +1180,7 @@ fetch_proj_randomize:
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
- * clobbered registers: w14 to w25
+ * clobbered registers: w8 to w10, w14 to w25, acc
  * clobbered flag groups: FG0
  */
 proj_double:
@@ -1299,7 +1299,7 @@ proj_double:
  * Flags: When leaving this subroutine, the M, L and Z flags of FG0 depend on
  *        the computed affine y-coordinate.
  *
- * clobbered registers: x2, x3, x10, w0 to w30
+ * clobbered registers: x2 to x3, x10, w0 to w29, w31, acc, mod
  * clobbered flag groups: FG0
  */
 scalar_mult_int:
@@ -1546,7 +1546,7 @@ scalar_mult_int:
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
- * clobbered registers: x2, x3, x16, x17, x19, x20, x21, x22, w0 to w29
+ * clobbered registers: x2 to x3, x10, x16, x21 to x22, w0 to w29, w31, acc, mod
  * clobbered flag groups: FG0
  */
 p256_base_mult:
@@ -1641,7 +1641,7 @@ p256_base_mult:
  * @param[out] w15,w16:  first share of secret scalar t (320 bits)
  * @param[out] w17,w18:  second share of secret scalar t (320 bits)
  *
- * clobbered registers: x2, x3, x20, w12 to w29
+ * clobbered registers: x2 to x3, w12 to w26, w28 to w29, w31, acc, mod
  * clobbered flag groups: FG0
  */
 p256_random_scalar:
@@ -1729,7 +1729,7 @@ p256_random_scalar:
  * @param[out]  dmem[d0]:  first share of private key d
  * @param[out]  dmem[d1]:  second share of private key d
  *
- * clobbered registers: x2, x3, x20, w20, w21, w29
+ * clobbered registers: x2 to x3, x20, w12 to w26, w28 to w29, w31, acc, mod
  * clobbered flag groups: FG0
  */
 p256_generate_random_key:
@@ -1767,7 +1767,7 @@ p256_generate_random_key:
  * @param[out]  dmem[k0]:  first share of secret scalar k
  * @param[out]  dmem[k1]:  second share of secret scalar k
  *
- * clobbered registers: x2, x3, x20, w20, w21, w29
+ * clobbered registers: x2 to x3, x20, w12 to w26, w28 to w29, w31, acc, mod
  * clobbered flag groups: FG0
  */
 p256_generate_k:
@@ -1842,7 +1842,7 @@ p256_generate_k:
  * @param[out] [w21, w20]: result x0 (321 bits)
  * @param[out] [w11, w10]: result x1 (320 bits)
  *
- * clobbered registers: w1 to w5, w20 to w23
+ * clobbered registers: w1 to w4, w11, w20 to w21, w28 to w29, w31
  * clobbered flag groups: FG0
  */
 boolean_to_arithmetic:
@@ -1956,7 +1956,7 @@ boolean_to_arithmetic:
  * @param[out] [w21, w20]: d0, first share of private key d (320 bits)
  * @param[out] [w11, w10]: d1, second share of private key d (320 bits)
  *
- * clobbered registers: x2, x3, w1 to w4, w20 to w29
+ * clobbered registers: x2 to x3, w1 to w4, w10 to w11, w20 to w21, w23 to w29, w31
  * clobbered flag groups: FG0
  */
 p256_key_from_seed:
@@ -2073,8 +2073,8 @@ p256_key_from_seed:
  * @param[in,out] dmem[d0..d0+64]: share 0 of 320-bit masked scalar.
  * @param[in,out] dmem[d1..d1+64]: share 1 of 320-bit masked scalar.
  *
- * clobbered registers: x3-x4, x10-x11, w1-w11, w31
- * clobbered flag groups: none
+ * clobbered registers: x3, x10 to x11, w1 to w11, w31
+ * clobbered flag groups: FG0, FG1
  */
 p256_scalar_remask:
   /* Initialize all-zero register. */

--- a/sw/acc/crypto/p256_isoncurve.s
+++ b/sw/acc/crypto/p256_isoncurve.s
@@ -41,7 +41,7 @@
  * @param[out]     w18: lhs, left side of equation = (x^3 + ax + b) mod p
  * @param[out]     w19: rhs, right side of equation = y^2 mod p
  *
- * clobbered registers: x2, x3, x19, x20, w0, w18 to w29
+ * clobbered registers: x2 to x3, w18 to w29, acc, mod
  * clobbered flag groups: FG0
  */
 p256_isoncurve:
@@ -113,7 +113,7 @@ p256_isoncurve:
  * @param[in] dmem[y]: Public key y-coordinate.
  * @param[out] dmem[ok]: success/failure of basic checks (32 bits)
  *
- * clobbered registers: x2, x3, x19, x20, w0, w2, w18 to w29
+ * clobbered registers: x2 to x3, w2, w18 to w29, w31, acc, mod
  * clobbered flag groups: FG0
  */
 p256_check_public_key:

--- a/sw/acc/crypto/p256_isoncurve_proj.s
+++ b/sw/acc/crypto/p256_isoncurve_proj.s
@@ -32,7 +32,7 @@
  * @param[out]     w18: lhs, left side of equation = (x^3 + ax + b) mod p
  * @param[out]     w19: rhs, right side of equation = y^2 mod p
  *
- * clobbered registers: x2, x3, x19, x20, w0, w18 to w29
+ * clobbered registers: x2 to x3, w18 to w29, acc, mod
  * clobbered flag groups: FG0
  */
 p256_isoncurve_proj:

--- a/sw/acc/crypto/p256_shared_key.s
+++ b/sw/acc/crypto/p256_shared_key.s
@@ -34,7 +34,7 @@
  * Flags: When leaving this subroutine, the M, L and Z flags of FG0 depend on
  *        the computed affine y-coordinate.
  *
- * clobbered registers: x2, x3, x16, x17, x21, x22, w0 to w25
+ * clobbered registers: x2 to x4, x10, x16, x21 to x22, w0 to w29, w31, acc, mod
  * clobbered flag groups: FG0
  */
 p256_shared_key:
@@ -185,7 +185,7 @@ p256_shared_key:
  * @param[in]  w11: arithmetically masked value A, such that x = A + r
  * @param[out] w20: boolean masked value x', such that x = x' ^ r
  *
- * clobbered registers: w1 to w6, w11, w12, w18, w20 to w27, and w29
+ * clobbered registers: w1 to w6, w11 to w12, w18 to w22, w24 to w27, w29, w31
  * clobbered flag groups: FG0
  */
 arithmetic_to_boolean_mod:
@@ -310,7 +310,7 @@ arithmetic_to_boolean_mod:
  * @param[out] w21: upper part of boolean masked value x',
  *                  such that x = x' ^ r
  *
- * clobbered registers: w1 - w6, w11, w12, and w18 - w21
+ * clobbered registers: w1 to w6, w12, w19 to w21, w31
  * clobbered flag groups: FG0
  */
 arithmetic_to_boolean:

--- a/sw/acc/crypto/p256_sign.s
+++ b/sw/acc/crypto/p256_sign.s
@@ -64,7 +64,7 @@
  * Flags: When leaving this subroutine, the M, L and Z flags of FG0 depend on
  *        the computed affine y-coordinate.
  *
- * clobbered registers: x2, x3, x16 to x23, w0 to w29
+ * clobbered registers: x2 to x3, x10, x16, x18 to x22, w0 to w29, w31, acc, mod
  * clobbered flag groups: FG0
  */
 p256_sign:

--- a/sw/acc/crypto/p256_verify.s
+++ b/sw/acc/crypto/p256_verify.s
@@ -52,7 +52,7 @@
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
- * clobbered registers: x2, x3, x11, x12, x13, x14, x17 to x24, w0 to w25
+ * clobbered registers: x2 to x3, x11 to x14, x17 to x24, w0 to w25, w27 to w29, w31, acc, mod
  * clobbered flag groups: FG0
  */
 p256_verify:
@@ -314,7 +314,7 @@ p256_verify:
  * @param[in]  w31: all-zero
  * @param[out]  w1: result c
  *
- * clobbered registers: x2, w2, w3, w4, w7
+ * clobbered registers: x2, w1 to w7
  * clobbered flag groups: FG0
  */
 mod_inv_var:

--- a/sw/acc/crypto/p384_a2b.s
+++ b/sw/acc/crypto/p384_a2b.s
@@ -39,7 +39,7 @@
  * @param[in]  [w12,w11]: arithmetically masked value A, such that x = A + r
  * @param[out] [w21,w20]: boolean masked value x', such that x = x' ^ r
  *
- * clobbered registers: w1 to w6, w10 to w12, w20, w21, w23 to w28
+ * clobbered registers: w1 to w6, w10 to w12, w18 to w21, w23 to w28, w31
  * clobbered flag groups: FG0
  */
 p384_arithmetic_to_boolean_mod:
@@ -140,7 +140,7 @@ p384_arithmetic_to_boolean_mod:
  * @param[out] w21: upper part of boolean masked value x',
  *                  such that x = x' ^ r
  *
- * clobbered registers: w1 to w6, w11, w12, and w18 to w21
+ * clobbered registers: w1 to w6, w20 to w21, w31
  * clobbered flag groups: FG0
  */
 p384_arithmetic_to_boolean:

--- a/sw/acc/crypto/p384_b2a.s
+++ b/sw/acc/crypto/p384_b2a.s
@@ -44,7 +44,7 @@
  * @param[out] [w21, w20]: result x0 (385 bits)
  * @param[out] [w11, w10]: result x1 (384 bits)
  *
- * clobbered registers: w1 to w4, w20 to w23
+ * clobbered registers: w1 to w4, w20 to w21, w28 to w29, w31
  * clobbered flag groups: FG0
  */
 p384_boolean_to_arithmetic:

--- a/sw/acc/crypto/p384_base.s
+++ b/sw/acc/crypto/p384_base.s
@@ -397,8 +397,8 @@ p384_reduce_n:
  * @param[in] w31: all-zero.
  * @param[out] [w17, w16]: c, result, max. length 384 bit.
  *
- * Clobbered registers: w16 to w24
- * Clobbered flag groups: FG0
+ * clobbered registers: w16 to w24, w31, acc
+ * clobbered flag groups: FG0
  */
 .globl p384_mulmod_p
 p384_mulmod_p:
@@ -1122,7 +1122,7 @@ proj_double_p384:
  * @param[out] [w26, w25]: x_a, affine x-coordinate of resulting point.
  * @param[out] [w28, w27]: y_a, affine y-coordinate of resulting point.
  *
- * clobbered registers: w0 to w28
+ * clobbered registers: w0 to w11, w16 to w28, w31, acc
  * clobbered flag groups: FG0
  */
  .globl proj_to_affine_p384
@@ -1355,8 +1355,8 @@ proj_to_affine_p384:
  * @param[in,out] dmem[d0..d0+64]: share 0 of 448-bit masked scalar.
  * @param[in,out] dmem[d1..d1+64]: share 1 of 448-bit masked scalar.
  *
- * clobbered registers: x3-x4, w1-w13, w31
- * clobbered flag groups: none
+ * clobbered registers: x3 to x4, w1 to w13, w31
+ * clobbered flag groups: FG0, FG1
  */
 .globl p384_scalar_remask
 p384_scalar_remask:

--- a/sw/acc/crypto/p384_base_mult.s
+++ b/sw/acc/crypto/p384_base_mult.s
@@ -31,9 +31,8 @@
  * Flags: When leaving this subroutine, the M, L and Z flags of FG0 correspond
  *        to the computed affine y-coordinate.
  *
- * clobbered registers: x2, x3, x9 to x13, x17 to x23, x26 to x30
- *                      w0 to w30
- * clobbered flag groups: FG0
+ * clobbered registers: x2 to x7, x10 to x13, x17 to x25, x27 to x28, w0 to w31, acc
+ * clobbered flag groups: FG0, FG1
  */
 .globl p384_base_mult_checked
 p384_base_mult_checked:
@@ -67,9 +66,8 @@ p384_base_mult_checked:
  * Flags: When leaving this subroutine, the M, L and Z flags of FG0 correspond
  *        to the computed affine y-coordinate.
  *
- * clobbered registers: x2, x3, x9 to x13, x17 to x21, x26 to x30
- *                      w0 to w30
- * clobbered flag groups: FG0
+ * clobbered registers: x2 to x7, x10 to x13, x17 to x25, x27 to x28, w0 to w31, acc
+ * clobbered flag groups: FG0, FG1
  */
 .globl p384_base_mult
 p384_base_mult:

--- a/sw/acc/crypto/p384_internal_mult.s
+++ b/sw/acc/crypto/p384_internal_mult.s
@@ -40,8 +40,7 @@
  * Flags: When leaving this subroutine, the M, L and Z flags of FG0 depend on
  *        the upper limb of projective y-coordinate.
  *
- * clobbered registers: x10, x11 to x13
-  *                     w2, w3, w8 to w11, w16 to w24, w29, w30
+ * clobbered registers: x10 to x13, w2 to w3, w10 to w11, w16 to w24, w31, acc
  * clobbered flag groups: FG0
  */
  .globl store_proj_randomize
@@ -159,7 +158,7 @@ store_proj_randomize:
  * Flags: When leaving this subroutine, the M, L and Z flags of FG0 depend on
  *        the computed affine y-coordinate.
  *
- * clobbered registers: x2 to x7, x10 to x13, x18, x22 to x27, x30, w0 to w11, w16 to w31, acc
+ * clobbered registers: x2 to x7, x10 to x13, x18, x22 to x25, x27, w0 to w11, w14 to w31, acc
  * clobbered flag groups: FG0, FG1
  */
  .globl scalar_mult_int_p384

--- a/sw/acc/crypto/p384_isoncurve.s
+++ b/sw/acc/crypto/p384_isoncurve.s
@@ -31,8 +31,8 @@
  * @param[in]    w31: all-zero
  * @param[in]  FG0.Z: boolean indicating (complement of) fault condition
  *
- * clobbered registers: x2, x3
- * clobbered flag groups: none
+ * clobbered registers: x2 to x3, w31
+ * clobbered flag groups: FG0
  */
  .globl trigger_fault_if_fg0_not_z
 trigger_fault_if_fg0_not_z:
@@ -90,7 +90,7 @@ trigger_fault_if_fg0_not_z:
  * @param[in]  x23:         dptr_lhs, pointer to dmem location where left side
  *                                    result will be stored
  *
- * clobbered registers: x2, x3, w0 to w5, w10 to w17
+ * clobbered registers: x2 to x3, w0 to w5, w10 to w11, w16 to w24, w31, acc
  * clobbered flag groups: FG0
  */
  .globl p384_isoncurve
@@ -192,7 +192,7 @@ p384_isoncurve:
  * @param[in]  x21:         dptr_y, pointer to dmem location containing affine
  *                                  y-coordinate of input point
  *
- * clobbered registers: x2, x3, w0 to w5, w10 to w17
+ * clobbered registers: x2 to x3, x22 to x23, w0 to w7, w10 to w11, w16 to w24, w31, acc
  * clobbered flag groups: FG0
  */
  .globl p384_isoncurve_check
@@ -248,7 +248,7 @@ p384_isoncurve_check:
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
- * clobbered registers: x2, x3, x20 to x23, w0 to w17
+ * clobbered registers: x2 to x3, x20 to x23, w0 to w13, w16 to w24, w31, acc
  * clobbered flag groups: FG0
  */
  .globl p384_check_public_key
@@ -348,7 +348,7 @@ p384_check_public_key:
  * @param[in]  FG0.Z: boolean indicating fault condition
  *
  * clobbered registers: x2
- * clobbered flag groups: none
+ * clobbered flag groups: FG0
  */
 trigger_input_error_if_fg0_not_z:
   /* Fail if FG0.Z is false. */

--- a/sw/acc/crypto/p384_isoncurve_proj.s
+++ b/sw/acc/crypto/p384_isoncurve_proj.s
@@ -33,7 +33,7 @@
  * @param[in]  x21:         dptr_y, pointer to y-coordinate in dmem
  * @param[in]  x30:         dptr_z, pointer to z-coordinate in dmem
  *
- * clobbered registers: x2, x3, w0 to w5, w10 to w17
+ * clobbered registers: x2 to x3, w0 to w5, w10 to w11, w16 to w24, w31, acc
  * clobbered flag groups: FG0
  */
  .globl p384_isoncurve_proj_check
@@ -90,7 +90,7 @@ p384_isoncurve_proj_check:
  * @param[out] dmem[lhs]:   left-hand side of equation.
  * @param[out] dmem[rhs]:   right-hand side of equation.
  *
- * clobbered registers: x2, x3, w0 to w5, w10 to w17
+ * clobbered registers: x2 to x3, w0 to w5, w10 to w11, w16 to w24, w31, acc
  * clobbered flag groups: FG0
  */
  .globl p384_isoncurve_proj

--- a/sw/acc/crypto/p384_keygen.s
+++ b/sw/acc/crypto/p384_keygen.s
@@ -48,7 +48,7 @@
  * @param[out]      [w7,w6]:  first share of secret scalar t (448 bits)
  * @param[out]      [w9,w8]:  second share of secret scalar t (448 bits)
  *
- * clobbered registers: x2, x3, w4 to w11, w14, w16 to w28
+ * clobbered registers: x2 to x3, w4 to w14, w16 to w28, w31, acc
  * clobbered flag groups: FG0
  */
 p384_random_scalar:
@@ -178,7 +178,7 @@ p384_random_scalar:
  * @param[out]  dmem[d0]: 1st private key share d0
  * @param[out]  dmem[d1]: 2nd private key share d1
  *
- * clobbered registers: x2, x3, x20, x21, w4 to w11, w14, w16 to w28
+ * clobbered registers: x2 to x3, x20 to x21, w4 to w14, w16 to w28, w31, acc
  * clobbered flag groups: FG0
  */
 .globl p384_generate_random_key
@@ -218,7 +218,7 @@ p384_generate_random_key:
  * @param[out]  dmem[k0]: 1st scalar share k0
  * @param[out]  dmem[k1]: 2nd scalar share k1
  *
- * clobbered registers: x2, x3, x20, x21, w4 to w11, w14, w16 to w28
+ * clobbered registers: x2 to x3, x20 to x21, w4 to w14, w16 to w28, w31, acc
  * clobbered flag groups: FG0
  */
 .globl p384_generate_k

--- a/sw/acc/crypto/p384_keygen_from_seed.s
+++ b/sw/acc/crypto/p384_keygen_from_seed.s
@@ -54,7 +54,7 @@
  * @param[out]      dmem[d0]: d0, first share of private key d (448 bits)
  * @param[out]      dmem[d1]: d1, second share of private key d (448 bits)
  *
- * clobbered registers: x2, x3, x20, w1 to w6, w16 to w29
+ * clobbered registers: x2 to x3, x20, w1 to w6, w10 to w11, w16 to w29, w31, acc
  * clobbered flag groups: FG0
  */
 .globl p384_key_from_seed

--- a/sw/acc/crypto/p384_modinv.s
+++ b/sw/acc/crypto/p384_modinv.s
@@ -46,7 +46,7 @@
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
- * clobbered registers: x2, w2, w3, w10, w11, w16 to w24
+ * clobbered registers: x2, w2 to w3, w10 to w11, w16 to w24, w31, acc
  * clobbered flag groups: FG0
  */
  .globl mod_inv_p384

--- a/sw/acc/crypto/p384_scalar_mult.s
+++ b/sw/acc/crypto/p384_scalar_mult.s
@@ -37,9 +37,8 @@
  * Flags: When leaving this subroutine, the M, L and Z flags of FG0 depend on
  *        the computed affine y-coordinate.
  *
- * clobbered registers: x2, x3, x9 to x13, x17 to x21, x26 to x30
- *                      w0 to w30
- * clobbered flag groups: FG0
+ * clobbered registers: x2 to x7, x10 to x13, x17 to x25, x27 to x28, x30, w0 to w31, acc
+ * clobbered flag groups: FG0, FG1
  */
 .globl p384_scalar_mult
 p384_scalar_mult:

--- a/sw/acc/crypto/p384_sign.s
+++ b/sw/acc/crypto/p384_sign.s
@@ -37,9 +37,8 @@
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
- * clobbered registers: x2 to x6, x9 to x15, x17 to x28, x30
- *                      w0 to w31
- * clobbered flag groups: FG0
+ * clobbered registers: x2 to x7, x10 to x15, x17 to x25, x27 to x28, w0 to w31, acc
+ * clobbered flag groups: FG0, FG1
  */
 .globl p384_sign
 p384_sign:

--- a/sw/acc/crypto/p384_verify.s
+++ b/sw/acc/crypto/p384_verify.s
@@ -119,7 +119,7 @@ store_proj:
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
- * clobbered registers: x2 to x5, x10, x11, x12, x15, x22 to 28, w0 to w31
+ * clobbered registers: x2 to x15, x17 to x28, w0 to w31, acc
  * clobbered flag groups: FG0
  */
 .globl p384_verify

--- a/sw/acc/crypto/rsa.s
+++ b/sw/acc/crypto/rsa.s
@@ -71,6 +71,7 @@ rsa_decrypt:
  * Zero the contents of work_buf
  *
  * clobbered registers: x3, w0
+ * clobbered flag groups: FG0
  */
 zero_work_buf:
   la     x3, work_buf
@@ -83,7 +84,8 @@ zero_work_buf:
 /**
  * Copy the contents of work_buf onto inout
  *
- * clobbered registers: x2, x3, x4, w0
+ * clobbered registers: x2 to x4, x30, w0
+ * clobbered flag groups: none
  */
 cp_work_buf:
   la    x2, n_limbs

--- a/sw/acc/crypto/rsa_keygen.s
+++ b/sw/acc/crypto/rsa_keygen.s
@@ -2271,7 +2271,7 @@ __relprime_small_primes_fail:
  * @param[in]  w31: all-zero
  * @param[out] x2: result, 8 if a mod m = 0 and otherwise 0
  *
- * clobbered registers: x2, w22, w25, w26
+ * clobbered registers: x2, w22, w25 to w26
  * clobbered flag groups: FG0
  */
 is_zero_mod_small_prime:

--- a/sw/acc/crypto/sha256.s
+++ b/sw/acc/crypto/sha256.s
@@ -23,7 +23,7 @@
  * @param[in]  dmem[state]: Initial hash state (256 bits)
  * @param[out] dmem[state]: Final hash state (256 bits)
  *
- * clobbered registers: x2, x3, x10 to x12, x21 to x23, w20 to w30
+ * clobbered registers: x2 to x3, x10 to x12, x21 to x23, w20 to w31
  * clobbered flag groups: FG0
  */
 sha256:

--- a/sw/acc/crypto/sha512.s
+++ b/sw/acc/crypto/sha512.s
@@ -74,8 +74,7 @@
  * @param[in]  dmem[dptr_msg]: Pointer to memory location containing the pre-
  *                               formatted message chunks.
  *
- * clobbered registers: w0 to w7, w10, w11, w15 to w26, w31
- *                      x1, x2, x10, x11 to x17, x20
+ * clobbered registers: x2, x10 to x17, x19 to x20, w0 to w7, w10 to w11, w15 to w26, w31
  * clobbered flag groups: FG0
  */
 .globl sha512

--- a/sw/acc/crypto/sha512_compact.s
+++ b/sw/acc/crypto/sha512_compact.s
@@ -73,8 +73,7 @@
  * @param[in]  dmem[sha512_dptr_msg]: Pointer to memory location containing the pre-
  *                                    formatted message chunks.
  *
- * clobbered registers: w0 to w7, w10, w11, w15 to w27, w31
- *                      x2, x10 to x17, x19, x20
+ * clobbered registers: x2, x10 to x11, x14 to x17, x19 to x20, w0 to w7, w10, w15 to w27, w31
  * clobbered flag groups: FG0
  */
 .globl sha512_compact

--- a/sw/acc/crypto/sha512_interface.s
+++ b/sw/acc/crypto/sha512_interface.s
@@ -25,8 +25,8 @@
  * @param[out] dmem[state..state+256]: Working SHA-512 state.
  * @param[out] dmem[sha512_dptr_state]: state, pointer to working state.
  *
- * clobbered registers: x2, x3, x20, w20
- * clobbered flag groups: FG0
+ * clobbered registers: x2 to x3, x20, w20
+ * clobbered flag groups: none
  */
 sha512_init:
   /* Copy the initial state into the working buffer.
@@ -83,8 +83,7 @@ sha512_init:
  * @param[in,out] dmem[partial]: Current partial message block ((len % 128) bytes).
  * @param[in,out] dmem[state]: Working hash state.
  *
- * clobbered registers: x2, x3, x10 to x22, x28
- *                      w0 to w7, w10, w11, w15 to w29
+ * clobbered registers: x2 to x3, x10 to x22, x28, w0 to w7, w10, w15 to w29, w31
  * clobbered flag groups: FG0
  */
 sha512_update:
@@ -178,8 +177,7 @@ sha512_update:
  * @param[in]  dmem[state]: Working hash state.
  * @param[out] dmem[dptr_result..dptr_result+64]: SHA-512 digest.
  *
- * clobbered registers: x2 to x5, x10 to x12, x14 to x17, x19 to x23, x28
- *                      w0 to w7, w10, w15 to w30
+ * clobbered registers: x2 to x5, x10 to x12, x14 to x17, x19 to x23, x28, w0 to w7, w10, w15 to w31
  * clobbered flag groups: FG0
  */
 sha512_final:
@@ -264,8 +262,8 @@ sha512_final:
  * @param[in,out] x21: dptr_dst, pointer to the destination buffer.
  * @param[out]    dmem[dptr_dst..dptr_dst+src_len]: data, copied value.
  *
- * clobbered registers: x2, x10, x11, x13, x16, x17, x19 to x21, w20, w21
- * clobbered flag groups: FG0
+ * clobbered registers: x2, x10 to x11, x13, x16 to x17, x19 to x21, w20 to w21
+ * clobbered flag groups: none
  */
 copy:
   /* Continue only if the length of new data is nonzero; otherwise return. */
@@ -410,7 +408,7 @@ reverse_bytes:
  * @param[in]     x12: dptr_msg, pointer to the start of the first block.
  * @param[in,out] dmem[dptr_msg..dptr_msg+nblocks*128]: Message (modified in-place).
  *
- * clobbered registers: x2, x3, x12, x28, w20 to w29
+ * clobbered registers: x2 to x3, x12, x28, w20 to w29
  * clobbered flag groups: FG0
  */
 sha512_format_blocks:

--- a/sw/acc/crypto/sha512_padding.s
+++ b/sw/acc/crypto/sha512_padding.s
@@ -38,7 +38,7 @@
  * @param[out] dmem[dptr_pad..dptr_end]: message padding
  *
  * clobbered registers: x2 to x5, x20 to x23, w27
- * clobbered flag groups: FG0
+ * clobbered flag groups: none
  */
 .globl sha512_pad_message
 sha512_pad_message:
@@ -132,8 +132,8 @@ sha512_pad_message:
  * @param[in]  x23: w, input word (w[0] || w[1] || w[2] || w[3])
  * @param[out] x23: result (w[3] || w[2] || w[1] || w[0])
  *
- * clobbered registers: x2, x3, x23
- * clobbered flag groups: FG0
+ * clobbered registers: x2 to x3, x23
+ * clobbered flag groups: none
  */
 bswap32:
   /* x2 <= w[0] << 24 */

--- a/sw/acc/crypto/tests/BUILD
+++ b/sw/acc/crypto/tests/BUILD
@@ -3,9 +3,140 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
-load("//rules:acc.bzl", "acc_consttime_test", "acc_library", "acc_sim_test", "acc_sim_test_suite")
+load("//rules:acc.bzl", "acc_clobbered_regs_test", "acc_consttime_test", "acc_library", "acc_sim_test", "acc_sim_test_suite")
 
 package(default_visibility = ["//visibility:public"])
+
+# Clobbered-register checks: verify that docstring annotations match
+# the actual registers written (determined by information-flow analysis).
+# N-dependent RSA/bignum helpers, routines taking a WDR index in a GPR,
+# and sha3_shake (no acc_binary) are omitted.
+#
+# TODO: investigate why these take 30s-200s; tagged "manual" until fixed.
+_SLOW_CLOBBERED_REGS_SUBS = [
+    ("run_p384", "p384_base_mult"),
+    ("run_p384", "p384_base_mult_checked"),
+    ("run_p384", "scalar_mult_int_p384"),
+    ("run_p384", "p384_scalar_mult"),
+    ("run_p384", "p384_sign"),
+    ("run_p384", "p384_verify"),
+]
+
+[acc_clobbered_regs_test(
+    name = elf + "_" + sub + "_clobbered",
+    srcs = ["//sw/acc/crypto:" + src],
+    subroutine = sub,
+    tags = ["manual"] if (elf, sub) in _SLOW_CLOBBERED_REGS_SUBS else [],
+    deps = ["//sw/acc/crypto:" + elf],
+) for sub, src, elf in [
+    # Ed25519
+    ("ed25519_verify_var", "ed25519.s", "run_ed25519"),
+    ("ed25519_sign_prehashed", "ed25519.s", "run_ed25519"),
+    ("sc_clamp", "ed25519.s", "run_ed25519"),
+    ("affine_to_ext", "ed25519.s", "run_ed25519"),
+    ("ext_to_affine", "ed25519.s", "run_ed25519"),
+    ("affine_encode", "ed25519.s", "run_ed25519"),
+    ("affine_decode_var", "ed25519.s", "run_ed25519"),
+    ("ext_scmul", "ed25519.s", "run_ed25519"),
+    ("ext_scmul_var", "ed25519.s", "run_ed25519"),
+    ("ext_double", "ed25519.s", "run_ed25519"),
+    ("ext_add", "ed25519.s", "run_ed25519"),
+    ("ext_equal_var", "ed25519.s", "run_ed25519"),
+    ("fe_pow_2252m3", "ed25519.s", "run_ed25519"),
+    ("fe_init", "field25519.s", "run_ed25519"),
+    ("fe_mul", "field25519.s", "run_ed25519"),
+    ("fe_square", "field25519.s", "run_ed25519"),
+    ("fe_inv", "field25519.s", "run_ed25519"),
+    ("sc_init", "ed25519_scalar.s", "run_ed25519"),
+    ("sc_reduce", "ed25519_scalar.s", "run_ed25519"),
+    ("sc_mul", "ed25519_scalar.s", "run_ed25519"),
+    ("sha512_compact", "sha512_compact.s", "run_ed25519"),
+    ("sha512_init", "sha512_interface.s", "run_ed25519"),
+    ("sha512_update", "sha512_interface.s", "run_ed25519"),
+    ("sha512_final", "sha512_interface.s", "run_ed25519"),
+    ("sha512_format_blocks", "sha512_interface.s", "run_ed25519"),
+    ("copy", "sha512_interface.s", "run_ed25519"),
+    ("reverse_bytes", "sha512_interface.s", "run_ed25519"),
+    ("bswap64", "sha512_interface.s", "run_ed25519"),
+    ("sha512_pad_message", "sha512_padding.s", "run_ed25519"),
+    ("bswap32", "sha512_padding.s", "run_ed25519"),
+    # SHA-512 (standalone)
+    ("sha512", "sha512.s", "run_sha512"),
+    # SHA-256
+    ("sha256", "sha256.s", "run_sha256"),
+    # P-256
+    ("setup_modp", "p256_base.s", "run_p256"),
+    ("mul_modp", "p256_base.s", "run_p256"),
+    ("mod_inv", "p256_base.s", "run_p256"),
+    ("proj_add", "p256_base.s", "run_p256"),
+    ("proj_double", "p256_base.s", "run_p256"),
+    ("proj_to_affine", "p256_base.s", "run_p256"),
+    ("mod_mul_256x256", "p256_base.s", "run_p256"),
+    ("mod_mul_320x128", "p256_base.s", "run_p256"),
+    ("p256_reduce", "p256_base.s", "run_p256"),
+    ("scalar_mult_int", "p256_base.s", "run_p256"),
+    ("p256_base_mult", "p256_base.s", "run_p256"),
+    ("p256_random_scalar", "p256_base.s", "run_p256"),
+    ("p256_generate_random_key", "p256_base.s", "run_p256"),
+    ("p256_generate_k", "p256_base.s", "run_p256"),
+    ("boolean_to_arithmetic", "p256_base.s", "run_p256"),
+    ("p256_key_from_seed", "p256_base.s", "run_p256"),
+    ("p256_scalar_remask", "p256_base.s", "run_p256"),
+    ("trigger_fault_if_fg0_not_z", "p256_base.s", "run_p256"),
+    ("trigger_fault_if_fg0_z", "p256_base.s", "run_p256"),
+    ("p256_isoncurve", "p256_isoncurve.s", "run_p256"),
+    ("p256_check_public_key", "p256_isoncurve.s", "run_p256"),
+    ("p256_isoncurve_proj", "p256_isoncurve_proj.s", "run_p256"),
+    ("p256_shared_key", "p256_shared_key.s", "run_p256"),
+    ("arithmetic_to_boolean", "p256_shared_key.s", "run_p256"),
+    ("arithmetic_to_boolean_mod", "p256_shared_key.s", "run_p256"),
+    ("p256_sign", "p256_sign.s", "run_p256"),
+    ("p256_verify", "p256_verify.s", "run_p256"),
+    ("mod_inv_var", "p256_verify.s", "run_p256"),
+    ("copy_share", "run_p256.s", "run_p256"),
+    # P-384
+    ("p384_mulmod_p", "p384_base.s", "run_p384"),
+    ("proj_to_affine_p384", "p384_base.s", "run_p384"),
+    ("p384_scalar_remask", "p384_base.s", "run_p384"),
+    ("p384_base_mult_checked", "p384_base_mult.s", "run_p384"),
+    ("p384_base_mult", "p384_base_mult.s", "run_p384"),
+    ("p384_isoncurve", "p384_isoncurve.s", "run_p384"),
+    ("p384_isoncurve_check", "p384_isoncurve.s", "run_p384"),
+    ("p384_check_public_key", "p384_isoncurve.s", "run_p384"),
+    ("trigger_fault_if_fg0_not_z", "p384_isoncurve.s", "run_p384"),
+    ("trigger_input_error_if_fg0_not_z", "p384_isoncurve.s", "run_p384"),
+    ("p384_isoncurve_proj", "p384_isoncurve_proj.s", "run_p384"),
+    ("p384_isoncurve_proj_check", "p384_isoncurve_proj.s", "run_p384"),
+    ("scalar_mult_int_p384", "p384_internal_mult.s", "run_p384"),
+    ("store_proj_randomize", "p384_internal_mult.s", "run_p384"),
+    ("p384_verify", "p384_verify.s", "run_p384"),
+    ("p384_sign", "p384_sign.s", "run_p384"),
+    ("p384_generate_k", "p384_keygen.s", "run_p384"),
+    ("p384_generate_random_key", "p384_keygen.s", "run_p384"),
+    ("p384_random_scalar", "p384_keygen.s", "run_p384"),
+    ("p384_key_from_seed", "p384_keygen_from_seed.s", "run_p384"),
+    ("p384_scalar_mult", "p384_scalar_mult.s", "run_p384"),
+    ("mod_inv_p384", "p384_modinv.s", "run_p384"),
+    ("p384_arithmetic_to_boolean", "p384_a2b.s", "run_p384"),
+    ("p384_arithmetic_to_boolean_mod", "p384_a2b.s", "run_p384"),
+    ("p384_boolean_to_arithmetic", "p384_b2a.s", "run_p384"),
+    ("copy_share", "run_p384.s", "run_p384"),
+    # X25519
+    ("X25519", "x25519.s", "x25519_sideload"),
+    ("scalar_mult", "x25519.s", "x25519_sideload"),
+    ("ladderstep", "x25519.s", "x25519_sideload"),
+    # RSA
+    ("m0inv", "montmul.s", "rsa"),
+    ("mul256_w30xw25", "montmul.s", "rsa"),
+    ("mul256_w30xw2", "montmul.s", "rsa"),
+    ("mul256_w20xw21", "mul.s", "rsa"),
+    ("zero_work_buf", "rsa.s", "rsa"),
+    ("cp_work_buf", "rsa.s", "rsa"),
+    # RSA keygen
+    ("is_zero_mod_small_prime", "rsa_keygen.s", "run_rsa_keygen"),
+    # Boot
+    ("attestation_secret_key_from_seed", "boot.s", "boot"),
+]]
 
 acc_sim_test(
     name = "ed25519_encode_decode_test",

--- a/sw/acc/crypto/x25519.s
+++ b/sw/acc/crypto/x25519.s
@@ -22,7 +22,7 @@
  * @param[in]  w9: enc(u), encoded Montgomery u-coordinate (256 bits)
  * @param[out] w22: result, X25519(k, u) as an encoded u-coordinate
  *
- * clobbered registers: w2 to w24
+ * clobbered registers: x2 to x3, w2 to w24, w30 to w31, acc, mod
  * clobbered flag groups: FG0
  */
 .globl X25519
@@ -107,7 +107,7 @@ X25519:
  * @param[in]  MOD: p, modulus = 2^255 - 19
  * @param[out] w22: result, Montgomery u-coordinate of point kA
  *
- * clobbered registers: w2 to w7, w10 to w18, w20 to w24
+ * clobbered registers: x2 to x3, w2 to w7, w10 to w18, w20 to w24, acc
  * clobbered flag groups: FG0
  */
 scalar_mult:
@@ -270,7 +270,7 @@ scalar_mult:
  * @param[in,out] w12:  z_2
  * @param[in,out] w13:  z_3
  *
- * clobbered registers: w2 to w5, w10 to w13, w17, w18, w20 to w23
+ * clobbered registers: w2 to w5, w10 to w13, w17 to w18, w20 to w23, acc
  * clobbered flag groups: FG0
  */
 ladderstep:


### PR DESCRIPTION
Add a static checker that verifies clobbered-register docstring
annotations against the actual registers written, as determined by
the existing information-flow analysis.

The check currently only covers a part of the routines
(those that are currently supported by the information-flow
analysis script).

Also adjusted the docstrings for the covered routines - most of those were not aligned with the output of the information-flow script, but some of those differences are just cosmetic (like changing `x2, x3` to `x2 to x3`)