### PR TITLE
[crypto] Add pure Ed25519 signing and verification

### DIFF
--- a/sw/acc/crypto/ed25519.s
+++ b/sw/acc/crypto/ed25519.s
@@ -240,7 +240,7 @@ ed25519_verify_var:
 /**
  * Top-level Ed25519ph signature generation operation.
  *
- * Returns an 512-bit signature (R_ || S).
+ * Returns a 512-bit signature (R_ || S).
  *
  * Briefly, the signature generation algorithm is:
  *   1. Compute h = SHA-512(d). Denote the second half of h as prefix.
@@ -266,7 +266,7 @@ ed25519_verify_var:
  * @param[out] dmem[ed25519_sig_R]: R component of signature (256 bits)
  * @param[out] dmem[ed25519_sig_S]: S component of signature (256 bits)
  *
- * clobbered registers: x2 to x4, x20 to x23, w1 to w30
+ * clobbered registers: x2 to x5, x10 to x23, x28, w0 to w31
  * clobbered flag groups: FG0
  */
 .globl ed25519_sign_prehashed
@@ -284,7 +284,7 @@ ed25519_sign_prehashed:
   or       x4, x4, x2
   sw       x4, 32(x3)
 
-  /* dmem[ed25519_r] <= SHA-512(domain-separator || h[63:32] || PH(M)) */
+  /* dmem[ed25519_hash_r] <= SHA-512(domain-separator || h[63:32] || PH(M)) */
   jal      x1, sha512_init
   li       x18, 34
   la       x20, ed25519_prehash_dom_sep
@@ -303,6 +303,186 @@ ed25519_sign_prehashed:
   la       x18, ed25519_hash_r
   jal      x1, sha512_final
 
+  /* Compute R and A from hash_r and hash_h. */
+  jal      x1, _ed25519_sign_compute_r_a
+
+  /* dmem[ed25519_hash_k] <= SHA-512(domain-separator || R_ || A_ || PH(M)) */
+  jal      x1, sha512_init
+  li       x18, 34
+  la       x20, ed25519_prehash_dom_sep
+  jal      x1, sha512_update
+  la       x18, ed25519_ctx_len
+  lw       x18, 0(x18)
+  la       x20, ed25519_ctx
+  jal      x1, sha512_update
+  li       x18, 32
+  la       x20, ed25519_sig_R
+  jal      x1, sha512_update
+  li       x18, 32
+  la       x20, ed25519_public_key
+  jal      x1, sha512_update
+  li       x18, 64
+  la       x20, ed25519_message
+  jal      x1, sha512_update
+  la       x18, ed25519_hash_k
+  jal      x1, sha512_final
+
+  /* Compute S from hash_k, hash_h, and hash_r. */
+  jal      x1, _ed25519_sign_compute_s
+
+  ret
+
+/**
+ * Incremental pure Ed25519 signing - INIT phase.
+ *
+ * Begins the nonce hash r = SHA-512(prefix || M) by hashing the key prefix
+ * (upper 32 bytes of h) and the first message chunk.
+ *
+ * This routine runs in constant time.
+ *
+ * Flags: Flags have no meaning beyond the scope of this subroutine.
+ *
+ * @param[in]  dmem[ed25519_hash_h]: hash of secret key (512 bits)
+ * @param[in]  dmem[ed25519_message]: first message chunk (up to 1280 bytes)
+ * @param[in]  dmem[ed25519_message_len]: chunk length in bytes (32 bits)
+ *
+ * clobbered registers: x2, x3, x10 to x22, x28, w0 to w7, w10, w15 to w29, w31
+ * clobbered flag groups: FG0
+ */
+.globl ed25519_sign_pure_init
+ed25519_sign_pure_init:
+  bn.xor   w31, w31, w31
+  jal      x1, sha512_init
+  li       x18, 32
+  la       x20, ed25519_hash_h
+  addi     x20, x20, 32
+  jal      x1, sha512_update
+  la       x18, ed25519_message_len
+  lw       x18, 0(x18)
+  la       x20, ed25519_message
+  jal      x1, sha512_update
+  ret
+
+/**
+ * Incremental pure Ed25519 signing - UPDATE phase.
+ *
+ * Feeds more message data into the current hash (nonce or challenge).
+ * Used for both the nonce hash r = SHA-512(prefix || M) and the challenge
+ * hash k = SHA-512(R_ || A_ || M) when the message exceeds one chunk.
+ *
+ * This routine runs in constant time.
+ *
+ * Flags: Flags have no meaning beyond the scope of this subroutine.
+ *
+ * @param[in]  dmem[ed25519_message]: message chunk (up to 1280 bytes)
+ * @param[in]  dmem[ed25519_message_len]: chunk length in bytes (32 bits)
+ *
+ * clobbered registers: x2, x3, x10 to x22, x28, w0 to w7, w10, w15 to w29, w31
+ * clobbered flag groups: FG0
+ */
+.globl ed25519_sign_pure_update
+ed25519_sign_pure_update:
+  bn.xor   w31, w31, w31
+  la       x18, ed25519_message_len
+  lw       x18, 0(x18)
+  la       x20, ed25519_message
+  jal      x1, sha512_update
+  ret
+
+/**
+ * Incremental pure Ed25519 signing - MID phase.
+ *
+ * Finalizes the nonce hash to get r, computes the signature point
+ * R_ = encode([r]B) and public key A_ = encode([s]B), then begins the
+ * challenge hash k = SHA-512(R_ || A_ || M) with the first message chunk.
+ *
+ * This routine runs in constant time.
+ *
+ * Flags: Flags have no meaning beyond the scope of this subroutine.
+ *
+ * @param[in]  dmem[ed25519_hash_h]: hash of secret key (512 bits)
+ * @param[in]  dmem[ed25519_message]: first message chunk (up to 1280 bytes)
+ * @param[in]  dmem[ed25519_message_len]: chunk length in bytes (32 bits)
+ * @param[out] dmem[ed25519_sig_R]: R component of signature (256 bits)
+ * @param[out] dmem[ed25519_public_key]: encoded public key A_ (256 bits)
+ *
+ * clobbered registers: x2 to x5, x10 to x23, x28, w0 to w31, acc, mod
+ * clobbered flag groups: FG0
+ */
+.globl ed25519_sign_pure_mid
+ed25519_sign_pure_mid:
+  bn.xor   w31, w31, w31
+
+  /* Finalize the nonce hash: r = SHA-512(prefix || M). */
+  la       x18, ed25519_hash_r
+  jal      x1, sha512_final
+
+  /* Compute R_ = encode([r]B) and A_ = encode([s]B). */
+  jal      x1, _ed25519_sign_compute_r_a
+
+  /* Begin the challenge hash: k = SHA-512(R_ || A_ || M). */
+  jal      x1, sha512_init
+  li       x18, 32
+  la       x20, ed25519_sig_R
+  jal      x1, sha512_update
+  li       x18, 32
+  la       x20, ed25519_public_key
+  jal      x1, sha512_update
+  la       x18, ed25519_message_len
+  lw       x18, 0(x18)
+  la       x20, ed25519_message
+  jal      x1, sha512_update
+  ret
+
+/**
+ * Incremental pure Ed25519 signing - FINAL phase.
+ *
+ * Finalizes the challenge hash to get k, then computes the signature
+ * scalar S = (r + k * s) mod L.
+ *
+ * This routine runs in constant time.
+ *
+ * Flags: Flags have no meaning beyond the scope of this subroutine.
+ *
+ * @param[out] dmem[ed25519_sig_S]: S component of signature (256 bits)
+ *
+ * clobbered registers: x2 to x5, x10 to x12, x14 to x23, x28, w0 to w7, w10 to w31, acc, mod
+ * clobbered flag groups: FG0
+ */
+.globl ed25519_sign_pure_final
+ed25519_sign_pure_final:
+  bn.xor   w31, w31, w31
+
+  /* Finalize the challenge hash: k = SHA-512(R_ || A_ || M). */
+  la       x18, ed25519_hash_k
+  jal      x1, sha512_final
+
+  /* Compute S = (r + k * s) mod L. */
+  jal      x1, _ed25519_sign_compute_s
+
+  ret
+
+/**
+ * Compute signature point R and public key A.
+ *
+ * Reads the nonce hash r from dmem[ed25519_hash_r] and the secret key hash
+ * from dmem[ed25519_hash_h]. Computes R = [r]B and A = [s]B, encodes both,
+ * and writes them to dmem[ed25519_sig_R] and dmem[ed25519_public_key].
+ *
+ * This routine runs in constant time.
+ *
+ * Flags: Flags have no meaning beyond the scope of this subroutine.
+ *
+ * @param[in]  w31: all-zero
+ * @param[in]  dmem[ed25519_hash_h]: hash of secret key (512 bits)
+ * @param[in]  dmem[ed25519_hash_r]: nonce hash r (512 bits)
+ * @param[out] dmem[ed25519_sig_R]: encoded R (256 bits)
+ * @param[out] dmem[ed25519_public_key]: encoded A (256 bits)
+ *
+ * clobbered registers: x2, x3, w1, w5 to w30, acc, mod
+ * clobbered flag groups: FG0
+ */
+_ed25519_sign_compute_r_a:
   /* Set up for scalar arithmetic.
        [w15:w14] <= mu
        MOD <= L */
@@ -409,28 +589,28 @@ ed25519_sign_prehashed:
   la       x3, ed25519_public_key
   bn.sid   x2, 0(x3)
 
-  /* TODO: we could start with the pre-computed domain separator prefix here potentially */
-  /* dmem[ed25519_hash_k] <= SHA-512(domain-separator || R_ || A_ || PH(M)) */
-  jal      x1, sha512_init
-  li       x18, 34
-  la       x20, ed25519_prehash_dom_sep
-  jal      x1, sha512_update
-  la       x18, ed25519_ctx_len
-  lw       x18, 0(x18)
-  la       x20, ed25519_ctx
-  jal      x1, sha512_update
-  li       x18, 32
-  la       x20, ed25519_sig_R
-  jal      x1, sha512_update
-  li       x18, 32
-  la       x20, ed25519_public_key
-  jal      x1, sha512_update
-  li       x18, 64
-  la       x20, ed25519_message
-  jal      x1, sha512_update
-  la       x18, ed25519_hash_k
-  jal      x1, sha512_final
+  ret
 
+/**
+ * Compute signature scalar S = (r + k * s) mod L.
+ *
+ * Reads the challenge hash k from dmem[ed25519_hash_k], recovers s from
+ * dmem[ed25519_hash_h], and loads r from dmem[ed25519_hash_r].
+ *
+ * This routine runs in constant time.
+ *
+ * Flags: Flags have no meaning beyond the scope of this subroutine.
+ *
+ * @param[in]  w31: all-zero
+ * @param[in]  dmem[ed25519_hash_k]: challenge hash k (512 bits)
+ * @param[in]  dmem[ed25519_hash_h]: hash of secret key (512 bits)
+ * @param[in]  dmem[ed25519_hash_r]: nonce hash r (512 bits)
+ * @param[out] dmem[ed25519_sig_S]: S component of signature (256 bits)
+ *
+ * clobbered registers: x2, x3, w4, w10 to w18, w21, w22, acc, mod
+ * clobbered flag groups: FG0
+ */
+_ed25519_sign_compute_s:
   /* Set up for scalar arithmetic.
        [w15:w14] <= mu
        MOD <= L */
@@ -1789,8 +1969,17 @@ ed25519_hash_k:
 ed25519_ctx:
   .zero 256
 
-/* Message (pre-hashed, 64 bytes). */
+/* Message length in bytes. */
+.balign 4
+.weak ed25519_message_len
+ed25519_message_len:
+  .zero 4
+
+/* Message buffer (64 bytes for HashEdDSA, up to 1280 bytes for pure Ed25519).
+
+   Note: If the message length is not a multiple of 32 bytes, the bytes up to
+   the next multiple of 32 should be initialized to prevent read errors. */
 .balign 32
 .weak ed25519_message
 ed25519_message:
-  .zero 64
+  .zero 1280

--- a/sw/acc/crypto/run_ed25519.s
+++ b/sw/acc/crypto/run_ed25519.s
@@ -6,15 +6,19 @@
  * Entrypoint for Ed25519 operations.
  *
  * This binary has the following modes of operation:
- * 1. ED25519_MODE_SIGN: generate an Ed25519 signature using caller-provided secret key
- * 2. ED25519_MODE_VERIFY: verify an Ed25519 signature
+ * 1. ED25519_MODE_SIGN_PREHASH: generate a HashEd25519 signature (single-shot)
+ * 2. ED25519_MODE_SIGN_PURE_INIT: start incremental pure Ed25519 signing
+ * 3. ED25519_MODE_SIGN_PURE_UPDATE: feed more message data
+ * 4. ED25519_MODE_SIGN_PURE_MID: finalize nonce hash, do point math, start challenge hash
+ * 5. ED25519_MODE_SIGN_PURE_FINAL: finalize challenge hash, compute signature scalar S
+ * 6. ED25519_MODE_VERIFY: verify an Ed25519 signature
  */
 
 /**
  * Mode magic values.
  *
  * Encoding generated with:
- * $ ./util/design/sparse-fsm-encode.py -d 6 -m 2 -n 11 \
+ * $ ./util/design/sparse-fsm-encode.py -d 6 -m 7 -n 11 \
  *     -s 923549298 --avoid-zero
  *
  * Call the same utility with the same arguments and a higher -m to generate
@@ -25,13 +29,21 @@
  * as `li`. If support is added, we could use 32-bit values here instead of
  * 11-bit.
  */
-.equ ED25519_MODE_SIGN, 0x5be
+.equ ED25519_MODE_SIGN_PREHASH, 0x5be
+.equ ED25519_MODE_SIGN_PURE_INIT, 0x327
+.equ ED25519_MODE_SIGN_PURE_UPDATE, 0x1e9
+.equ ED25519_MODE_SIGN_PURE_MID, 0x68b
+.equ ED25519_MODE_SIGN_PURE_FINAL, 0x555
 .equ ED25519_MODE_VERIFY, 0x672
 
 /**
  * Make the mode constants visible to Ibex.
  */
-.globl ED25519_MODE_SIGN
+.globl ED25519_MODE_SIGN_PREHASH
+.globl ED25519_MODE_SIGN_PURE_INIT
+.globl ED25519_MODE_SIGN_PURE_UPDATE
+.globl ED25519_MODE_SIGN_PURE_MID
+.globl ED25519_MODE_SIGN_PURE_FINAL
 .globl ED25519_MODE_VERIFY
 
 .section .text.start
@@ -44,11 +56,23 @@ start:
   la      x2, ed25519_mode
   lw      x2, 0(x2)
 
-  addi    x3, x0, ED25519_MODE_SIGN
-  beq     x2, x3, ed25519_sign_top
+  addi    x3, x0, ED25519_MODE_SIGN_PREHASH
+  beq     x2, x3, ed25519_sign_hash_top
 
-  addi  x3, x0, ED25519_MODE_VERIFY
-  beq   x2, x3, ed25519_verify_top
+  addi    x3, x0, ED25519_MODE_SIGN_PURE_INIT
+  beq     x2, x3, ed25519_sign_pure_init_top
+
+  addi    x3, x0, ED25519_MODE_SIGN_PURE_UPDATE
+  beq     x2, x3, ed25519_sign_pure_update_top
+
+  addi    x3, x0, ED25519_MODE_SIGN_PURE_MID
+  beq     x2, x3, ed25519_sign_pure_mid_top
+
+  addi    x3, x0, ED25519_MODE_SIGN_PURE_FINAL
+  beq     x2, x3, ed25519_sign_pure_final_top
+
+  addi    x3, x0, ED25519_MODE_VERIFY
+  beq     x2, x3, ed25519_verify_top
 
   /* Invalid mode; fail. */
   unimp
@@ -56,7 +80,7 @@ start:
   unimp
 
 /**
- * Generate an Ed25519 signature.
+ * Generate a HashEd25519 signature (one-shot).
  *
  * See documentation for ed25519_sign_prehashed in ed25519.s for details.
  *
@@ -67,8 +91,44 @@ start:
  * @param[out] dmem[ed25519_sig_R]: R component of signature (256 bits)
  * @param[out] dmem[ed25519_sig_S]: S component of signature (256 bits)
  */
-ed25519_sign_top:
+ed25519_sign_hash_top:
   jal x1, ed25519_sign_prehashed
+  ecall
+
+/**
+ * Pure Ed25519 incremental signing - INIT phase.
+ *
+ * See documentation for ed25519_sign_pure_init in ed25519.s for details.
+ */
+ed25519_sign_pure_init_top:
+  jal x1, ed25519_sign_pure_init
+  ecall
+
+/**
+ * Pure Ed25519 incremental signing - UPDATE phase.
+ *
+ * See documentation for ed25519_sign_pure_update in ed25519.s for details.
+ */
+ed25519_sign_pure_update_top:
+  jal x1, ed25519_sign_pure_update
+  ecall
+
+/**
+ * Pure Ed25519 incremental signing - MID phase.
+ *
+ * See documentation for ed25519_sign_pure_mid in ed25519.s for details.
+ */
+ed25519_sign_pure_mid_top:
+  jal x1, ed25519_sign_pure_mid
+  ecall
+
+/**
+ * Pure Ed25519 incremental signing - FINAL phase.
+ *
+ * See documentation for ed25519_sign_pure_final in ed25519.s for details.
+ */
+ed25519_sign_pure_final_top:
+  jal x1, ed25519_sign_pure_final
   ecall
 
 /**
@@ -156,8 +216,18 @@ ed25519_hash_k:
 ed25519_ctx:
   .zero 256
 
-/* Message (pre-hashed, 64 bytes). */
+/* Message length in bytes. */
+.globl ed25519_message_len
+.balign 4
+ed25519_message_len:
+  .zero 4
+
+/* Message (up to 1280 bytes for pure Ed25519, 64 bytes for HashEd25519).
+
+   Note: If the message length is not a multiple of 32 bytes, the bytes up to
+   the next multiple of 32 should be initialized in order to prevent read
+   errors. The value of these bytes is ignored. */
 .globl ed25519_message
 .balign 32
 ed25519_message:
-  .zero 64
+  .zero 1280

--- a/sw/acc/crypto/tests/BUILD
+++ b/sw/acc/crypto/tests/BUILD
@@ -91,6 +91,22 @@ acc_sim_test(
 )
 
 acc_sim_test(
+    name = "ed25519_sign_pure_test",
+    srcs = [
+        "ed25519_sign_pure_test.s",
+    ],
+    dexp = "ed25519_sign_pure_test.dexp",
+    deps = [
+        "//sw/acc/crypto:ed25519",
+        "//sw/acc/crypto:ed25519_scalar",
+        "//sw/acc/crypto:field25519",
+        "//sw/acc/crypto:sha512_compact",
+        "//sw/acc/crypto:sha512_interface",
+        "//sw/acc/crypto:sha512_padding",
+    ],
+)
+
+acc_sim_test(
     name = "ed25519_verify_test",
     srcs = [
         "ed25519_verify_test.s",

--- a/sw/acc/crypto/tests/ed25519_sign_prehashed_test.s
+++ b/sw/acc/crypto/tests/ed25519_sign_prehashed_test.s
@@ -62,6 +62,11 @@ main:
 ed25519_ctx_len:
 .word 0x00000000
 
+.balign 4
+.globl ed25519_message_len
+ed25519_message_len:
+.word 0x00000000
+
 .balign 32
 .globl ed25519_sk
 ed25519_sk:

--- a/sw/acc/crypto/tests/ed25519_sign_pure_test.dexp
+++ b/sw/acc/crypto/tests/ed25519_sign_pure_test.dexp
@@ -1,0 +1,5 @@
+# Expected signature from RFC 8032 section 7.1 TEST 2.
+# Note: bytes are reversed here compared to the standard bytewise
+# representation of the signature.
+ed25519_sig_R: a909a092b8cad4f00b820e724025645f547bb2a28f3f5016232276b3da69dbeb
+ed25519_sig_S: e4c15a086e99153e13368f458c1df1d0ae2e7b38ee2a30b416290db0000cbb12

--- a/sw/acc/crypto/tests/ed25519_sign_pure_test.s
+++ b/sw/acc/crypto/tests/ed25519_sign_pure_test.s
@@ -1,0 +1,89 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+.section .text.start
+
+/**
+ * Standalone test for incremental pure Ed25519 signing.
+ *
+ * Test data from IETF RFC 8032, section 7.1 (TEST 2):
+ * https://datatracker.ietf.org/doc/html/rfc8032#section-7.1
+ *
+ * SECRET KEY:
+ * 4ccd089b28ff96da9db6c346ec114e0f
+ * 5b8a319f35aba624da8cf6ed4fb8a6fb
+ *
+ * PUBLIC KEY:
+ * 3d4017c3e843895a92b70aa74d1b7ebc
+ * 9c982ccf2ec4968cc0cd55f12af4660c
+ *
+ * MESSAGE (1 byte):
+ * 72
+ *
+ * SIGNATURE:
+ * 92a009a9f0d4cab8720e820b5f642540
+ * a2b27b5416503f8fb3762223ebdb69da
+ * 085ac1e43e15996e458f3613d0f11d8c
+ * 387b2eaeb4302aeeb00d291612bb0c00
+ */
+
+main:
+  /* Initialize all-zero register. */
+  bn.xor   w31, w31, w31
+
+  /* Call the SHA-512 routine to hash d.
+       dmem[ed25519_hash_h] <= SHA-512(d) = h */
+  jal      x1, sha512_init
+  li       x18, 32
+  la       x20, ed25519_sk
+  jal      x1, sha512_update
+  la       x18, ed25519_hash_h
+  jal      x1, sha512_final
+
+  /* INIT phase: hash prefix + message chunk. */
+  jal      x1, ed25519_sign_pure_init
+
+  /* MID phase: finalize nonce, point math, start challenge hash. */
+  jal      x1, ed25519_sign_pure_mid
+
+  /* FINAL phase: finalize challenge hash, compute S. */
+  jal      x1, ed25519_sign_pure_final
+
+  ecall
+
+.data
+
+.balign 4
+.globl ed25519_message_len
+ed25519_message_len:
+.word 0x00000001
+
+.balign 32
+.globl ed25519_sk
+ed25519_sk:
+.word 0x9b08cd4c
+.word 0xda96ff28
+.word 0x46c3b69d
+.word 0x0f4e11ec
+.word 0x9f318a5b
+.word 0x24a6ab35
+.word 0xedf68cda
+.word 0xfba6b84f
+
+/* Message: 0x72 (1 byte) */
+.balign 32
+.globl ed25519_message
+ed25519_message:
+.word 0x00000072
+.zero 28
+
+.balign 32
+.globl ed25519_sig_R
+ed25519_sig_R:
+.zero 32
+
+.balign 32
+.globl ed25519_sig_S
+ed25519_sig_S:
+.zero 32

--- a/sw/device/lib/crypto/impl/ecc/ed25519.c
+++ b/sw/device/lib/crypto/impl/ecc/ed25519.c
@@ -26,6 +26,7 @@ ACC_DECLARE_SYMBOL_ADDR(run_ed25519, ed25519_hash_h);   // Secret key hash h.
 ACC_DECLARE_SYMBOL_ADDR(run_ed25519, ed25519_hash_k);   // Pre-computed hash k.
 ACC_DECLARE_SYMBOL_ADDR(run_ed25519, ed25519_ctx);      // Context string.
 ACC_DECLARE_SYMBOL_ADDR(run_ed25519, ed25519_ctx_len);  // Context length.
+ACC_DECLARE_SYMBOL_ADDR(run_ed25519, ed25519_message_len);    // Message length.
 ACC_DECLARE_SYMBOL_ADDR(run_ed25519, ed25519_public_key);     // Public key.
 ACC_DECLARE_SYMBOL_ADDR(run_ed25519, ed25519_verify_result);  // Verify result.
 ACC_DECLARE_SYMBOL_ADDR(run_ed25519, ed25519_session_token);  // Session token.
@@ -46,6 +47,8 @@ static const acc_addr_t kAccVarEd25519Ctx =
     ACC_ADDR_T_INIT(run_ed25519, ed25519_ctx);
 static const acc_addr_t kAccVarEd25519CtxLen =
     ACC_ADDR_T_INIT(run_ed25519, ed25519_ctx_len);
+static const acc_addr_t kAccVarEd25519MessageLen =
+    ACC_ADDR_T_INIT(run_ed25519, ed25519_message_len);
 static const acc_addr_t kAccVarEd25519PublicKey =
     ACC_ADDR_T_INIT(run_ed25519, ed25519_public_key);
 static const acc_addr_t kAccVarEd25519VerifyResult =
@@ -54,12 +57,29 @@ static const acc_addr_t kAccVarEd25519SessionToken =
     ACC_ADDR_T_INIT(run_ed25519, ed25519_session_token);
 
 // Declare mode constants.
-ACC_DECLARE_SYMBOL_ADDR(run_ed25519, ED25519_MODE_SIGN);  // Ed25519 signing.
+ACC_DECLARE_SYMBOL_ADDR(run_ed25519,
+                        ED25519_MODE_SIGN_PREHASH);  // HashEd25519 signing.
+ACC_DECLARE_SYMBOL_ADDR(run_ed25519,
+                        ED25519_MODE_SIGN_PURE_INIT);  // Pure sign: init.
+ACC_DECLARE_SYMBOL_ADDR(run_ed25519,
+                        ED25519_MODE_SIGN_PURE_UPDATE);  // Pure sign: update.
+ACC_DECLARE_SYMBOL_ADDR(run_ed25519,
+                        ED25519_MODE_SIGN_PURE_MID);  // Pure sign: mid.
+ACC_DECLARE_SYMBOL_ADDR(run_ed25519,
+                        ED25519_MODE_SIGN_PURE_FINAL);  // Pure sign: final.
 ACC_DECLARE_SYMBOL_ADDR(run_ed25519,
                         ED25519_MODE_VERIFY);  // Ed25519 verification.
 
-static const uint32_t kAccEd25519ModeSign =
-    ACC_ADDR_T_INIT(run_ed25519, ED25519_MODE_SIGN);
+static const uint32_t kAccEd25519ModeSignHash =
+    ACC_ADDR_T_INIT(run_ed25519, ED25519_MODE_SIGN_PREHASH);
+static const uint32_t kAccEd25519ModeSignPureInit =
+    ACC_ADDR_T_INIT(run_ed25519, ED25519_MODE_SIGN_PURE_INIT);
+static const uint32_t kAccEd25519ModeSignPureUpdate =
+    ACC_ADDR_T_INIT(run_ed25519, ED25519_MODE_SIGN_PURE_UPDATE);
+static const uint32_t kAccEd25519ModeSignPureMid =
+    ACC_ADDR_T_INIT(run_ed25519, ED25519_MODE_SIGN_PURE_MID);
+static const uint32_t kAccEd25519ModeSignPureFinal =
+    ACC_ADDR_T_INIT(run_ed25519, ED25519_MODE_SIGN_PURE_FINAL);
 static const uint32_t kAccEd25519ModeVerify =
     ACC_ADDR_T_INIT(run_ed25519, ED25519_MODE_VERIFY);
 
@@ -100,7 +120,7 @@ static status_t set_context(const uint32_t context[kEd25519ContextWords],
   return acc_dmem_write(1, &context_length, kAccVarEd25519CtxLen);
 }
 
-status_t ed25519_sign_start(
+status_t ed25519_sign_hash_start(
     const uint32_t prehashed_message[kEd25519PreHashWords],
     const uint32_t hash_h[kEd25519HashWords],
     const uint32_t context[kEd25519ContextWords], const uint32_t context_length,
@@ -108,8 +128,8 @@ status_t ed25519_sign_start(
   // Load the Ed25519 app. Fails if ACC is non-idle.
   HARDENED_TRY(acc_load_app(kAccAppEd25519));
 
-  // Set mode so start() will jump into signing.
-  uint32_t mode = kAccEd25519ModeSign;
+  // Set mode so start() will jump into HashEd25519 signing.
+  uint32_t mode = kAccEd25519ModeSignHash;
   HARDENED_TRY(acc_dmem_write(kAccEd25519ModeWords, &mode, kAccVarEd25519Mode));
 
   // Set the precomputed private key hash h.
@@ -132,8 +152,152 @@ status_t ed25519_sign_start(
   return acc_execute();
 }
 
-status_t ed25519_sign_finalize(uint32_t session_token,
-                               ed25519_signature_t *result) {
+enum {
+  /**
+   * Maximum message chunk size in bytes for incremental pure Ed25519 signing.
+   */
+  kEd25519MaxChunkBytes = 1280,
+};
+
+/**
+ * Run one phase of the incremental pure Ed25519 signing on ACC.
+ *
+ * Sets the mode, executes the ACC, waits for completion, and checks the
+ * instruction count against the expected range for the phase.
+ */
+static status_t ed25519_sign_pure_run_phase(uint32_t mode, uint32_t min_insn,
+                                            uint32_t max_insn) {
+  HARDENED_TRY(acc_dmem_write(kAccEd25519ModeWords, &mode, kAccVarEd25519Mode));
+  HARDENED_TRY(acc_execute());
+  ACC_WIPE_IF_ERROR(acc_busy_wait_for_done());
+  ACC_CHECK_INSN_COUNT(min_insn, max_insn);
+  return OTCRYPTO_OK;
+}
+
+/**
+ * Write a message chunk to DMEM, padded to a 32-byte boundary.
+ */
+static status_t ed25519_sign_pure_write_chunk(const uint8_t *chunk,
+                                              size_t chunk_len) {
+  size_t padded_words =
+      ceil_div(chunk_len, kAccWideWordNumBytes) * kAccWideWordNumWords;
+  uint32_t padded[padded_words];
+  memset(padded, 0, sizeof(padded));
+  memcpy(padded, chunk, chunk_len);
+  HARDENED_TRY(acc_dmem_write(padded_words, padded, kAccVarEd25519Message));
+  uint32_t len_word = (uint32_t)chunk_len;
+  return acc_dmem_write(1, &len_word, kAccVarEd25519MessageLen);
+}
+
+/**
+ * Start an incremental pure Ed25519 signature generation on ACC.
+ *
+ * The message M may be larger than what can fit in ACC DMEM.
+ * Hence, we stream in the message using an incremental API.
+ * Because M appears in both the nonce and challenge hash,
+ * it needs to be streamed twice.
+ *
+ * Pure Ed25519 signing (RFC 8032, section 5.1.6) computes:
+ *   h = SHA-512(d)                 - secret key hash (done by caller)
+ *   prefix = h[32:64]              - upper half of h
+ *   s = clamp(h[0:32])             - secret scalar from lower half
+ *   r = SHA-512(prefix || M)       - nonce hash
+ *   R = [r]B                       - signature point
+ *   A = [s]B                       - public key
+ *   k = SHA-512(R_ || A_ || M)     - challenge hash
+ *   S = (r + k * s) mod L          - signature scalar
+ *
+ * The signature is (R_, S).
+ *
+ * ACC offers the following operations:
+ * INIT   - start nonce hash: SHA-512(prefix || first_chunk)
+ * UPDATE - feed more chunks into the nonce hash
+ *          (if M > kEd25519MaxChunkBytes bytes)
+ * MID    - finalize nonce hash, compute R and A, start challenge hash.
+ * UPDATE - feed more chunks into the challenge hash
+ *          (if M > kEd25519MaxChunkBytes bytes)
+ * FINAL  - finalize challenge, compute S = (r + k * s) mod L
+ *
+ * The UPDATE steps are only required if the message is larger
+ * than kEd25519MaxChunkBytes.
+ * The two UPDATE steps are identical.
+ */
+status_t ed25519_sign_pure_start(const uint32_t *message, size_t message_len,
+                                 const uint32_t hash_h[kEd25519HashWords],
+                                 uint32_t *session_token) {
+  const uint8_t *msg = (const uint8_t *)message;
+
+  // Load the Ed25519 app. Fails if ACC is non-idle.
+  HARDENED_TRY(acc_load_app(kAccAppEd25519));
+
+  // Set the precomputed private key hash h.
+  HARDENED_TRY(acc_dmem_write(kEd25519HashWords, hash_h, kAccVarEd25519HashH));
+
+  // Generate a fresh session token, and store it in DMEM.
+  uint32_t token = ibex_rnd32_read();
+  HARDENED_TRY(acc_dmem_write(1, &token, kAccVarEd25519SessionToken));
+  *session_token = token;
+
+  // INIT: begin the nonce hash r = SHA-512(prefix || M) by hashing the key
+  // prefix (upper 32 bytes of h) and the first message chunk.
+  size_t first_chunk = (message_len < kEd25519MaxChunkBytes)
+                           ? message_len
+                           : kEd25519MaxChunkBytes;
+  HARDENED_TRY(ed25519_sign_pure_write_chunk(msg, first_chunk));
+  ACC_WIPE_IF_ERROR(ed25519_sign_pure_run_phase(
+      kAccEd25519ModeSignPureInit, kEd25519SignPureInitMinInstructionCount,
+      kEd25519SignPureInitMaxInstructionCount));
+
+  // UPDATE: feed remaining message chunks into the nonce hash.
+  for (size_t offset = first_chunk; offset < message_len;
+       offset += kEd25519MaxChunkBytes) {
+    size_t chunk = message_len - offset;
+    if (chunk > kEd25519MaxChunkBytes) {
+      chunk = kEd25519MaxChunkBytes;
+    }
+    HARDENED_TRY(ed25519_sign_pure_write_chunk(msg + offset, chunk));
+    ACC_WIPE_IF_ERROR(
+        ed25519_sign_pure_run_phase(kAccEd25519ModeSignPureUpdate,
+                                    kEd25519SignPureUpdateMinInstructionCount,
+                                    kEd25519SignPureUpdateMaxInstructionCount));
+  }
+
+  // MID: finalize the nonce hash to get r, compute the signature point
+  // R_ = encode([r]B) and public key A_ = encode([s]B), then begin the
+  // challenge hash k = SHA-512(R_ || A_ || M) with the first message chunk.
+  HARDENED_TRY(ed25519_sign_pure_write_chunk(msg, first_chunk));
+  ACC_WIPE_IF_ERROR(ed25519_sign_pure_run_phase(
+      kAccEd25519ModeSignPureMid, kEd25519SignPureMidMinInstructionCount,
+      kEd25519SignPureMidMaxInstructionCount));
+
+  // UPDATE: feed remaining message chunks into the challenge hash.
+  for (size_t offset = first_chunk; offset < message_len;
+       offset += kEd25519MaxChunkBytes) {
+    size_t chunk = message_len - offset;
+    if (chunk > kEd25519MaxChunkBytes) {
+      chunk = kEd25519MaxChunkBytes;
+    }
+    HARDENED_TRY(ed25519_sign_pure_write_chunk(msg + offset, chunk));
+    ACC_WIPE_IF_ERROR(
+        ed25519_sign_pure_run_phase(kAccEd25519ModeSignPureUpdate,
+                                    kEd25519SignPureUpdateMinInstructionCount,
+                                    kEd25519SignPureUpdateMaxInstructionCount));
+  }
+
+  // FINAL: finalize the challenge hash to get k, then compute the signature
+  // scalar S = (r + k * s) mod L. The caller reads R_ and S from DMEM.
+  uint32_t mode = kAccEd25519ModeSignPureFinal;
+  HARDENED_TRY(acc_dmem_write(kAccEd25519ModeWords, &mode, kAccVarEd25519Mode));
+  return acc_execute();
+}
+
+/**
+ * Common finalize logic for Ed25519 signing (both modes).
+ */
+static status_t ed25519_sign_finalize_inner(uint32_t session_token,
+                                            uint32_t min_insn_count,
+                                            uint32_t max_insn_count,
+                                            ed25519_signature_t *result) {
   // Return `OTCRYTPO_ASYNC_INCOMPLETE` if ACC not done.
   HARDENED_TRY(acc_assert_idle());
 
@@ -151,8 +315,7 @@ status_t ed25519_sign_finalize(uint32_t session_token,
   HARDENED_CHECK_EQ(stored_token, session_token);
 
   // Check instruction count.
-  ACC_CHECK_INSN_COUNT(kEd25519SignMinInstructionCount,
-                       kEd25519SignMaxInstructionCount);
+  ACC_CHECK_INSN_COUNT(min_insn_count, max_insn_count);
 
   // Read signature R out of ACC dmem.
   HARDENED_TRY(acc_dmem_read(8, kAccVarEd25519SigR, result->r));
@@ -162,6 +325,20 @@ status_t ed25519_sign_finalize(uint32_t session_token,
 
   // Wipe DMEM.
   return acc_dmem_sec_wipe();
+}
+
+status_t ed25519_sign_hash_finalize(uint32_t session_token,
+                                    ed25519_signature_t *result) {
+  return ed25519_sign_finalize_inner(
+      session_token, kEd25519SignHashMinInstructionCount,
+      kEd25519SignHashMaxInstructionCount, result);
+}
+
+status_t ed25519_sign_pure_finalize(uint32_t session_token,
+                                    ed25519_signature_t *result) {
+  return ed25519_sign_finalize_inner(
+      session_token, kEd25519SignPureFinalMinInstructionCount,
+      kEd25519SignPureFinalMaxInstructionCount, result);
 }
 
 status_t ed25519_verify_start(const ed25519_signature_t *signature,

--- a/sw/device/lib/crypto/impl/ecc/ed25519.c
+++ b/sw/device/lib/crypto/impl/ecc/ed25519.c
@@ -164,28 +164,19 @@ status_t ed25519_sign_finalize(uint32_t session_token,
   return acc_dmem_sec_wipe();
 }
 
-status_t ed25519_verify_start(
-    const ed25519_signature_t *signature,
-    const uint32_t prehashed_message[kEd25519PreHashWords],
-    const uint32_t hash_k[kEd25519HashWords], const ed25519_point_t *public_key,
-    const uint32_t context[kEd25519ContextWords], const uint32_t context_length,
-    uint32_t *session_token) {
-  // Load the P-256 app and set up data pointers
+status_t ed25519_verify_start(const ed25519_signature_t *signature,
+                              const uint32_t hash_k[kEd25519HashWords],
+                              const ed25519_point_t *public_key,
+                              uint32_t *session_token) {
+  // Load the Ed25519 app.
   HARDENED_TRY(acc_load_app(kAccAppEd25519));
 
   // Set mode so start() will jump into verifying.
   uint32_t mode = kAccEd25519ModeVerify;
   HARDENED_TRY(acc_dmem_write(kAccEd25519ModeWords, &mode, kAccVarEd25519Mode));
 
-  // Set the pre-hashed message to the provided digest.
-  HARDENED_TRY(acc_dmem_write(kEd25519HashWords, prehashed_message,
-                              kAccVarEd25519Message));
-
   // Set the precomputed hash value k.
   HARDENED_TRY(acc_dmem_write(kEd25519HashWords, hash_k, kAccVarEd25519HashK));
-
-  // Set the context string.
-  HARDENED_TRY(set_context(context, context_length));
 
   // Set the signature R.
   HARDENED_TRY(

--- a/sw/device/lib/crypto/impl/ecc/ed25519.h
+++ b/sw/device/lib/crypto/impl/ecc/ed25519.h
@@ -179,21 +179,16 @@ status_t ed25519_sign_finalize(uint32_t session_token,
  * function; see that section of the RFC for details.
  *
  * @param signature Signature to verify.
- * @param prehashed_message Prehashed (SHA-512) message to sign.
  * @param hash_k Pre-computed scalar value k for verification.
  * @param public_key Public key to verify against.
- * @param context Context to use for signing.
- * @param context_length Length of the provided context in bytes.
  * @param[out] session_token ACC session token for the operation.
  * @return Result of the operation (OK or error).
  */
 OT_WARN_UNUSED_RESULT
-status_t ed25519_verify_start(
-    const ed25519_signature_t *signature,
-    const uint32_t prehashed_message[kEd25519PreHashWords],
-    const uint32_t hash_k[kEd25519HashWords], const ed25519_point_t *public_key,
-    const uint32_t context[kEd25519ContextWords], const uint32_t context_length,
-    uint32_t *session_token);
+status_t ed25519_verify_start(const ed25519_signature_t *signature,
+                              const uint32_t hash_k[kEd25519HashWords],
+                              const ed25519_point_t *public_key,
+                              uint32_t *session_token);
 
 /**
  * Finish an async Ed25519 signature verification operation on ACC.

--- a/sw/device/lib/crypto/impl/ecc/ed25519.h
+++ b/sw/device/lib/crypto/impl/ecc/ed25519.h
@@ -138,7 +138,7 @@ typedef struct ed25519_signature {
 ;
 
 /**
- * Start an async Ed25519ph signature generation operation on ACC.
+ * Start an async HashEd25519 signature generation operation on ACC.
  *
  * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if ACC is busy.
  *
@@ -150,26 +150,49 @@ typedef struct ed25519_signature {
  * @return Result of the operation (OK or error).
  */
 OT_WARN_UNUSED_RESULT
-status_t ed25519_sign_start(
+status_t ed25519_sign_hash_start(
     const uint32_t prehashed_message[kEd25519PreHashWords],
     const uint32_t hash_h[kEd25519HashWords],
     const uint32_t context[kEd25519ContextWords], const uint32_t context_length,
     uint32_t *session_token);
 
 /**
- * Finish an async Ed25519 signature generation operation on ACC.
+ * Start an async pure Ed25519 signature generation operation on ACC.
  *
- * See the documentation of `p256_ecdsa_sign` for details.
+ * Returns an `OTCRYPTO_ASYNC_INCOMPLETE` error if ACC is busy.
  *
- * Blocks until ACC is idle.
+ * @param message Message to sign (word-aligned).
+ * @param message_len Length of the message in bytes.
+ * @param hash_h SHA-512 hash of the Ed25519 private key to sign with.
+ * @param[out] session_token ACC session token for the operation.
+ * @return Result of the operation (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+status_t ed25519_sign_pure_start(const uint32_t *message, size_t message_len,
+                                 const uint32_t hash_h[kEd25519HashWords],
+                                 uint32_t *session_token);
+
+/**
+ * Finish an async HashEd25519 signature generation operation on ACC.
  *
  * @param session_token ACC session token for the operation.
  * @param[out] result Buffer in which to store the generated signature.
  * @return Result of the operation (OK or error).
  */
 OT_WARN_UNUSED_RESULT
-status_t ed25519_sign_finalize(uint32_t session_token,
-                               ed25519_signature_t *result);
+status_t ed25519_sign_hash_finalize(uint32_t session_token,
+                                    ed25519_signature_t *result);
+
+/**
+ * Finish an async pure Ed25519 signature generation operation on ACC.
+ *
+ * @param session_token ACC session token for the operation.
+ * @param[out] result Buffer in which to store the generated signature.
+ * @return Result of the operation (OK or error).
+ */
+OT_WARN_UNUSED_RESULT
+status_t ed25519_sign_pure_finalize(uint32_t session_token,
+                                    ed25519_signature_t *result);
 
 /**
  * Start an async Ed25519 signature verification operation on ACC.

--- a/sw/device/lib/crypto/impl/ecc/ed25519_modes.hjson
+++ b/sw/device/lib/crypto/impl/ecc/ed25519_modes.hjson
@@ -4,9 +4,29 @@
 
 [
   {
-    symbol: "ed25519_sign_top",
-    const_str: "Ed25519Sign",
-    comment: "Ed25519 signing",
+    symbol: "ed25519_sign_hash_top",
+    const_str: "Ed25519SignHash",
+    comment: "Ed25519 signing (HashEd25519)",
+  },
+  {
+    symbol: "ed25519_sign_pure_init_top",
+    const_str: "Ed25519SignPureInit",
+    comment: "Ed25519 pure signing (init phase)",
+  },
+  {
+    symbol: "ed25519_sign_pure_update_top",
+    const_str: "Ed25519SignPureUpdate",
+    comment: "Ed25519 pure signing (update phase)",
+  },
+  {
+    symbol: "ed25519_sign_pure_mid_top",
+    const_str: "Ed25519SignPureMid",
+    comment: "Ed25519 pure signing (mid phase)",
+  },
+  {
+    symbol: "ed25519_sign_pure_final_top",
+    const_str: "Ed25519SignPureFinal",
+    comment: "Ed25519 pure signing (final phase)",
   },
   {
     symbol: "ed25519_verify_top",

--- a/sw/device/lib/crypto/impl/ed25519.c
+++ b/sw/device/lib/crypto/impl/ed25519.c
@@ -32,7 +32,8 @@ otcrypto_status_t otcrypto_ed25519_sign(
   HARDENED_TRY(otcrypto_ed25519_sign_async_start(
       private_key, input_message, context, sign_mode, &session_token));
   ACC_WIPE_IF_ERROR(acc_busy_wait_for_done());
-  return otcrypto_ed25519_sign_async_finalize(session_token, signature);
+  return otcrypto_ed25519_sign_async_finalize(session_token, sign_mode,
+                                              signature);
 }
 
 otcrypto_status_t otcrypto_ed25519_verify(
@@ -147,20 +148,22 @@ otcrypto_status_t otcrypto_ed25519_sign_async_start(
   // Check that the entropy complex is initialized.
   HARDENED_TRY(entropy_complex_check());
 
-  // Check the mode; currently, only HashEd25519 is allowed.
-  if (launder32(sign_mode) != kOtcryptoEddsaSignModeHashEddsa) {
+  // Check the sign mode and message/context constraints.
+  if (launder32(sign_mode) == kOtcryptoEddsaSignModeHashEddsa) {
+    HARDENED_CHECK_EQ(sign_mode, kOtcryptoEddsaSignModeHashEddsa);
+    if (launder32(input_message.len) != kEd25519PreHashBytes) {
+      return OTCRYPTO_BAD_ARGS;
+    }
+    HARDENED_CHECK_EQ(input_message.len, kEd25519PreHashBytes);
+  } else if (launder32(sign_mode) == kOtcryptoEddsaSignModeEddsa) {
+    HARDENED_CHECK_EQ(sign_mode, kOtcryptoEddsaSignModeEddsa);
+    if (launder32(context.len) != 0) {
+      return OTCRYPTO_BAD_ARGS;
+    }
+    HARDENED_CHECK_EQ(context.len, 0);
+  } else {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(sign_mode, kOtcryptoEddsaSignModeHashEddsa);
-
-  // Check the input message size: since only HashEd25519 is allowed presently,
-  // this must be the full size of the prehash output.
-  if (launder32(input_message.len) != kEd25519PreHashBytes) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  HARDENED_CHECK_EQ(input_message.len, kEd25519PreHashBytes);
-
-  // TODO: how will we check context size? should we?
 
   // Check the integrity of the private key.
   if (launder32(integrity_blinded_key_check(private_key)) !=
@@ -186,25 +189,31 @@ otcrypto_status_t otcrypto_ed25519_sign_async_start(
   // Copy the input message into a 32-bit aligned buffer.
   size_t input_message_wordlen = ceil_div(input_message.len, sizeof(uint32_t));
   uint32_t input_message_aligned[input_message_wordlen];
-  // TODO(#17711) Change to `hardened_memcpy`.
+  memset(input_message_aligned, 0, sizeof(input_message_aligned));
   memcpy(input_message_aligned, input_message.data, input_message.len);
-  memset(input_message_aligned, 0,
-         sizeof(input_message_aligned) - input_message.len);
-
-  // Copy the context into a 32-bit aligned buffer.
-  size_t context_wordlen = ceil_div(context.len, sizeof(uint32_t));
-  uint32_t context_aligned[context_wordlen];
-  // TODO(#17711) Change to `hardened_memcpy`.
-  memcpy(context_aligned, context.data, context.len);
-  memset(context_aligned, 0, sizeof(context_aligned) - context.len);
 
   // Start the asynchronous signature-generation routine.
-  return ed25519_sign_start(input_message_aligned, hash_h, context_aligned,
-                            context.len, session_token);
+  if (launder32(sign_mode) == kOtcryptoEddsaSignModeHashEddsa) {
+    HARDENED_CHECK_EQ(sign_mode, kOtcryptoEddsaSignModeHashEddsa);
+    // Copy the context into a 32-bit aligned buffer.
+    size_t context_wordlen = ceil_div(context.len, sizeof(uint32_t));
+    uint32_t context_aligned[context_wordlen];
+    // TODO(#17711) Change to `hardened_memcpy`.
+    memset(context_aligned, 0, sizeof(context_aligned));
+    memcpy(context_aligned, context.data, context.len);
+    return ed25519_sign_hash_start(input_message_aligned, hash_h,
+                                   context_aligned, context.len, session_token);
+  } else if (launder32(sign_mode) == kOtcryptoEddsaSignModeEddsa) {
+    HARDENED_CHECK_EQ(sign_mode, kOtcryptoEddsaSignModeEddsa);
+    return ed25519_sign_pure_start(input_message_aligned, input_message.len,
+                                   hash_h, session_token);
+  }
+  return OTCRYPTO_BAD_ARGS;
 }
 
 otcrypto_status_t otcrypto_ed25519_sign_async_finalize(
-    otcrypto_session_token_t session_token, otcrypto_word32_buf_t signature) {
+    otcrypto_session_token_t session_token,
+    otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t signature) {
   if (signature.data == NULL) {
     return OTCRYPTO_BAD_ARGS;
   }
@@ -219,7 +228,14 @@ otcrypto_status_t otcrypto_ed25519_sign_async_finalize(
   // Note: This operation wipes DMEM, so if an error occurs after this
   // point then the signature would be unrecoverable. This should be the
   // last potentially error-causing line before returning to the caller.
-  return ed25519_sign_finalize(session_token, sig_ed25519);
+  if (launder32(sign_mode) == kOtcryptoEddsaSignModeHashEddsa) {
+    HARDENED_CHECK_EQ(sign_mode, kOtcryptoEddsaSignModeHashEddsa);
+    return ed25519_sign_hash_finalize(session_token, sig_ed25519);
+  } else if (launder32(sign_mode) == kOtcryptoEddsaSignModeEddsa) {
+    HARDENED_CHECK_EQ(sign_mode, kOtcryptoEddsaSignModeEddsa);
+    return ed25519_sign_pure_finalize(session_token, sig_ed25519);
+  }
+  return OTCRYPTO_BAD_ARGS;
 }
 
 OT_WARN_UNUSED_RESULT
@@ -299,12 +315,6 @@ otcrypto_status_t otcrypto_ed25519_verify_async_start(
 
   // Ensure the entropy complex is initialized.
   HARDENED_TRY(entropy_complex_check());
-
-  // Check the mode; currently, only HashEd25519 is allowed.
-  if (launder32(sign_mode) != kOtcryptoEddsaSignModeHashEddsa) {
-    return OTCRYPTO_BAD_ARGS;
-  }
-  HARDENED_CHECK_EQ(sign_mode, kOtcryptoEddsaSignModeHashEddsa);
 
   // Check the integrity of the public key.
   if (launder32(integrity_unblinded_key_check(public_key)) !=

--- a/sw/device/lib/crypto/impl/ed25519.c
+++ b/sw/device/lib/crypto/impl/ed25519.c
@@ -237,26 +237,28 @@ static status_t construct_hash_k(uint32_t hash_k[kEd25519HashWords],
                                  otcrypto_const_word32_buf_t signature,
                                  otcrypto_const_byte_buf_t context,
                                  const otcrypto_unblinded_key_t *public_key,
-                                 otcrypto_const_byte_buf_t input_message) {
+                                 otcrypto_const_byte_buf_t input_message,
+                                 otcrypto_eddsa_sign_mode_t sign_mode) {
   // Initialize the SHA-512 computation.
   otcrypto_sha2_context_t ctx;
   HARDENED_TRY(otcrypto_sha2_init(kOtcryptoHashModeSha512, &ctx));
 
-  // Update with the domain separation string, pre-hash flag, and context
-  // length all together.
-  uint8_t domain_sep_data[34] = {'S', 'i', 'g', 'E', 'd', '2',  '5', '5', '1',
-                                 '9', ' ', 'n', 'o', ' ', 'E',  'd', '2', '5',
-                                 '5', '1', '9', ' ', 'c', 'o',  'l', 'l', 'i',
-                                 's', 'i', 'o', 'n', 's', 0x01, 0x00};
-  domain_sep_data[33] = (uint8_t)context.len;
-  otcrypto_const_byte_buf_t domain_sep_buf = {
-      .data = domain_sep_data,
-      .len = sizeof(domain_sep_data),
-  };
-  HARDENED_TRY(otcrypto_sha2_update(&ctx, domain_sep_buf));
-
-  // Update with the context.
-  HARDENED_TRY(otcrypto_sha2_update(&ctx, context));
+  if (launder32(sign_mode) == kOtcryptoEddsaSignModeHashEddsa) {
+    // HashEd25519: include dom2(1, ctx) prefix (RFC 8032 5.1).
+    HARDENED_CHECK_EQ(sign_mode, kOtcryptoEddsaSignModeHashEddsa);
+    uint8_t domain_sep_data[34] = {'S', 'i', 'g', 'E', 'd', '2',  '5', '5', '1',
+                                   '9', ' ', 'n', 'o', ' ', 'E',  'd', '2', '5',
+                                   '5', '1', '9', ' ', 'c', 'o',  'l', 'l', 'i',
+                                   's', 'i', 'o', 'n', 's', 0x01, 0x00};
+    domain_sep_data[33] = (uint8_t)context.len;
+    otcrypto_const_byte_buf_t domain_sep_buf = {
+        .data = domain_sep_data,
+        .len = sizeof(domain_sep_data),
+    };
+    HARDENED_TRY(otcrypto_sha2_update(&ctx, domain_sep_buf));
+    HARDENED_TRY(otcrypto_sha2_update(&ctx, context));
+  }
+  // Pure Ed25519: no domain separator (RFC 8032 5.1.7).
 
   // Update with the first half of the signature, R.
   otcrypto_const_byte_buf_t signature_point_buf = {
@@ -272,7 +274,7 @@ static status_t construct_hash_k(uint32_t hash_k[kEd25519HashWords],
   };
   HARDENED_TRY(otcrypto_sha2_update(&ctx, public_key_buf));
 
-  // Update with the pre-hashed message, PH(M).
+  // Update with the message (PH(M) for HashEd25519, raw M for pure).
   HARDENED_TRY(otcrypto_sha2_update(&ctx, input_message));
 
   // Finalize the computed digest.
@@ -322,36 +324,36 @@ otcrypto_status_t otcrypto_ed25519_verify_async_start(
   HARDENED_TRY(ed25519_public_key_length_check(public_key));
   ed25519_point_t *pk = (ed25519_point_t *)public_key->key;
 
-  // Check the digest length.
-  if (launder32(input_message.len) != kEd25519PreHashBytes) {
+  // Check the sign mode.
+  if (launder32(sign_mode) == kOtcryptoEddsaSignModeHashEddsa) {
+    HARDENED_CHECK_EQ(sign_mode, kOtcryptoEddsaSignModeHashEddsa);
+    // HashEd25519: message must be the pre-hash output (64 bytes).
+    if (launder32(input_message.len) != kEd25519PreHashBytes) {
+      return OTCRYPTO_BAD_ARGS;
+    }
+    HARDENED_CHECK_EQ(input_message.len, kEd25519PreHashBytes);
+  } else if (launder32(sign_mode) == kOtcryptoEddsaSignModeEddsa) {
+    HARDENED_CHECK_EQ(sign_mode, kOtcryptoEddsaSignModeEddsa);
+    // Pure Ed25519: context must be empty.
+    if (launder32(context.len) != 0) {
+      return OTCRYPTO_BAD_ARGS;
+    }
+    HARDENED_CHECK_EQ(context.len, 0);
+  } else {
     return OTCRYPTO_BAD_ARGS;
   }
-  HARDENED_CHECK_EQ(input_message.len, kEd25519PreHashBytes);
 
   // Check the signature lengths.
   HARDENED_TRY(ed25519_signature_length_check(signature.len));
   ed25519_signature_t *sig = (ed25519_signature_t *)signature.data;
 
-  // Copy the input message into a 32-bit aligned buffer.
-  size_t input_message_wordlen = ceil_div(input_message.len, sizeof(uint32_t));
-  uint32_t input_message_aligned[input_message_wordlen];
-  memset(input_message_aligned, 0, sizeof(input_message_aligned));
-  memcpy(input_message_aligned, input_message.data, input_message.len);
-
-  // Compute the pre-computed hash k
+  // Compute the hash k = SHA-512([dom2] || R || A || M).
   uint32_t hash_k[kEd25519HashWords];
-  HARDENED_TRY(
-      construct_hash_k(hash_k, signature, context, public_key, input_message));
-
-  size_t context_wordlen = ceil_div(context.len, sizeof(uint32_t));
-  uint32_t context_aligned[context_wordlen];
-  // TODO(#17711) Change to `hardened_memcpy`.
-  memcpy(context_aligned, context.data, context.len);
-  memset(context_aligned, 0, sizeof(context_aligned) - context.len);
+  HARDENED_TRY(construct_hash_k(hash_k, signature, context, public_key,
+                                input_message, sign_mode));
 
   // Start the asynchronous signature-verification routine.
-  return ed25519_verify_start(sig, input_message_aligned, hash_k, pk,
-                              context_aligned, context.len, session_token);
+  return ed25519_verify_start(sig, hash_k, pk, session_token);
 }
 
 otcrypto_status_t otcrypto_ed25519_verify_async_finalize(

--- a/sw/device/lib/crypto/include/ed25519.h
+++ b/sw/device/lib/crypto/include/ed25519.h
@@ -142,7 +142,7 @@ otcrypto_status_t otcrypto_ed25519_sign_async_start(
 /**
  * Finalizes asynchronous signature generation for Ed25519.
  *
- * See `otcrypto_ecdsa_p256_sign` for requirements on input values.
+ * See `otcrypto_ed25519_sign` for requirements on input values.
  *
  * May block until the operation is complete.
  *
@@ -157,7 +157,7 @@ otcrypto_status_t otcrypto_ed25519_sign_async_finalize(
 /**
  * Starts asynchronous signature verification for Ed25519.
  *
- * See `otcrypto_ecdsa_p256_verify` for requirements on input values.
+ * See `otcrypto_ed25519_verify` for requirements on input values.
  *
  * @param public_key Pointer to the unblinded public key struct.
  * @param input_message Input message to be signed for verification.
@@ -177,7 +177,7 @@ otcrypto_status_t otcrypto_ed25519_verify_async_start(
 /**
  * Finalizes asynchronous signature verification for Ed25519.
  *
- * See `otcrypto_ecdsa_p256_verify` for requirements on input values.
+ * See `otcrypto_ed25519_verify` for requirements on input values.
  *
  * May block until the operation is complete.
  *

--- a/sw/device/lib/crypto/include/ed25519.h
+++ b/sw/device/lib/crypto/include/ed25519.h
@@ -147,12 +147,14 @@ otcrypto_status_t otcrypto_ed25519_sign_async_start(
  * May block until the operation is complete.
  *
  * @param session_token Session token for this operation.
+ * @param sign_mode Signing mode.
  * @param[out] signature Pointer to the EdDSA signature to get (s) value.
  * @return Result of async Ed25519 finalize operation.
  */
 OT_WARN_UNUSED_RESULT
 otcrypto_status_t otcrypto_ed25519_sign_async_finalize(
-    otcrypto_session_token_t session_token, otcrypto_word32_buf_t signature);
+    otcrypto_session_token_t session_token,
+    otcrypto_eddsa_sign_mode_t sign_mode, otcrypto_word32_buf_t signature);
 
 /**
  * Starts asynchronous signature verification for Ed25519.

--- a/sw/device/tests/crypto/cryptotest/BUILD
+++ b/sw/device/tests/crypto/cryptotest/BUILD
@@ -520,6 +520,7 @@ cryptotest(
 ED25519_TESTVECTOR_TARGETS = [
     "//sw/host/cryptotest/testvectors/data:acvp_eddsa_sigver_json",
     "//sw/host/cryptotest/testvectors/data:acvp_eddsa_siggen_json",
+    "//sw/host/cryptotest/testvectors/data:wycheproof_ed25519_json",
 ]
 
 ED25519_TESTVECTOR_ARGS = " ".join([

--- a/sw/device/tests/crypto/cryptotest/firmware/ed25519.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/ed25519.c
@@ -63,12 +63,13 @@ static status_t handle_ed25519_sigver(ujson_t *uj) {
   };
 
   // Set up the signature.
-  uint32_t sig_data[kEd25519SignatureWords];
+  size_t sig_words = uj_signature.signature_len / sizeof(uint32_t);
+  uint32_t sig_data[ED25519_CMD_MAX_SIGNATURE_BYTES / sizeof(uint32_t)];
   memset(sig_data, 0, sizeof(sig_data));
   memcpy(sig_data, uj_signature.signature, uj_signature.signature_len);
   otcrypto_const_word32_buf_t signature = {
       .data = sig_data,
-      .len = kEd25519SignatureWords,
+      .len = sig_words,
   };
 
   // Map the ujson sign mode to the cryptolib enum.

--- a/sw/device/tests/crypto/cryptotest/firmware/ed25519.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/ed25519.c
@@ -31,10 +31,12 @@ static const otcrypto_key_config_t kEd25519PrivateKeyConfig = {
 };
 
 static status_t handle_ed25519_sigver(ujson_t *uj) {
+  cryptotest_ed25519_sign_mode_t uj_sign_mode;
   cryptotest_ed25519_message_t uj_message;
   cryptotest_ed25519_signature_t uj_signature;
   cryptotest_ed25519_public_key_t uj_public_key;
 
+  TRY(ujson_deserialize_cryptotest_ed25519_sign_mode_t(uj, &uj_sign_mode));
   TRY(ujson_deserialize_cryptotest_ed25519_message_t(uj, &uj_message));
   TRY(ujson_deserialize_cryptotest_ed25519_signature_t(uj, &uj_signature));
   TRY(ujson_deserialize_cryptotest_ed25519_public_key_t(uj, &uj_public_key));
@@ -69,11 +71,24 @@ static status_t handle_ed25519_sigver(ujson_t *uj) {
       .len = kEd25519SignatureWords,
   };
 
+  // Map the ujson sign mode to the cryptolib enum.
+  otcrypto_eddsa_sign_mode_t sign_mode;
+  switch (uj_sign_mode) {
+    case kCryptotestEd25519SignModeEddsa:
+      sign_mode = kOtcryptoEddsaSignModeEddsa;
+      break;
+    case kCryptotestEd25519SignModeHashEddsa:
+      sign_mode = kOtcryptoEddsaSignModeHashEddsa;
+      break;
+    default:
+      return INVALID_ARGUMENT();
+  }
+
   // Verify.
   hardened_bool_t verification_result = kHardenedBoolFalse;
-  otcrypto_status_t status = otcrypto_ed25519_verify(
-      &public_key, message, context, kOtcryptoEddsaSignModeHashEddsa, signature,
-      &verification_result);
+  otcrypto_status_t status =
+      otcrypto_ed25519_verify(&public_key, message, context, sign_mode,
+                              signature, &verification_result);
 
   cryptotest_ed25519_verify_output_t uj_output =
       (status_ok(status) && verification_result == kHardenedBoolTrue)

--- a/sw/device/tests/crypto/cryptotest/firmware/ed25519.c
+++ b/sw/device/tests/crypto/cryptotest/firmware/ed25519.c
@@ -101,8 +101,24 @@ static status_t handle_ed25519_sigver(ujson_t *uj) {
 }
 
 static status_t handle_ed25519_siggen(ujson_t *uj) {
+  cryptotest_ed25519_sign_mode_t uj_sign_mode;
+  TRY(ujson_deserialize_cryptotest_ed25519_sign_mode_t(uj, &uj_sign_mode));
+
   cryptotest_ed25519_siggen_data_t uj_data;
   TRY(ujson_deserialize_cryptotest_ed25519_siggen_data_t(uj, &uj_data));
+
+  // Map the ujson sign mode to the cryptolib enum.
+  otcrypto_eddsa_sign_mode_t sign_mode;
+  switch (uj_sign_mode) {
+    case kCryptotestEd25519SignModeEddsa:
+      sign_mode = kOtcryptoEddsaSignModeEddsa;
+      break;
+    case kCryptotestEd25519SignModeHashEddsa:
+      sign_mode = kOtcryptoEddsaSignModeHashEddsa;
+      break;
+    default:
+      return INVALID_ARGUMENT();
+  }
 
   // Set up the private key.
   uint32_t sk_data[kEd25519PrivateKeyBytes / sizeof(uint32_t)];
@@ -115,7 +131,7 @@ static status_t handle_ed25519_siggen(ujson_t *uj) {
   };
   private_key.checksum = integrity_blinded_checksum(&private_key);
 
-  // Set up the pre-hashed message.
+  // Set up the message.
   otcrypto_const_byte_buf_t message = {
       .data = uj_data.message,
       .len = uj_data.message_len,
@@ -135,8 +151,8 @@ static status_t handle_ed25519_siggen(ujson_t *uj) {
   };
 
   // Sign.
-  otcrypto_status_t status = otcrypto_ed25519_sign(
-      &private_key, message, context, kOtcryptoEddsaSignModeHashEddsa, sig_buf);
+  otcrypto_status_t status =
+      otcrypto_ed25519_sign(&private_key, message, context, sign_mode, sig_buf);
 
   // Verify the signature we just produced.
   if (status_ok(status)) {
@@ -153,9 +169,8 @@ static status_t handle_ed25519_siggen(ujson_t *uj) {
     hardened_bool_t verification_result = kHardenedBoolFalse;
     otcrypto_const_word32_buf_t sig_const = {.data = sig,
                                              .len = ARRAYSIZE(sig)};
-    TRY(otcrypto_ed25519_verify(&public_key, message, context,
-                                kOtcryptoEddsaSignModeHashEddsa, sig_const,
-                                &verification_result));
+    TRY(otcrypto_ed25519_verify(&public_key, message, context, sign_mode,
+                                sig_const, &verification_result));
     if (verification_result != kHardenedBoolTrue) {
       LOG_ERROR("Ed25519 signature verification failed after signing");
       return INTERNAL();

--- a/sw/device/tests/crypto/cryptotest/json/ed25519_commands.h
+++ b/sw/device/tests/crypto/cryptotest/json/ed25519_commands.h
@@ -26,6 +26,11 @@ extern "C" {
     value(_, Ed25519Siggen)
 UJSON_SERDE_ENUM(Ed25519Subcommand, ed25519_subcommand_t, ED25519_SUBCOMMAND);
 
+#define ED25519_SIGN_MODE(_, value) \
+    value(_, Eddsa) \
+    value(_, HashEddsa)
+UJSON_SERDE_ENUM(CryptotestEd25519SignMode, cryptotest_ed25519_sign_mode_t, ED25519_SIGN_MODE);
+
 #define ED25519_MESSAGE(field, string) \
     field(input, uint8_t, ED25519_CMD_MAX_MESSAGE_BYTES) \
     field(input_len, size_t)

--- a/sw/device/tests/crypto/ed25519_functest.c
+++ b/sw/device/tests/crypto/ed25519_functest.c
@@ -52,6 +52,8 @@ static const otcrypto_key_config_t kPrivateKeyConfig = {
 };
 
 status_t sign_then_verify_test(hardened_bool_t *verification_result,
+                               otcrypto_eddsa_sign_mode_t sign_mode,
+                               const uint8_t *msg, size_t msg_len,
                                const uint8_t *ctx, size_t ctx_len) {
   // Set up private key.
   otcrypto_blinded_key_t private_key = {
@@ -71,23 +73,24 @@ status_t sign_then_verify_test(hardened_bool_t *verification_result,
   private_key.checksum = integrity_blinded_checksum(&private_key);
   public_key.checksum = integrity_unblinded_checksum(&public_key);
 
-  // Hash the message.
-  otcrypto_const_byte_buf_t msg = {
-      .data = (unsigned char *)&kMessage,
-      .len = sizeof(kMessage) - 1,
-  };
   uint32_t msg_digest_data[512 / 32];
-  otcrypto_hash_digest_t msg_digest = {
-      .data = msg_digest_data,
-      .len = ARRAYSIZE(msg_digest_data),
-  };
-  TRY(otcrypto_sha2_512(msg, &msg_digest));
-
-  // Convert the hashed message into a const byte buffer.
-  otcrypto_const_byte_buf_t msg_digest_buf = {
-      .data = (uint8_t *)msg_digest_data,
-      .len = sizeof(msg_digest_data),
-  };
+  if (sign_mode == kOtcryptoEddsaSignModeHashEddsa) {
+    // Hash the message for HashEd25519.
+    otcrypto_const_byte_buf_t raw_msg = {
+        .data = msg,
+        .len = msg_len,
+    };
+    otcrypto_hash_digest_t msg_digest = {
+        .data = msg_digest_data,
+        .len = ARRAYSIZE(msg_digest_data),
+    };
+    TRY(otcrypto_sha2_512(raw_msg, &msg_digest));
+  }
+  otcrypto_const_byte_buf_t message =
+      (sign_mode == kOtcryptoEddsaSignModeHashEddsa)
+          ? (otcrypto_const_byte_buf_t){.data = (uint8_t *)msg_digest_data,
+                                        .len = sizeof(msg_digest_data)}
+          : (otcrypto_const_byte_buf_t){.data = msg, .len = msg_len};
 
   // Allocate space for the signature.
   uint32_t sig[kEd25519SignatureWords] = {0};
@@ -95,15 +98,16 @@ status_t sign_then_verify_test(hardened_bool_t *verification_result,
   otcrypto_const_byte_buf_t context = {.data = ctx, .len = ctx_len};
 
   // Generate a signature for the message.
-  LOG_INFO("Signing (ctx_len=%d)...", ctx_len);
+  LOG_INFO("Signing (mode=%d, msg_len=%d, ctx_len=%d)...", sign_mode,
+           message.len, ctx_len);
   CHECK_STATUS_OK(otcrypto_ed25519_sign(
-      &private_key, msg_digest_buf, context, kOtcryptoEddsaSignModeHashEddsa,
+      &private_key, message, context, sign_mode,
       (otcrypto_word32_buf_t){.data = sig, .len = ARRAYSIZE(sig)}));
 
   // Verify the signature.
   LOG_INFO("Verifying...");
   CHECK_STATUS_OK(otcrypto_ed25519_verify(
-      &public_key, msg_digest_buf, context, kOtcryptoEddsaSignModeHashEddsa,
+      &public_key, message, context, sign_mode,
       (otcrypto_const_word32_buf_t){.data = sig, .len = ARRAYSIZE(sig)},
       verification_result));
 
@@ -115,14 +119,16 @@ OTTF_DEFINE_TEST_CONFIG();
 bool test_main(void) {
   CHECK_STATUS_OK(entropy_testutils_auto_mode_init());
 
-  // Test with various context lengths.
-  uint8_t ctx_buf[160];
+  // Test HashEd25519 with various context lengths.
+  uint8_t ctx_buf[255];
   memset(ctx_buf, 0x42, sizeof(ctx_buf));
-  size_t ctx_lens[] = {0, 8, 96, 160, 8, 32};
+  size_t ctx_lens[] = {0, 1, 8, 31, 32, 33, 96, 160, 8, 255};
 
   for (size_t i = 0; i < ARRAYSIZE(ctx_lens); i++) {
     hardened_bool_t result;
-    status_t err = sign_then_verify_test(&result, ctx_buf, ctx_lens[i]);
+    status_t err = sign_then_verify_test(
+        &result, kOtcryptoEddsaSignModeHashEddsa, (const uint8_t *)kMessage,
+        sizeof(kMessage) - 1, ctx_buf, ctx_lens[i]);
     if (!status_ok(err)) {
       LOG_INFO("ACC error bits: 0x%08x", acc_err_bits_get());
       LOG_INFO("ACC instruction count: 0x%08x", acc_instruction_count_get());
@@ -130,8 +136,33 @@ bool test_main(void) {
       return false;
     }
     if (result != kHardenedBoolTrue) {
-      LOG_ERROR("Verification failed (ctx_len=%d)!", ctx_lens[i]);
+      LOG_ERROR("HashEd25519 verification failed (ctx_len=%d)!", ctx_lens[i]);
       return false;
+    }
+  }
+
+  // Test pure Ed25519 with various message lengths.
+  {
+    static uint8_t msg_buf[4097];
+    memset(msg_buf, 0xA5, sizeof(msg_buf));
+    size_t msg_lens[] = {0,   1,   3,    31,   32,   33,   64,  127,
+                         128, 129, 1279, 1280, 1281, 2560, 4097};
+
+    for (size_t i = 0; i < ARRAYSIZE(msg_lens); i++) {
+      hardened_bool_t result;
+      status_t err = sign_then_verify_test(&result, kOtcryptoEddsaSignModeEddsa,
+                                           msg_buf, msg_lens[i], NULL, 0);
+      if (!status_ok(err)) {
+        LOG_INFO("ACC error bits: 0x%08x", acc_err_bits_get());
+        LOG_INFO("ACC instruction count: 0x%08x", acc_instruction_count_get());
+        CHECK_STATUS_OK(err);
+        return false;
+      }
+      if (result != kHardenedBoolTrue) {
+        LOG_ERROR("Pure Ed25519 verification failed (msg_len=%d)!",
+                  msg_lens[i]);
+        return false;
+      }
     }
   }
 

--- a/sw/device/tests/crypto/otcrypto_interface.h
+++ b/sw/device/tests/crypto/otcrypto_interface.h
@@ -190,6 +190,7 @@ typedef struct otcrypto_interface_t {
                                                 otcrypto_eddsa_sign_mode_t,
                                                 otcrypto_session_token_t *);
   otcrypto_status_t (*ed25519_sign_async_finalize)(otcrypto_session_token_t,
+                                                   otcrypto_eddsa_sign_mode_t,
                                                    otcrypto_word32_buf_t);
   otcrypto_status_t (*ed25519_verify_async_start)(
       const otcrypto_unblinded_key_t *, otcrypto_const_byte_buf_t,

--- a/sw/host/cryptotest/testvectors/data/schemas/ed25519_schema.json
+++ b/sw/host/cryptotest/testvectors/data/schemas/ed25519_schema.json
@@ -37,8 +37,13 @@
         "type": "string",
         "enum": ["verify", "sign"]
       },
+      "sign_mode": {
+        "description": "EdDSA signing mode",
+        "type": "string",
+        "enum": ["eddsa", "hash_eddsa"]
+      },
       "message": {
-        "description": "Pre-hashed message (SHA-512 digest)",
+        "description": "Message or pre-hashed message",
         "$ref": "#/$defs/byte_array"
       },
       "public_key": {

--- a/sw/host/cryptotest/testvectors/parsers/nist_acvp_eddsa_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/nist_acvp_eddsa_parser.py
@@ -27,25 +27,31 @@ import jsonschema
 def parse_sigver(data):
     """Parse EDDSA-SigVer internalProjection.
 
-    Only Ed25519 with preHash=true (Ed25519ph / HashEdDSA) is selected.
-    The message is pre-hashed with SHA-512 before output.
+    Supports both pure Ed25519 (preHash=false) and HashEd25519
+    (preHash=true). For HashEd25519, the message is pre-hashed with
+    SHA-512 before output.
     """
     test_vectors = []
     for group in data["testGroups"]:
         if group["curve"] != "ED-25519":
             continue
-        if not group.get("preHash", False):
-            continue
 
+        pre_hash = group.get("preHash", False)
         for test in group["tests"]:
             msg_bytes = bytes.fromhex(test["message"])
-            prehash = hashlib.sha512(msg_bytes).digest()
+            if pre_hash:
+                message = list(hashlib.sha512(msg_bytes).digest())
+                sign_mode = "hash_eddsa"
+            else:
+                message = list(msg_bytes)
+                sign_mode = "eddsa"
             test_vectors.append({
                 "vendor": "acvp",
                 "test_case_id": test["tcId"],
                 "algorithm": "ed25519",
                 "operation": "verify",
-                "message": list(prehash),
+                "sign_mode": sign_mode,
+                "message": message,
                 "public_key": list(bytes.fromhex(test["q"])),
                 "signature": list(bytes.fromhex(test["signature"])),
                 "result": test["testPassed"],
@@ -70,13 +76,13 @@ def parse_siggen(data):
         q = list(bytes.fromhex(group["q"]))
         for test in group["tests"]:
             msg_bytes = bytes.fromhex(test["message"])
-            prehash = hashlib.sha512(msg_bytes).digest()
             context = list(bytes.fromhex(test.get("context", "")))
             test_vectors.append({
                 "vendor": "acvp",
                 "test_case_id": test["tcId"],
                 "algorithm": "ed25519",
                 "operation": "sign",
+                "sign_mode": "hash_eddsa",
                 "private_key": d,
                 "public_key": q,
                 "message": list(prehash),

--- a/sw/host/cryptotest/testvectors/parsers/nist_acvp_eddsa_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/nist_acvp_eddsa_parser.py
@@ -6,14 +6,11 @@
 """Parser for converting ACVP EdDSA testvectors to JSON.
 
 Uses the internalProjection files from the NIST ACVP-Server repo.
-Only Ed25519ph (preHash=true) is supported, since the cryptolib only
-implements HashEdDSA mode.
+Supports both pure Ed25519 (preHash=false) and HashEd25519
+(preHash=true).
 
-For SigVer, the parser pre-hashes the message with SHA-512 so the
+For HashEd25519, the parser pre-hashes the message with SHA-512 so the
 firmware receives the 64-byte digest directly.
-
-For SigGen, the parser pre-hashes the message and emits the private
-key, context, and expected signature.
 """
 
 import argparse
@@ -62,30 +59,36 @@ def parse_sigver(data):
 def parse_siggen(data):
     """Parse EDDSA-SigGen internalProjection.
 
-    Only Ed25519 with preHash=true (Ed25519ph / HashEdDSA) is selected.
-    The message is pre-hashed with SHA-512 before output.
+    Supports both pure Ed25519 (preHash=false) and HashEd25519
+    (preHash=true). For HashEd25519, the message is pre-hashed with
+    SHA-512 before output.
     """
     test_vectors = []
     for group in data["testGroups"]:
         if group["curve"] != "ED-25519":
             continue
-        if not group.get("preHash", False):
-            continue
 
+        pre_hash = group.get("preHash", False)
         d = list(bytes.fromhex(group["d"]))
         q = list(bytes.fromhex(group["q"]))
         for test in group["tests"]:
             msg_bytes = bytes.fromhex(test["message"])
             context = list(bytes.fromhex(test.get("context", "")))
+            if pre_hash:
+                message = list(hashlib.sha512(msg_bytes).digest())
+                sign_mode = "hash_eddsa"
+            else:
+                message = list(msg_bytes)
+                sign_mode = "eddsa"
             test_vectors.append({
                 "vendor": "acvp",
                 "test_case_id": test["tcId"],
                 "algorithm": "ed25519",
                 "operation": "sign",
-                "sign_mode": "hash_eddsa",
+                "sign_mode": sign_mode,
                 "private_key": d,
                 "public_key": q,
-                "message": list(prehash),
+                "message": message,
                 "context": context,
                 "expected_signature": list(bytes.fromhex(test["signature"])),
                 "result": True,

--- a/sw/host/cryptotest/testvectors/parsers/wycheproof_ed25519_parser.py
+++ b/sw/host/cryptotest/testvectors/parsers/wycheproof_ed25519_parser.py
@@ -23,9 +23,16 @@ def parse_test_vectors(raw_data):
         # Parse tests within the group
         for test in group["tests"]:
             logging.debug(f"Parsing tcId {test['tcId']}")
+            # Skip signatures whose byte length is not a multiple of 4
+            # (not representable in the word-based API).
+            if len(test["sig"]) % 8 != 0:
+                continue
             test_vec = {
+                "vendor": "wycheproof",
+                "test_case_id": test["tcId"],
                 "algorithm": "ed25519",
                 "operation": "verify",
+                "sign_mode": "eddsa",
                 "message": list(bytes.fromhex(test["msg"])),
                 "public_key": list(bytes.fromhex(key["pk"])),
                 "signature": list(bytes.fromhex(test["sig"])),

--- a/sw/host/tests/crypto/ed25519_kat/src/main.rs
+++ b/sw/host/tests/crypto/ed25519_kat/src/main.rs
@@ -114,6 +114,13 @@ fn run_ed25519_sign(
 ) -> Result<bool> {
     Ed25519Subcommand::Ed25519Siggen.send(spi_console)?;
 
+    let sign_mode = match test_case.sign_mode.as_str() {
+        "eddsa" => CryptotestEd25519SignMode::Eddsa,
+        "hash_eddsa" => CryptotestEd25519SignMode::HashEddsa,
+        _ => panic!("Unknown sign mode: {}", test_case.sign_mode),
+    };
+    sign_mode.send(spi_console)?;
+
     let mut sk = ArrayVec::new();
     sk.try_extend_from_slice(&test_case.private_key)?;
     let mut pk = ArrayVec::new();

--- a/sw/host/tests/crypto/ed25519_kat/src/main.rs
+++ b/sw/host/tests/crypto/ed25519_kat/src/main.rs
@@ -12,8 +12,8 @@ use std::time::Duration;
 use cryptotest_commands::commands::CryptotestCommand;
 use cryptotest_commands::ed25519_commands::{
     CryptotestEd25519Message, CryptotestEd25519PublicKey, CryptotestEd25519SiggenData,
-    CryptotestEd25519SiggenOutput, CryptotestEd25519Signature, CryptotestEd25519VerifyOutput,
-    Ed25519Subcommand,
+    CryptotestEd25519SiggenOutput, CryptotestEd25519SignMode, CryptotestEd25519Signature,
+    CryptotestEd25519VerifyOutput, Ed25519Subcommand,
 };
 
 use opentitanlib::app::TransportWrapper;
@@ -44,6 +44,7 @@ struct Ed25519TestCase {
     test_case_id: usize,
     algorithm: String,
     operation: String,
+    sign_mode: String,
     message: Vec<u8>,
     #[serde(default)]
     public_key: Vec<u8>,
@@ -64,6 +65,13 @@ fn run_ed25519_verify(
     spi_console: &SpiConsoleDevice,
 ) -> Result<bool> {
     Ed25519Subcommand::Ed25519Sigver.send(spi_console)?;
+
+    let sign_mode = match test_case.sign_mode.as_str() {
+        "eddsa" => CryptotestEd25519SignMode::Eddsa,
+        "hash_eddsa" => CryptotestEd25519SignMode::HashEddsa,
+        _ => panic!("Unknown sign mode: {}", test_case.sign_mode),
+    };
+    sign_mode.send(spi_console)?;
 
     let mut input = ArrayVec::new();
     input.try_extend_from_slice(&test_case.message)?;


### PR DESCRIPTION
- Depends on #229 

This PR adds pure Ed25519 signature generation and verification as described in RFC 8032.

Verification is a straightforward extension only touching the C-side as the hash is computed using HMAC prior to invoking ACC - this is fine as all processed data is public. 

Signing is more involved as both required hashes are computed in ACC. To be able to support arbitrary message lengths, we have to stream in the message twice resulting in a 5-step API: INIT/UPDATE/MID/UPDATE/FINAL. I tried to share as much code as possible with the pre-hash mode.

This allows us to cover more ACVP test vectors and also support the Wycheproof testvectors.

I have also extended the functest accordingly and cleaned up a few typos on the way.

See the individual commit messages for details.