### PR TITLE
[acc] Clean up and optimize P-384 scalar multiplication.

### DIFF
--- a/sw/acc/crypto/p384_base.s
+++ b/sw/acc/crypto/p384_base.s
@@ -618,7 +618,7 @@ proj_add_p384:
   bn.sel    w14, w16, w10, C
   bn.sel    w15, w17, w11, C
 
-  /* 11: [w9, w8] = t4 <= t4*t5 = [w9, w8]*[w26, w25] */
+  /* 11: [w9, w8] = t4 <= t4*t5 = [w9, w8]*[w15, w14] */
   bn.mov    w10, w8
   bn.mov    w11, w9
   bn.mov    w16, w14

--- a/sw/acc/crypto/p384_base.s
+++ b/sw/acc/crypto/p384_base.s
@@ -495,8 +495,10 @@ p384_mulmod448x128_n:
  * terminology of Algorithm 4 of [2].
  * The routine is limited to P-384 curve points due to:
  *   - fixed a=-3 domain parameter
- *   - usage of a P-384 optimized Barrett multiplication kernel
+ *   - usage of a P-384 optimized multiplication kernel
  * This routine runs in constant time.
+ *
+ * The implementation overwrites one input in-place with the sum.
  *
  * [1] https://doi.org/10.1006/jnth.1995.1088
  * [2] https://doi.org/10.1007/978-3-662-49890-3_16
@@ -505,14 +507,13 @@ p384_mulmod448x128_n:
  * @param[in]  x23: set to 11, pointer to in reg for modular multiplication
  * @param[in]  x24: set to 16, pointer to in/out reg for modular multiplication
  * @param[in]  x25: set to 17, pointer to in/out reg for modular multiplication
- * @param[in]  x26: dptr_p_p, dmem pointer to point P in dmem (projective)
  * @param[in]  x27: dptr_q_p, dmem pointer to point Q in dmem (projective)
  * @param[in]  x28: dptr_b, dmem pointer to domain parameter b of P-384 in dmem
  * @param[in]  [w13, w12]: p, modulus of underlying field of P-384
  * @param[in]  w31: all-zero.
- * @param[out]  [w26, w25]: x_r, x-coordinate of resulting point R
- * @param[out]  [w28, w27]: y_r, y-coordinate of resulting point R
- * @param[out]  [w30, w29]: z_r, z-coordinate of resulting point R
+ * @param[in,out]  [w26, w25]: x_r, x-coordinate of input point P/result point R
+ * @param[in,out]  [w28, w27]: y_r, y-coordinate of input point P/result point R
+ * @param[in,out]  [w30, w29]: z_r, z-coordinate of input point P/result point R
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
@@ -525,40 +526,36 @@ proj_add_p384:
      X1 = x_p; Y1 = y_p; Z1 = z_p; X2 = x_q; Y2 = y_q; Z2 = z_q
      X3 = x_r; Y3 = y_r; Z3 = z_r */
 
-  /* 1: [w1, w0] = t0 <= X1*X2 = dmem[x26+0]*dmem[x27+0] */
-  bn.lid    x22, 0(x26)
-  bn.lid    x23, 32(x26)
+  /* 1: [w1, w0] = t0 <= X1*X2 = [w26, w25]*dmem[x27+0] */
+  bn.mov    w10, w25
+  bn.mov    w11, w26
   bn.lid    x24, 0(x27)
   bn.lid    x25, 32(x27)
   jal       x1, p384_mulmod_p
   bn.mov    w0, w16
   bn.mov    w1, w17
 
-  /* 2: [w3, w2] = t1 <= Y1*Y2 = dmem[x26+64]*dmem[x27+64] */
-  bn.lid    x22, 64(x26)
-  bn.lid    x23, 96(x26)
+  /* 2: [w3, w2] = t1 <= Y1*Y2 = [w28, w27]*dmem[x27+64] */
+  bn.mov    w10, w27
+  bn.mov    w11, w28
   bn.lid    x24, 64(x27)
   bn.lid    x25, 96(x27)
   jal       x1, p384_mulmod_p
   bn.mov    w2, w16
   bn.mov    w3, w17
 
-  /* 3: [w5, w4] = t2 <= Z1*Z2 = dmem[x26+128]*dmem[x27+128] */
-  bn.lid    x22, 128(x26)
-  bn.lid    x23, 160(x26)
+  /* 3: [w5, w4] = t2 <= Z1*Z2 = [w30, w29]*dmem[x27+128] */
+  bn.mov    w10, w29
+  bn.mov    w11, w30
   bn.lid    x24, 128(x27)
   bn.lid    x25, 160(x27)
   jal       x1, p384_mulmod_p
   bn.mov    w4, w16
   bn.mov    w5, w17
 
-  /* 4: [w7, w6] = t3 <= X1+Y1 = dmem[x26+0]+dmem[x26+64] */
-  bn.lid    x22, 0(x26)
-  bn.lid    x23, 32(x26)
-  bn.lid    x24, 64(x26)
-  bn.lid    x25, 96(x26)
-  bn.add    w16, w10, w16
-  bn.addc   w17, w11, w17
+  /* 4: [w7, w6] = t3 <= X1+Y1 = [w26, w25]+[w28, w27] */
+  bn.add    w16, w25, w27
+  bn.addc   w17, w26, w28
   bn.sub    w10, w16, w12
   bn.subb   w11, w17, w13
   bn.sel    w6, w16, w10, C
@@ -601,19 +598,15 @@ proj_add_p384:
   bn.sel    w6, w10, w16, C
   bn.sel    w7, w11, w17, C
 
-  /* 9: [w9, w8] = t4 <= Y1+Z1 = dmem[x26+64]+dmem[x26+128] */
-  bn.lid    x22, 64(x26)
-  bn.lid    x23, 96(x26)
-  bn.lid    x24, 128(x26)
-  bn.lid    x25, 160(x26)
-  bn.add    w16, w10, w16
-  bn.addc   w17, w11, w17
+  /* 9: [w9, w8] = t4 <= Y1+Z1 = [w28, w27]+[w30, w29] */
+  bn.add    w16, w27, w29
+  bn.addc   w17, w28, w30
   bn.sub    w10, w16, w12
   bn.subb   w11, w17, w13
   bn.sel    w8, w16, w10, C
   bn.sel    w9, w17, w11, C
 
-  /* 10: [w26, w25] = X3 <= Y2+Z2 = dmem[x27+64]+dmem[x27+128] */
+  /* 10: [w15, w14] = t5 <= Y2+Z2 = dmem[x27+64]+dmem[x27+128] */
   bn.lid    x22, 64(x27)
   bn.lid    x23, 96(x27)
   bn.lid    x24, 128(x27)
@@ -622,41 +615,37 @@ proj_add_p384:
   bn.addc   w17, w11, w17
   bn.sub    w10, w16, w12
   bn.subb   w11, w17, w13
-  bn.sel    w25, w16, w10, C
-  bn.sel    w26, w17, w11, C
+  bn.sel    w14, w16, w10, C
+  bn.sel    w15, w17, w11, C
 
-  /* 11: [w9, w8] = t4 <= t4*X3 = [w9, w8]*[w26, w25] */
+  /* 11: [w9, w8] = t4 <= t4*t5 = [w9, w8]*[w26, w25] */
   bn.mov    w10, w8
   bn.mov    w11, w9
-  bn.mov    w16, w25
-  bn.mov    w17, w26
+  bn.mov    w16, w14
+  bn.mov    w17, w15
   jal       x1, p384_mulmod_p
   bn.mov    w8, w16
   bn.mov    w9, w17
 
-  /* 12: [w26, w25] = X3 <= t1+t2 = [w3, w2]+[w5, w4] */
+  /* 12: [w15, w14] = t5 <= t1+t2 = [w3, w2]+[w5, w4] */
   bn.add    w16, w2, w4
   bn.addc   w17, w3, w5
   bn.sub    w10, w16, w12
   bn.subb   w11, w17, w13
-  bn.sel    w25, w16, w10, C
-  bn.sel    w26, w17, w11, C
+  bn.sel    w14, w16, w10, C
+  bn.sel    w15, w17, w11, C
 
-  /* 13: [w9, w8] = t4 <= t4-X3 = [w9, w8]-[w26, w25] */
-  bn.sub    w16, w8, w25
-  bn.subb   w17, w9, w26
+  /* 13: [w9, w8] = t4 <= t4-t5 = [w9, w8]-[w26, w25] */
+  bn.sub    w16, w8, w14
+  bn.subb   w17, w9, w15
   bn.add    w10, w16, w12
   bn.addc   w11, w17, w13
   bn.sel    w8, w10, w16, C
   bn.sel    w9, w11, w17, C
 
-  /* 14: [w26, w25] = X3 <= X1+Z1 = dmem[x26+0]+dmem[x26+128] */
-  bn.lid    x22, 0(x26)
-  bn.lid    x23, 32(x26)
-  bn.lid    x24, 128(x26)
-  bn.lid    x25, 160(x26)
-  bn.add    w16, w10, w16
-  bn.addc   w17, w11, w17
+  /* 14: [w26, w25] = X3 <= X1+Z1 = [w26, w25]+[w30, w29] */
+  bn.add    w16, w25, w29
+  bn.addc   w17, w26, w30
   bn.sub    w10, w16, w12
   bn.subb   w11, w17, w13
   bn.sel    w25, w16, w10, C
@@ -909,7 +898,6 @@ proj_add_p384:
 
   ret
 
-
 /**
  * P-384 point doubling in projective space.
  *
@@ -1104,7 +1092,6 @@ proj_double_p384:
   bn.sel    w27, w3, w27, Z
 
   ret
-
 
 /**
  * Convert projective coordinates of a P-384 curve point to affine coordinates

--- a/sw/acc/crypto/p384_base_mult.s
+++ b/sw/acc/crypto/p384_base_mult.s
@@ -86,9 +86,6 @@ p384_base_mult:
   /* set dmem pointer to domain parameter b */
   la        x28, p384_b
 
-  /* set dmem pointer to scratchpad */
-  la        x30, scratchpad
-
   /* set dmem pointer to 1st private key share d0 */
   la        x17, d0
 
@@ -134,8 +131,7 @@ p384_base_mult:
 
   ret
 
-/* variables and scratchpad memory */
-.section .bss
+.bss
 
 .balign 32
 
@@ -162,10 +158,3 @@ x:
 .weak y
 y:
   .zero 64
-
-/* 704 bytes of scratchpad memory */
-.balign 32
-.globl scratchpad
-.weak scratchpad
-scratchpad:
-  .zero 704

--- a/sw/acc/crypto/p384_internal_mult.s
+++ b/sw/acc/crypto/p384_internal_mult.s
@@ -293,7 +293,7 @@ scalar_mult_int_p384:
     /* Load P and 2P one limb at a time, using the L flag to select one. We
        select P if the L flag is set and 2P otherwise (in the case that both
        MSBs were zero, the addition result gets discarded).
-       [w24:w18] <= L ? dmem[scalarmult_P] : dmem[scalarmult_2P] */
+       [w30:w25] <= L ? dmem[scalarmult_P] : dmem[scalarmult_2P] */
     li    x2, 25
     loopi 6, 4
       bn.lid    x24, 0(x4++)

--- a/sw/acc/crypto/p384_internal_mult.s
+++ b/sw/acc/crypto/p384_internal_mult.s
@@ -1,3 +1,8 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+
 /* Copyright lowRISC contributors (OpenTitan project). */
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
@@ -26,8 +31,6 @@
  *                          x-coordinate of input point
  * @param[in]  x21: dptr_y, pointer to dmem location containing affine
  *                          y-coordinate of input point
- * @param[in]  [w15, w14]: u[383:0] lower 384 bit of Barrett constant u for
- *                                    modulus p
  * @param[in]  [w13, w12]: p, modulus of P-384 underlying finite field
  * @param[in]  w31: all-zero
  * @param[in]  x18: dptr_p_p, pointer to dmem location to store resulting point
@@ -139,7 +142,6 @@ store_proj_randomize:
  * @param[in]  x20: dptr_x, pointer to affine x-coordinate in dmem
  * @param[in]  x21: dptr_y, pointer to affine y-coordinate in dmem
  * @param[in]  x28: dptr_b, pointer to domain parameter b of P-384 in dmem
- * @param[in]  x30: dptr_sp, pointer to 704 bytes of scratchpad memory in dmem
  * @param[in]  [w13, w12]: p, modulus of P-384 underlying finite field
  * @param[in]  [w11, w10]: n, domain parameter of P-384 curve
  *                            (order of base point G)
@@ -147,15 +149,6 @@ store_proj_randomize:
  * @param[out]  [w26,w25]: x, x-coordinate of resulting point R (projective).
  * @param[out]  [w28,w27]: y, y-coordinate of resulting point R (projective).
  * @param[out]  [w30,w29]: z, z-coordinate of resulting point R (projective).
- *
- * Scratchpad memory layout:
- * The routine expects at least 704 bytes of scratchpad memory at dmem
- * location 'scratchpad' (sp). Internally the scratchpad is used as follows:
- * dptr_sp     .. dptr_sp+191: point P, projective
- * dptr_sp+192 .. dptr_sp+255: s0, 1st share of scalar
- * dptr_sp+256 .. dptr_sp+447: point 2P, projective
- * dptr_sp+448 .. dptr_sp+511: s1, 2nd share of scalar
- * dptr_sp+512 .. dptr_sp+703: point Q, projective
  *
  * Projective coordinates of a point are kept in dmem in little endian format
  * with the individual coordinates 512 bit aligned. The coordinates are stored
@@ -165,13 +158,13 @@ store_proj_randomize:
  * Flags: When leaving this subroutine, the M, L and Z flags of FG0 depend on
  *        the computed affine y-coordinate.
  *
- * clobbered registers: x2, x10, x11 to x13, x18, x26, x27, w0 to w30
- * clobbered flag groups: FG0
+ * clobbered registers: x2 to x7, x10 to x13, x18, x22 to x27, x30, w0 to w11, w16 to w31, acc
+ * clobbered flag groups: FG0, FG1
  */
  .globl scalar_mult_int_p384
 scalar_mult_int_p384:
 
-  /* set regfile pointers to in/out regs of Barrett routine. Set here to avoid
+  /* set regfile pointers to in/out regs of mulmod routine. Set here to avoid
      resetting in very call to point addition routine */
   li        x22, 10
   li        x23, 11
@@ -195,188 +188,189 @@ scalar_mult_int_p384:
   bn.rshi   w3, w3, w2 >> 192
   bn.rshi   w2, w2, w31 >> 192
 
-   /* store shares in scratchpad */
+  /* Store first scalar share to scratchpad. */
   li        x2, 0
-  bn.sid    x2++, 192(x30)
-  bn.sid    x2++, 224(x30)
-  bn.sid    x2++, 448(x30)
+  la        x3, scalarmult_k0
+  bn.sid    x2++,  0(x3)
+  bn.sid    x2++, 32(x3)
 
-  /* Dummy instruction to avoid consecutive share access. */
+  /* Dummy operation in between share accesses. */
   bn.xor    w31, w31, w31
 
-  bn.sid    x2++, 480(x30)
+  /* Store second scalar share to scratchpad. */
+  la        x3, scalarmult_k1
+  bn.sid    x2++,  0(x3)
+  bn.sid    x2++, 32(x3)
 
-  /* get randomized projective coodinates of curve point
-     P = (x_p, y_p, z_p) = dmem[dptr_sp] = (x*z mod p, y*z mod p, z) */
-  add       x18, x30, 0
+  /* Convert P to projective coordinates and copy to scratchpad. */
+  la        x18, scalarmult_P
   jal       x1, store_proj_randomize
+
+  /* load randomized point P */
+  li        x2, 25
+  bn.lid    x2++,   0(x18)
+  bn.lid    x2++,  32(x18)
+  bn.lid    x2++,  64(x18)
+  bn.lid    x2++,  96(x18)
+  bn.lid    x2++, 128(x18)
+  bn.lid    x2++, 160(x18)
 
   /* double point P
      2P = ([w30,w29], [w28,w27], [w26, w25]) <= 2*P */
-  add       x27, x30, x0
-  add       x26, x30, x0
+  addi      x27, x18, 0
   jal       x1, proj_add_p384
 
-  /* store point 2P in scratchpad @w30+256
-     dmem[dptr_sc+256] = [w30:w25] = 2P */
+  /* Store point 2P.
+     dmem[scalarmult_2P] = [w30:w25] = 2P */
+  la        x3, scalarmult_2P
   li        x2, 25
-  bn.sid    x2++, 256(x30)
-  bn.sid    x2++, 288(x30)
-  bn.sid    x2++, 320(x30)
-  bn.sid    x2++, 352(x30)
-  bn.sid    x2++, 384(x30)
-  bn.sid    x2++, 416(x30)
+  bn.sid    x2++,   0(x3)
+  bn.sid    x2++,  32(x3)
+  bn.sid    x2++,  64(x3)
+  bn.sid    x2++,  96(x3)
+  bn.sid    x2++, 128(x3)
+  bn.sid    x2++, 160(x3)
 
-  /* init point Q = (0,1,0) for double-and-add in scratchpad */
-  /* dmem[x26] = dmem[dptr_sc+512] = Q = (0,1,0) */
-  addi      x26, x30, 512
-  li        x2, 30
-  bn.addi   w30, w31, 1
-  bn.sid    x2++, 64(x26)
-  bn.sid    x2, 0(x26)
-  bn.sid    x2, 32(x26)
-  bn.sid    x2, 96(x26)
-  bn.sid    x2, 128(x26)
-  bn.sid    x2, 160(x26)
+  /* Initialize the point Q = (0, 1, 0) in registers [w30:w25]. */
+  bn.xor    w25, w25, w25
+  bn.xor    w26, w26, w26
+  bn.addi   w27, w26, 1
+  bn.xor    w28, w28, w28
+  bn.xor    w29, w29, w29
+  bn.xor    w30, w30, w30
 
-  /* double-and-add loop with decreasing index */
-  loopi     448, 85
+  /* Double-and-add loop with decreasing index.
 
-    /* double point Q
+     Loop invariants (i=448..0):
+       x27 = scalarmult_Q (tmp)
+       [w30:w25] = Q = ((k >> i) * P)
+       dmem[x4:x4+64] = P
+       dmem[x5:x5+64] = 2*P
+       dmem[x6:x6+64] = (k0 << (i+64)) % 2^512
+       dmem[x7:x7+64] = (k1 << (i+64)) % 2^512
+   */
+  la        x4, scalarmult_P
+  la        x5, scalarmult_2P
+  la        x6, scalarmult_k0
+  la        x7, scalarmult_k1
+  la        x27, scalarmult_Q
+  loopi     448, 67
+
+    /* Double point Q.
        Q = ([w30,w29], [w28,w27], [w26, w25]) <= Q + dmem[x27] */
-    add       x27, x26, x0
-    jal       x1, proj_add_p384
+    jal       x1, proj_double_p384
 
-    /* store Q in dmem
-     dmem[x26] = dmem[dptr_sc+512] <= [w30:w25] */
+    /* Store Q in dmem and load scalar shares, interleaving to avoid
+       consecutive share access.
+         dmem[scalarmult_Q] <= [w30:w25]
+         [w1:w0] <= dmem[scalarmult_k0]
+         [w3:w2] <= dmem[scalarmult_k1] */
     li        x2, 25
-    bn.sid    x2++, 0(x26)
-    bn.sid    x2++, 32(x26)
-    bn.sid    x2++, 64(x26)
-    bn.sid    x2++, 96(x26)
-    bn.sid    x2++, 128(x26)
-    bn.sid    x2++, 160(x26)
+    li        x3, 0
+    bn.sid    x2++,   0(x27)
+    bn.sid    x2++,  32(x27)
+    bn.lid    x3++,   0(x6)
+    bn.lid    x3++,  32(x6)
+    bn.sid    x2++,  64(x27)
+    bn.sid    x2++,  96(x27)
+    bn.lid    x3++,   0(x7)
+    bn.lid    x3++,  32(x7)
+    bn.sid    x2++, 128(x27)
+    bn.sid    x2++, 160(x27)
 
-    /* Probe if MSb of either of the two scalars (rnd or d-rnd) but not both
-       is 1.
-       If only one MSb is set, select P for addition.
-       If both MSbs are set, select 2P for addition.
-       (If neither MSB is set, 2P will be selected but result discarded.) */
-    li        x2, 0
-    bn.lid    x2++, 224(x30)
-    bn.lid    x2, 480(x30)
-    bn.xor    w8, w0, w1
-    /* Create conditional offeset into scratchpad.
-       if (s0[512] xor s1[512]) x27 <= x30 else x27 <= x30+256 */
-    csrrs     x3, FG0, x0
-    xori      x3, x3, -1
-    andi      x3, x3, 2
-    slli      x27, x3, 7
-    add       x27, x27, x30
+    /* Probe the MSB xor and or of the combined scalars. Randomize other bits
+       to obfuscate power signals.
+         FG0.L <= w1[255] ^ w3[255] = k0[i] ^ k1[i]
+         FG1.L <= w1[255] | w3[255] = k0[i] | k1[i]
+    */
+    bn.wsrr   w18, urnd
+    bn.rshi   w20, w18, w1 >> 255
+    bn.wsrr   w19, urnd
+    bn.rshi   w21, w19, w3 >> 255
+    bn.cmp    w20, w21
+    bn.or     w20, w20, w21, FG1
 
-    /* Reload randomized projective coodinates for curve point P.
-       P = (x_p, y_p, z_p) = dmem[dptr_sp] <= (x*z mod p, y*z mod p, z) */
-    jal       x1, store_proj_randomize
+    /* Load P and 2P one limb at a time, using the L flag to select one. We
+       select P if the L flag is set and 2P otherwise (in the case that both
+       MSBs were zero, the addition result gets discarded).
+       [w24:w18] <= L ? dmem[scalarmult_P] : dmem[scalarmult_2P] */
+    li    x2, 25
+    loopi 6, 4
+      bn.lid    x24, 0(x4++)
+      bn.lid    x25, 0(x5++)
+      bn.sel    w11, w16, w17, L
+      bn.movr   x2++, x23
+    addi  x4, x4, -192
+    addi  x5, x5, -192
 
-    /* Add points Q+P or Q+2P depending on offset in x27.
-       Q_a = ([w30,w29], [w28,w27], [w26, w25]) <= Q + dmem[x27] */
-    jal       x1, proj_add_p384
-
-    /* load shares from scratchpad
-       [w1, w0] = s0; [w3, w2] = s1 */
-    li        x2, 0
-    bn.lid    x2++, 192(x30)
-    bn.lid    x2++, 224(x30)
-    bn.lid    x2++, 448(x30)
-    bn.lid    x2++, 480(x30)
-
-    /* M = s0[511] | s1[511] */
-    bn.or     w8, w1, w3
-
-    /* load q from scratchpad
-        Q = ([w9,w8], [w7,w6], [w5,w4]) <= dmem[x26] */
-    li        x2, 4
-    bn.lid    x2++, 0(x26)
-    bn.lid    x2++, 32(x26)
-    bn.lid    x2++, 64(x26)
-    bn.lid    x2++, 96(x26)
-    bn.lid    x2++, 128(x26)
-    bn.lid    x2++, 160(x26)
-
-    /* select either Q or Q_a
-       if M: Q = ([w30,w29], [w28,w27], [w26, w25]) <= Q else: Q <= Q_a */
-    bn.sel    w25, w25, w4, M
-    bn.sel    w26, w26, w5, M
-    bn.sel    w27, w27, w6, M
-    bn.sel    w28, w28, w7, M
-    bn.sel    w29, w29, w8, M
-    bn.sel    w30, w30, w9, M
-
-    /* store Q in dmem
-     dmem[x26] = dmem[dptr_sc+512] <= [w30:w25] */
-    li        x2, 25
-    bn.sid    x2++, 0(x26)
-    bn.sid    x2++, 32(x26)
-    bn.sid    x2++, 64(x26)
-    bn.sid    x2++, 96(x26)
-    bn.sid    x2++, 128(x26)
-    bn.sid    x2++, 160(x26)
-
-    /* left shift both shares
-       s0 <= s0 << 1 ; s1 <= s1 << 1 */
+    /* Shift the scalar shares one place and store them. */
     bn.add    w0, w0, w0
     bn.addc   w1, w1, w1
+    li        x2, 0
+    bn.sid    x2++,  0(x6)
+    bn.sid    x2++, 32(x6)
+    bn.xor    w31, w31, w31 /* dummy instruction between share accesses */
     bn.add    w2, w2, w2
     bn.addc   w3, w3, w3
-    /* store both shares in scratchpad */
-    li        x2, 0
-    bn.sid    x2++, 192(x30)
-    bn.sid    x2++, 224(x30)
-    bn.sid    x2++, 448(x30)
-    bn.sid    x2++, 480(x30)
+    bn.sid    x2++,  0(x7)
+    bn.sid    x2++, 32(x7)
 
+    /* [w30:w25] <= [w30:w25] + dmem[scalarmult_Q] */
+    jal       x1, proj_add_p384
 
-    /* Get a fresh random number from URND and scale the coordinates of 2P.
-       (scaling each proj. coordinate by same factor results in same point) */
+    /* Get a pseudorandom 384-bit scaling factor and reduce modulo p. */
+    bn.wsrr   w4, urnd
+    bn.wsrr   w5, urnd
+    bn.rshi   w5, w31, w5 >> 128
+    bn.sub    w2, w4, w12
+    bn.subb   w3, w5, w13
+    bn.sel    w10, w4, w2, C
+    bn.sel    w11, w5, w3, C
 
-    /* get a 384-bit random number from URND */
-    bn.wsrr   w2, 2
-    bn.wsrr   w3, 2
-    bn.rshi   w3, w31, w3 >> 128
-
-    /* reduce random number
-      [w2, w3] = z <= [w2, w3] mod p */
-    bn.sub    w10, w2, w12
-    bn.subb   w11, w3, w13
-    bn.sel    w2, w2, w10, C
-    bn.sel    w3, w3, w11, C
-
-    /* scale all coordinates in scratchpad */
-    li        x2, 16
-    li        x3, 17
-    /* x-coordinate */
-    bn.mov    w10, w2
-    bn.mov    w11, w3
-    bn.lid    x2, 256(x30)
-    bn.lid    x3, 288(x30)
+    /* Select either Q or Q_a based on FG1.L, randomizing as we go. */
+    li        x2, 1
+    bn.lid    x0,  0(x27)
+    bn.lid    x2, 32(x27)
+    bn.sel    w16, w25, w0, FG1.L
+    bn.sel    w17, w26, w1, FG1.L
     jal       x1, p384_mulmod_p
-    bn.sid    x2, 256(x30)
-    bn.sid    x3, 288(x30)
-    /* y-coordinate */
-    bn.mov    w10, w2
-    bn.mov    w11, w3
-    bn.lid    x2, 320(x30)
-    bn.lid    x3, 352(x30)
+    bn.mov    w25, w16
+    bn.mov    w26, w17
+    bn.lid    x0, 64(x27)
+    bn.lid    x2, 96(x27)
+    bn.sel    w16, w27, w0, FG1.L
+    bn.sel    w17, w28, w1, FG1.L
     jal       x1, p384_mulmod_p
-    bn.sid    x2, 320(x30)
-    bn.sid    x3, 352(x30)
-    /* z-coordinate */
-    bn.mov    w10, w2
-    bn.mov    w11, w3
-    bn.lid    x2, 384(x30)
-    bn.lid    x3, 416(x30)
+    bn.mov    w27, w16
+    bn.mov    w28, w17
+    bn.lid    x0, 128(x27)
+    bn.lid    x2, 160(x27)
+    bn.sel    w16, w29, w0, FG1.L
+    bn.sel    w17, w30, w1, FG1.L
     jal       x1, p384_mulmod_p
-    bn.sid    x2, 384(x30)
-    bn.sid    x3, 416(x30)
+    bn.mov    w29, w16
+    bn.mov    w30, w17
 
   ret
+
+.section .scratchpad
+
+.balign 32
+scalarmult_k0:
+.zero 64
+
+.balign 32
+scalarmult_k1:
+.zero 64
+
+.balign 32
+scalarmult_P:
+.zero 192
+
+.balign 32
+scalarmult_2P:
+.zero 192
+
+.balign 32
+scalarmult_Q:
+.zero 192

--- a/sw/acc/crypto/p384_isoncurve.s
+++ b/sw/acc/crypto/p384_isoncurve.s
@@ -181,8 +181,9 @@ p384_isoncurve:
  * The routine makes use of the property that the domain parameter 'a' can be
  * written as a=-3 for the P-384 curve, hence the routine is limited to P-384.
  *
- * This routine sets `ok` to false if the check fails and immediately exits the
- * program. If the check succeeds, `ok` is unmodified.
+ * This routine causes a fatal error if the point is not on the curve, and
+ * should only be used in circumstances where this situation would indicate a
+ * fault attack.
  *
  * The routine runs in constant time.
  *

--- a/sw/acc/crypto/p384_isoncurve_proj.s
+++ b/sw/acc/crypto/p384_isoncurve_proj.s
@@ -1,3 +1,7 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
 /* Copyright lowRISC contributors (OpenTitan project). */
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
@@ -14,29 +18,19 @@
  * curve point on P-384. To this end p384_isoncurve_proj is called to compute
  * both sides of the Weierstrass equation zy^2 = x^3 + axz^2 + bz^3  mod p.
  *
- * Finally, both sides of the equation are compared.
- * This routine sets `ok` to false if the check fails and immediately exits the
- * program. If the check succeeds, `ok` is unmodified.
+ * Finally, both sides of the equation are compared. This routine produces an
+ * error if the equation fails, so it should only be used in cases where this
+ * would indicate an ongoing attack (e.g. after a scalar multiplication for a
+ * point that was already checked).
  *
  * The routine runs in constant time.
  *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
  * @param[in]  [w13, w12]:  domain parameter p (modulus)
- * @param[in]  x20:         dptr_x, pointer to dmem location containing projective
- *                                  x-coordinate of input point
- * @param[in]  x21:         dptr_y, pointer to dmem location containing projective
- *                                  y-coordinate of input point
- * @param[in]  x30:         dptr_sp, pointer to 704 bytes of scratchpad memory in dmem
- *
- * Scratchpad memory layout:
- * The routine expects at least 192 bytes of scratchpad memory at dmem
- * location 'scratchpad' (sp). Internally the scratchpad is used as follows:
- * dptr_sp     .. dptr_sp+63:   z-coordinate of input point, projective
- * dptr_sp+64  .. dptr_sp+127:  dptr_rhs, pointer to dmem location where right
- *                              side result will be stored
- * dptr_sp+128 .. dptr_sp+191:  dptr_lhs, pointer to dmem location where left
- *                              side result will be stored
+ * @param[in]  x20:         dptr_x, pointer to x-coordinate in dmem
+ * @param[in]  x21:         dptr_y, pointer to y-coordinate in dmem
+ * @param[in]  x30:         dptr_z, pointer to z-coordinate in dmem
  *
  * clobbered registers: x2, x3, w0 to w5, w10 to w17
  * clobbered flag groups: FG0
@@ -44,17 +38,16 @@
  .globl p384_isoncurve_proj_check
 p384_isoncurve_proj_check:
 
-  addi      x22, x30, 64
-  addi      x23, x22, 64
-
   jal       x1, p384_isoncurve_proj
 
   /* load result to WDRs for comparison */
   li        x2, 2
-  bn.lid    x2++,  0(x22)
-  bn.lid    x2++, 32(x22)
-  bn.lid    x2++,  0(x23)
-  bn.lid    x2++, 32(x23)
+  la        x3, lhs
+  bn.lid    x2++,  0(x3)
+  bn.lid    x2++, 32(x3)
+  la        x3, rhs
+  bn.lid    x2++,  0(x3)
+  bn.lid    x2++, 32(x3)
 
   /* Compare the two sides of the equation.
        FG0.Z <= (y^2) mod p == (x^2 + ax + b) mod p */
@@ -90,16 +83,11 @@ p384_isoncurve_proj_check:
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
  * @param[in]  [w13, w12]:  domain parameter p (modulus)
- * @param[in]  x20:         dptr_x,   pointer to dmem location containing projective
- *                                    x-coordinate of input point
- * @param[in]  x21:         dptr_y,   pointer to dmem location containing projective
- *                                    y-coordinate of input point
- * @param[in]  x22:         dptr_rhs, pointer to dmem location where right
- *                                    side result will be stored
- * @param[in]  x23:         dptr_lhs, pointer to dmem location where left side
- *                                    result will be stored
- * @param[in]  x30:         dptr_z,   pointer to dmem location containing projective
- *                                    z-coordinate of input point
+ * @param[in]  x20:         dptr_x, pointer to x-coordinate in dmem
+ * @param[in]  x21:         dptr_y, pointer to y-coordinate in dmem
+ * @param[in]  x30:         dptr_z, pointer to z-coordinate in dmem
+ * @param[out] dmem[lhs]:   left-hand side of equation.
+ * @param[out] dmem[rhs]:   right-hand side of equation.
  *
  * clobbered registers: x2, x3, w0 to w5, w10 to w17
  * clobbered flag groups: FG0
@@ -165,10 +153,11 @@ p384_isoncurve_proj:
   /* zy^2 = [w17,w16] <= z*y^2 = [w17,w16]*[w11,w10] */
   jal       x1, p384_mulmod_p
 
-  /* store result (left side): dmem[dptr_lhs] <= zy^2 = [w17,w16] */
+  /* store result (left side): dmem[lhs] <= zy^2 = [w17,w16] */
   li        x2, 16
-  bn.sid    x2++, 0(x23)
-  bn.sid    x2++, 32(x23)
+  la        x3, lhs
+  bn.sid    x2++, 0(x3)
+  bn.sid    x2++, 32(x3)
 
   /* load projective z-coordinate of curve point from dmem
      [w11, w10] <= dmem[dptr_z] = dmem[x30] */
@@ -224,25 +213,24 @@ p384_isoncurve_proj:
   bn.sel    w1,  w17, w11, C
 
   /* store result (right side)
-     dmem[dptr_rhs] <= x^3 + axz^2 + bz^3 mod p = [w1,w0] */
+     dmem[rhs] <= x^3 + axz^2 + bz^3 mod p = [w1,w0] */
   li        x2, 0
-  bn.sid    x2++, 0(x22)
-  bn.sid    x2++, 32(x22)
+  la        x3, rhs
+  bn.sid    x2++, 0(x3)
+  bn.sid    x2++, 32(x3)
 
   ret
 
-.data
+.bss
 
-/* x-coordinate */
-.globl x
-.weak x
+/* Left-hand side of Weierstrauss equation (local tmp buffer). */
 .balign 32
-x:
+.globl lhs
+lhs:
   .zero 64
 
-/* y-coordinate */
-.globl y
-.weak y
+/* Right-hand side of Weierstrauss equation (local tmp buffer). */
 .balign 32
-y:
+.globl rhs
+rhs:
   .zero 64

--- a/sw/acc/crypto/p384_modinv.s
+++ b/sw/acc/crypto/p384_modinv.s
@@ -1,3 +1,7 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
 /* Copyright lowRISC contributors (OpenTitan project). */
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
@@ -21,9 +25,9 @@
  * algorithm.
  *
  * This routine is mainly intended to be used for inversion of scalars in
- * context of the P-384 curve. In theory, it can be used with any 384-bit
- * modulus m with a corresponding 385-bit Barrett constant u,
- * where u[383:192] = 0.
+ * context of the P-384 curve. However, it can be used with any 384-bit modulus
+ * that fits the conditions of the p384_mulmod_n subroutine, in particular
+ * including the P-384 coordinate field modulus (p).
  *
  * Note: When used for P-384 scalar inversion, the routine will need 672 calls
  * to the multiplication routine. By using an adder chain this could be reduced
@@ -44,8 +48,8 @@
  * clobbered registers: x2, w2, w3, w10, w11, w16 to w24
  * clobbered flag groups: FG0
  */
- .globl mod_inv_n_p384
-mod_inv_n_p384:
+ .globl mod_inv_p384
+mod_inv_p384:
 
   /* subtract 2 from modulus for Fermat's little theorem
      [w3,w2] <= m - 2 = [w13,w12]-2 (left aligned) */

--- a/sw/acc/crypto/p384_scalar_mult.s
+++ b/sw/acc/crypto/p384_scalar_mult.s
@@ -108,7 +108,7 @@ p384_scalar_mult:
    4. Multiply mask with z^-1 for use in
       affine space. */
 
-/* Load domain parameter.
+  /* Load domain parameter.
      [w13,w12] = dmem[p384_p] */
   li        x2, 12
   la        x4, p384_p

--- a/sw/acc/crypto/p384_scalar_mult.s
+++ b/sw/acc/crypto/p384_scalar_mult.s
@@ -49,9 +49,6 @@ p384_scalar_mult:
   /* set dmem pointer to domain parameter b */
   la        x28, p384_b
 
-  /* set dmem pointer to scratchpad */
-  la        x30, scratchpad
-
   /* set dmem pointer to point to x-coordinate */
   la       x20, x
 
@@ -85,14 +82,15 @@ p384_scalar_mult:
   /* load the result of the scalar multiplication into memory for
      the projective is on curve check. */
   li        x2, 25
-  la        x3, x
-  bn.sid    x2++, 0(x3)
-  bn.sid    x2++, 32(x3)
-  la        x3, y
-  bn.sid    x2++, 0(x3)
-  bn.sid    x2++, 32(x3)
+  la        x20, x
+  bn.sid    x2++, 0(x20)
+  bn.sid    x2++, 32(x20)
+  la        x21, y
+  bn.sid    x2++, 0(x21)
+  bn.sid    x2++, 32(x21)
 
-  /* store the z coordinate to scratchpad */
+  /* store the z coordinate */
+  la        x30, z
   bn.sid    x2++, 0(x30)
   bn.sid    x2++, 32(x30)
 
@@ -194,7 +192,6 @@ p384_scalar_mult:
 
   ret
 
-/* scratchpad memory */
 .section .bss
 
 .balign 32
@@ -223,7 +220,6 @@ x:
 y:
   .zero 64
 
-/* 704 bytes of scratchpad memory */
-.balign 32
-scratchpad:
-  .zero 704
+/* z-coordinate (local temp buffer) */
+z:
+  .zero 64

--- a/sw/acc/crypto/p384_scalar_mult.s
+++ b/sw/acc/crypto/p384_scalar_mult.s
@@ -1,3 +1,7 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
 /* Copyright lowRISC contributors (OpenTitan project). */
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
@@ -106,7 +110,7 @@ p384_scalar_mult:
    4. Multiply mask with z^-1 for use in
       affine space. */
 
-  /* Load domain parameter.
+/* Load domain parameter.
      [w13,w12] = dmem[p384_p] */
   li        x2, 12
   la        x4, p384_p

--- a/sw/acc/crypto/p384_sign.s
+++ b/sw/acc/crypto/p384_sign.s
@@ -344,7 +344,6 @@ p384_sign:
   ret
 
 
-/* scratchpad memory */
 .section .bss
 
 .balign 32
@@ -390,10 +389,3 @@ d0:
 .weak d1
 d1:
   .zero 64
-
-/* 704 bytes of scratchpad memory */
-.balign 32
-.globl scratchpad
-.weak scratchpad
-scratchpad:
-  .zero 704

--- a/sw/acc/crypto/p384_sign.s
+++ b/sw/acc/crypto/p384_sign.s
@@ -1,3 +1,7 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
 /* Copyright lowRISC contributors (OpenTitan project). */
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
@@ -50,29 +54,17 @@ p384_sign:
   /* get dmem pointer of base point y-coordinate */
   la        x21, p384_gy
 
-  /* get dmem pointer of scratchpad */
-  la        x30, scratchpad
-
   /* get dmem pointer of 1st scalar share k0 */
   la        x17, k0
 
   /* get dmem pointer of 1st scalar share k1 */
   la        x19, k1
 
-  /* get dmem pointer of message */
-  la        x6, msg
-
   /* get dmem pointer of r component */
   la        x14, r
 
   /* get dmem pointer of s component */
   la        x15, s
-
-  /* get dmem pointer of 1st private key share d0 */
-  la        x4, d0
-
-  /* get dmem pointer of 1st private key share d0 */
-  la        x5, d1
 
   /* load domain parameter p (modulus)
      [w13, w12] <= p = dmem[dptr_p] */
@@ -187,6 +179,12 @@ p384_sign:
   bn.wsrr   w29, URND
   bn.wsrr   w30, URND
 
+  /* get dmem pointer of 1st private key share d0 */
+  la        x4, d0
+
+  /* get dmem pointer of 1st private key share d0 */
+  la        x5, d1
+
   /* load 1st share d0 from dmem
      [w11,w10] <= d0 = dmem[dptr_d0] */
   bn.mov    w16, w4      /* prepare for next p384_mulmod488x128_n call below */
@@ -258,6 +256,9 @@ p384_sign:
 
   /* Multiplicative masking of message msg */
 
+  /* get dmem pointer of message */
+  la        x6, msg
+
   /* load message from dmem
      [w11, w10] <= msg = dmem[dptr_msg] */
   bn.mov    w16, w4      /* prepare for next p384_mulmod488x128_n call below */
@@ -281,7 +282,7 @@ p384_sign:
      [w3, w2] <= [w17, w16] <= (k*alpha)^(-1) mod n */
   bn.mov    w29, w16
   bn.mov    w30, w17
-  jal       x1, mod_inv_n_p384
+  jal       x1, mod_inv_p384
   bn.mov    w2, w16
   bn.mov    w3, w17
 

--- a/sw/acc/crypto/p384_verify.s
+++ b/sw/acc/crypto/p384_verify.s
@@ -116,17 +116,6 @@ store_proj:
  * @param[out] dmem[ok]:  whether the signature passed basic checks (32 bits)
  * @param[out] dmem[x_r]: verification result: reduced affine x1-coordinate
  *
- * Scratchpad memory layout:
- * The routine expects at least 896 bytes of scratchpad memory at dmem
- * location 'scratchpad' (sp).
- * Internally the scratchpad is used as follows:
- * dptr_sp     .. dptr_sp+191: point C, projective
- * dptr_sp+192 .. dptr_sp+383: point G, projective
- * dptr_sp+384 .. dptr_sp+575: point Q, projective
- * dptr_sp+576 .. dptr_sp+767: point Q+G, projective
- * dptr_sp+768 .. dptr_sp+831: scalar u1
- * dptr_sp+832 .. dptr_sp+896: scalar u2
- *
  * Flags: Flags have no meaning beyond the scope of this subroutine.
  *
  * clobbered registers: x2 to x5, x10, x11, x12, x15, x22 to 28, w0 to w31
@@ -246,14 +235,15 @@ p384_verify:
   bn.rshi   w1, w1, w0 >> 128
   bn.rshi   w0, w0, w31 >> 128
 
-  /* store u1 and u2 in scratchpad
-     scratchpad[768] <= u1; scratchpad[832] <= u2 */
+  /* store u1 and u2
+     dmem[verify_u1] <= u1; dmem[verify_u2] <= u2 */
   li        x2, 0
-  la        x26, scratchpad
-  bn.sid    x2++, 768(x26)
-  bn.sid    x2++, 800(x26)
-  bn.sid    x2++, 832(x26)
-  bn.sid    x2++, 864(x26)
+  la        x3, verify_u1
+  bn.sid    x2++,  0(x3)
+  bn.sid    x2++, 32(x3)
+  la        x3, verify_u2
+  bn.sid    x2++,  0(x3)
+  bn.sid    x2++, 32(x3)
 
   /* load domain parameter p (modulus)
      [w13, w12] <= p = dmem[p384_p] */
@@ -266,26 +256,28 @@ p384_verify:
   la        x28, p384_b
 
   /* init double and add algorithm with C = (0, 1, 0)
-     GQ = (x,y,z) = scratchpad[0] <= (0, 1, 0) */
+     (x,y,z) = dmem[verify_C] <= (0, 1, 0) */
   bn.xor    w25, w25, w25
   bn.xor    w26, w26, w26
   bn.addi   w27, w31, 1
   bn.xor    w28, w28, w28
   bn.xor    w29, w29, w29
   bn.xor    w30, w30, w30
-  la        x12, scratchpad
+  la        x12, verify_C
   jal       x1, store_proj
 
   /* load base point G and use in projective form (set z to 1)
-     G = (x,y,z) = scratchpad[192] <= (dmem[p384_gy], dmem[p384_gy], 1) */
+     G = (x,y,z) = dmem[verify_G] <= (dmem[p384_gy], dmem[p384_gy], 1) */
   la        x10, p384_gx
   la        x11, p384_gy
+  la        x12, verify_G
   jal       x1, store_aff_proj
 
   /* load public key Q from dmem and use in projective form (set z to 1)
-     Q = (x,y,z) = scratchpad[384] <= (dmem[*dptr_x], dmem[*dptr_y], 1) */
+     Q = (x,y,z) = dmem[verify_Q] <= (dmem[*dptr_x], dmem[*dptr_y], 1) */
   add       x10, x13, x0
   add       x11, x14, x0
+  la        x12, verify_Q
   jal       x1,  store_aff_proj
 
   /* The remaining part of the routine implements a variable time
@@ -294,29 +286,28 @@ p384_verify:
      single double-and-add routine by using Shamir's Trick. */
 
   /* load point G */
-  la       x26, scratchpad
+  la       x3, verify_G
   li       x2, 25
-  bn.lid   x2++, 192(x26)
-  bn.lid   x2++, 224(x26)
-  bn.lid   x2++, 256(x26)
-  bn.lid   x2++, 288(x26)
-  bn.lid   x2++, 320(x26)
-  bn.lid   x2++, 352(x26)
+  bn.lid   x2++,   0(x3)
+  bn.lid   x2++,  32(x3)
+  bn.lid   x2++,  64(x3)
+  bn.lid   x2++,  96(x3)
+  bn.lid   x2++, 128(x3)
+  bn.lid   x2++, 160(x3)
 
   /* Compute G+Q and store in dmem
-     GQ = (x,y,z) = dmem[dptr_sp+576]
-        <= sp[dptr_sp+192] (+) dmem[dptr_sp+384] */
-  addi      x27, x26, 384
+     QG = (x,y,z) = dmem[verify_QG] <= Q + G */
+  la        x27, verify_Q
   jal       x1, proj_add_p384
+  la        x12, verify_QG
   jal       x1, store_proj
-
-  la        x26, scratchpad
 
   /* Initialize loop counter to 0. */
   addi      x15, x0, 0
 
   /* load point C */
   li       x2, 25
+  la       x26, verify_C
   bn.lid   x2++,   0(x26)
   bn.lid   x2++,  32(x26)
   bn.lid   x2++,  64(x26)
@@ -325,18 +316,23 @@ p384_verify:
   bn.lid   x2++, 160(x26)
 
   /* main loop with decreasing index i (i=383 downto 0) */
+  la        x17, verify_G
+  la        x18, verify_Q
+  la        x19, verify_QG
+  la        x20, verify_u1
+  la        x21, verify_u2
   loopi     384, 31
 
     /* probe MSBs of u1 and u2 and u1|u2 to determine which point has to be
        added. */
 
-    /* load u1 and u2 from scratchpad
+    /* load u1 and u2
        [w1,w0] <= u1; [w3, w2] = u2 */
     li        x2, 0
-    bn.lid    x2++, 768(x26)
-    bn.lid    x2++, 800(x26)
-    bn.lid    x2++, 832(x26)
-    bn.lid    x2++, 864(x26)
+    bn.lid    x2++,  0(x20)
+    bn.lid    x2++, 32(x20)
+    bn.lid    x2++,  0(x21)
+    bn.lid    x2++, 32(x21)
 
     /* left shift u1 = [w1,w0] <= [w1,w0] << 1 */
     bn.add    w0, w0, w0
@@ -355,11 +351,11 @@ p384_verify:
     andi      x4, x4, 1
     li        x2, 0
 
-    /* write back u1 and u2 to scratchpad */
-    bn.sid    x2++, 768(x26)
-    bn.sid    x2++, 800(x26)
-    bn.sid    x2++, 832(x26)
-    bn.sid    x2++, 864(x26)
+    /* write back u1 and u2 */
+    bn.sid    x2++,  0(x20)
+    bn.sid    x2++, 32(x20)
+    bn.sid    x2++,  0(x21)
+    bn.sid    x2++, 32(x21)
 
     /* test if at least one MSb of the scalars is 1
        x5 <= x4 | x3 = u1[i] | u2[i] */
@@ -378,16 +374,16 @@ p384_verify:
     bne       x3, x0, u1_set
 
     /* only u2[i] is set: do C <= C + Q */
-    addi      x27, x26, 384
+    addi      x27, x18, 0
     jal       x0, ver_do_add
 
     u1_set:
     /* check if u2[i] is set as well, if so do C <= C + (G + Q) */
-    addi      x27, x26, 576
+    addi      x27, x19, 0
     bne       x4, x0, ver_do_add
 
     /* only u1[i] is set: do C <= C + G */
-    add       x27, x26, 192
+    add       x27, x17, 0
     jal       x0, ver_do_add
 
     ver_do_add:
@@ -485,9 +481,38 @@ y:
 x_r:
   .zero 64
 
-/* Scratchpad memory */
+/* First scalar (local temp buffer) */
 .balign 32
-.globl scratchpad
-.weak scratchpad
-scratchpad:
-  .zero 896
+.globl verify_u1
+verify_u1:
+.zero 64
+
+/* Second scalar (local temp buffer) */
+.balign 32
+.globl verify_u2
+verify_u2:
+.zero 64
+
+/* Stored projective point (local temp buffer) */
+.balign 32
+.globl verify_Q
+verify_Q:
+.zero 192
+
+/* Stored projective point (local temp buffer) */
+.balign 32
+.globl verify_G
+verify_G:
+.zero 192
+
+/* Stored projective point (local temp buffer) */
+.balign 32
+.globl verify_QG
+verify_QG:
+.zero 192
+
+/* Stored projective point (local temp buffer) */
+.balign 32
+.globl verify_C
+verify_C:
+.zero 192

--- a/sw/acc/crypto/p384_verify.s
+++ b/sw/acc/crypto/p384_verify.s
@@ -267,7 +267,7 @@ p384_verify:
   jal       x1, store_proj
 
   /* load base point G and use in projective form (set z to 1)
-     G = (x,y,z) = dmem[verify_G] <= (dmem[p384_gy], dmem[p384_gy], 1) */
+     G = (x,y,z) = dmem[verify_G] <= (dmem[p384_gx], dmem[p384_gy], 1) */
   la        x10, p384_gx
   la        x11, p384_gy
   la        x12, verify_G

--- a/sw/acc/crypto/p384_verify.s
+++ b/sw/acc/crypto/p384_verify.s
@@ -1,3 +1,7 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
 /* Copyright lowRISC contributors (OpenTitan project). */
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
@@ -184,15 +188,13 @@ p384_verify:
      w14 <= 2^256 - n[255:0] = (2^384 - n) mod (2^256) = 2^384 - n */
   bn.sub    w14, w31, w12
 
-  /* Compute modular inverse of S
-     Note: This can be replaced by the 'mod_inv_n_p384' subroutine at the
-           cost of ~60k cycles if reduced code size is targeted */
+  /* Compute modular inverse of S. */
   /* [w9,w8] <= [w17,w16] <= s^-1  mod n = [w30,w29]^-1 mod [w13,w12] */
-  jal       x1, mod_inv_n_p384
+  jal       x1, mod_inv_p384
   bn.mov    w8, w16
   bn.mov    w9, w17
 
-  /* set regfile pointers to in/out regs of Barrett routine */
+  /* set regfile pointers to in/out regs of multiplication routine */
   li        x22, 10
   li        x23, 11
   li        x24, 16
@@ -291,12 +293,20 @@ p384_verify:
      compute the point C = (x1, y1) = u1*G + _2*Q. This can be done in a
      single double-and-add routine by using Shamir's Trick. */
 
+  /* load point G */
+  la       x26, scratchpad
+  li       x2, 25
+  bn.lid   x2++, 192(x26)
+  bn.lid   x2++, 224(x26)
+  bn.lid   x2++, 256(x26)
+  bn.lid   x2++, 288(x26)
+  bn.lid   x2++, 320(x26)
+  bn.lid   x2++, 352(x26)
+
   /* Compute G+Q and store in dmem
      GQ = (x,y,z) = dmem[dptr_sp+576]
         <= sp[dptr_sp+192] (+) dmem[dptr_sp+384] */
-  la        x26, scratchpad
   addi      x27, x26, 384
-  addi      x26, x26, 192
   jal       x1, proj_add_p384
   jal       x1, store_proj
 
@@ -305,8 +315,17 @@ p384_verify:
   /* Initialize loop counter to 0. */
   addi      x15, x0, 0
 
+  /* load point C */
+  li       x2, 25
+  bn.lid   x2++,   0(x26)
+  bn.lid   x2++,  32(x26)
+  bn.lid   x2++,  64(x26)
+  bn.lid   x2++,  96(x26)
+  bn.lid   x2++, 128(x26)
+  bn.lid   x2++, 160(x26)
+
   /* main loop with decreasing index i (i=383 downto 0) */
-  loopi     384, 35
+  loopi     384, 31
 
     /* probe MSBs of u1 and u2 and u1|u2 to determine which point has to be
        added. */
@@ -349,41 +368,34 @@ p384_verify:
     /* always double, let both input pointers for point addition point to C */
     add       x27, x26, x0
 
+    /* perform point doubling C <= 2 (*) C */
+    jal       x1, proj_double_p384
+
     /* no addition if x5 = u1[i] | u2[i] == 0 */
     beq       x5, x0, ver_end_loop
-
-    /* perform point doubling C <= 2 (*) C */
-    jal       x1, proj_add_p384
-    addi      x12, x26, 0
-    jal       x1, store_proj
 
     /* check if u1[i] is set */
     bne       x3, x0, u1_set
 
     /* only u2[i] is set: do C <= C + Q */
     addi      x27, x26, 384
-    jal       x0, ver_end_loop
+    jal       x0, ver_do_add
 
     u1_set:
-    /* chek if u2[i] is set as well */
-    bne       x4, x0, both
+    /* check if u2[i] is set as well, if so do C <= C + (G + Q) */
+    addi      x27, x26, 576
+    bne       x4, x0, ver_do_add
 
     /* only u1[i] is set: do C <= C + G */
     add       x27, x26, 192
-    jal       x0, ver_end_loop
+    jal       x0, ver_do_add
 
-    /* both bits at current index (u1[i] and u2[i]) are set:
-       do: C <= C + (G + Q) */
-    both:
-    addi      x27, x26, 576
+    ver_do_add:
+    /* Add selected point.
+         [w30:w25] <= [w30:w25] + dmem[x27] */
+    jal       x1, proj_add_p384
 
     ver_end_loop:
-    /* perform addition of selected point here, or point doubling in case
-       of no addition */
-    jal       x1, proj_add_p384
-    addi      x12, x26, 0
-    jal       x1, store_proj
-
     /* increment counter */
     addi     x15, x15, 1
 
@@ -400,7 +412,7 @@ p384_verify:
   bn.sub    w14, w31, w12
 
   /* compute inverse of z-coordinate: [w17,w16] <= z_c^-1  mod p */
-  jal       x1, mod_inv_n_p384
+  jal       x1, mod_inv_p384
 
   /* convert x-coordinate of C back to affine: x1 = x_c * z_c^-1  mod p */
   bn.mov    w10, w25
@@ -433,8 +445,6 @@ p384_verify:
 
   ret
 
-
-/* scratchpad memory */
 .section .bss
 
 .balign 32

--- a/sw/acc/crypto/tests/p384_isoncurve_proj_test.s
+++ b/sw/acc/crypto/tests/p384_isoncurve_proj_test.s
@@ -1,3 +1,7 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
 /* Copyright lowRISC contributors (OpenTitan project). */
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
@@ -30,10 +34,12 @@ p384_isoncurve_proj_test:
 
   /* load result to WDRs for comparison with reference */
   li        x2, 0
-  bn.lid    x2++, 0(x22)
-  bn.lid    x2++, 32(x22)
-  bn.lid    x2++, 0(x23)
-  bn.lid    x2++, 32(x23)
+  la        x3, lhs
+  bn.lid    x2++, 0(x3)
+  bn.lid    x2++, 32(x3)
+  la        x3, rhs
+  bn.lid    x2++, 0(x3)
+  bn.lid    x2++, 32(x3)
 
   ecall
 

--- a/sw/acc/crypto/tests/p384_proj_add_test.s
+++ b/sw/acc/crypto/tests/p384_proj_add_test.s
@@ -1,3 +1,7 @@
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
 /* Copyright lowRISC contributors (OpenTitan project). */
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
@@ -18,8 +22,15 @@ p384_proj_add_test:
   /* set dmem pointer to domain parameter b */
   la       x28, p384_b
 
-  /* set dmem pointer to point 1 */
-  la       x26, p1_x
+  /* load point 1 */
+  li x2,   25
+  la x3, p1_x
+  bn.lid   x2++,   0(x3)
+  bn.lid   x2++,  32(x3)
+  bn.lid   x2++,  64(x3)
+  bn.lid   x2++,  96(x3)
+  bn.lid   x2++, 128(x3)
+  bn.lid   x2++, 160(x3)
 
   /* set dmem pointer to point 2 */
   la       x27, p2_x
@@ -30,11 +41,6 @@ p384_proj_add_test:
   la       x3, p384_p
   bn.lid   x2++, 0(x3)
   bn.lid   x2++, 32(x3)
-
-  /* Compute Solinas constant k for modulus p (we know it is only 129 bits, so
-     no need to compute the high part):
-     w14 <= 2^256 - p[255:0] = (2^384 - p) mod (2^256) = 2^384 - p */
-  bn.sub    w14, w31, w12
 
   /* init all-zero reg */
   bn.xor   w31, w31, w31


### PR DESCRIPTION
On top of #237, draft until that PR is merged. However, I thought it would be helpful to open this already to show how `proj_double` can get used.

While working on memory tracking for the constant-time checker I took a close look at the P-384 scalarmult code and noticed it could use some attention from both performance and readability perspectives. This PR is a collection of interrelated improvements to make the code simpler and faster.

- adjust `proj_add_p384` to take one input in registers to reduce loads/stores
- use specialized point doubling to accelerate scalarmult/verify
- improve randomization techniques and better mask MSBs
- use dedicated buffers instead of scratchpad offsets
- remove some unused constants and stale comments
- rename `mod_inv_n_p384` to `mod_inv_p384`, since it is used for `p` as well as `n` (this confused me for a bit)

**Overall, this resulted in about a 20% speed improvement across top-level P-384 operations.**

Full printout from `bench/acc/analyze_stats.py`, omitting median because there was only 1 test each:

```
Measurement                     | Baseline |     New | Percentage change
p384_base_mult avg_cycles       |  1611885 | 1267361 |            -21.37
p384_ecdsa_sign avg_cycles      |  1683063 | 1338539 |            -20.47
p384_ecdsa_verify avg_cycles    |  1161878 |  930615 |            -19.90
p384_scalar_mult avg_cycles     |  1612992 | 1268476 |            -21.36
```