### PR TITLE
[acc] Streamine trigger_fault routines and better recognize no-ops in information flow.

### DIFF
--- a/hw/ip/acc/data/bignum-insns.yml
+++ b/hw/ip/acc/data/bignum-insns.yml
@@ -525,7 +525,13 @@
     The content of the second source WDR can be shifted by an unsigned immediate before it is consumed by the operation.
   errs: []
   iflow:
-    - to: [wrd, flags-all]
+    - test:
+        - wrs1 == wrs2
+      to: [wrd, flags-all]
+      from: []
+    - test:
+        - wrs1 != wrs2
+      to: [wrd, flags-all]
       from: [wrs1, wrs2]
   encoding:
     scheme: bnaf
@@ -546,7 +552,13 @@
     Subtracts the second WDR value and the Carry from the first one, writes the result to the destination WDR, and updates the flags.
     The content of the second source WDR can be shifted by an unsigned immediate before it is consumed by the operation.
   iflow:
-    - to: [wrd, flags-all]
+    - test:
+        - wrs1 == wrs2
+      to: [wrd, flags-all]
+      from: [flags-c]
+    - test:
+        - wrs1 != wrs2
+      to: [wrd, flags-all]
       from: [wrs1, wrs2, flags-c]
   encoding:
     scheme: bnaf
@@ -799,7 +811,15 @@
     The content of the second source WDR can be shifted by an immediate before it is consumed by the operation.
     The M, L and Z flags in flag group `flag_group` are updated with the result of the operation.
   errs: []
-  iflow: *bn-and-iflow
+  iflow:
+    - test:
+        - wrs1 != wrs2
+      to: [wrd, flags-m, flags-l, flags-z]
+      from: [wrs1, wrs2]
+    - test:
+        - wrs1 == wrs2
+      to: [wrd, flags-m, flags-l, flags-z]
+      from: []
   encoding:
     scheme: bna
     mapping:
@@ -1141,8 +1161,14 @@
     - An `ILLEGAL_INSN` error if either the value in GPR `grd` or the value in GPR `grs` is greater than 31.
     - An `ILLEGAL_INSN` error if both `grs_inc` and `grd_inc` are set.
   iflow:
-    - to: [wref-grd]
+    - test:
+        - grs != grd
+      to: [wref-grd]
       from: [wref-grs]
+    - test:
+        - grs == grd
+      to: []
+      from: []
     - test:
         - grd_inc == 1
       to: [grd]

--- a/hw/ip/acc/util/shared/information_flow.py
+++ b/hw/ip/acc/util/shared/information_flow.py
@@ -549,10 +549,16 @@ def _parse_iflow_nodes(
 
 class InsnInformationFlowTest:
     '''Wrapper class for tests for information-flow rules.'''
-    def __init__(self, as_string: str, operand: str, value: int):
+    def __init__(self, as_string: str, operand: str, value: Any):
         self.as_string = as_string
         self.operand = operand
         self.value = value
+        assert isinstance(value, str) or isinstance(value, int)
+
+    def get_value(self, op_vals: Dict[str, int]) -> int:
+        if isinstance(self.value, int):
+            return self.value
+        return op_vals[self.value]
 
     def check(self, op_vals: Dict[str, int]) -> bool:
         # Should be overridden by subclasses
@@ -565,25 +571,25 @@ class InsnInformationFlowTest:
 class EqTest(InsnInformationFlowTest):
     '''Tests that the operand is equal to the value.'''
     def check(self, op_vals: Dict[str, int]) -> bool:
-        return op_vals[self.operand] == self.value
+        return op_vals[self.operand] == self.get_value(op_vals)
 
 
 class NotEqTest(InsnInformationFlowTest):
     '''Tests that the operand is not equal to the value.'''
     def check(self, op_vals: Dict[str, int]) -> bool:
-        return not (op_vals[self.operand] == self.value)
+        return not (op_vals[self.operand] == self.get_value(op_vals))
 
 
 class GeqTest(InsnInformationFlowTest):
     '''Tests that the operand is greater than or equal to the value.'''
     def check(self, op_vals: Dict[str, int]) -> bool:
-        return op_vals[self.operand] >= self.value
+        return op_vals[self.operand] >= self.get_value(op_vals)
 
 
 class LeqTest(InsnInformationFlowTest):
     '''Tests that the operand is less than or equal to the value.'''
     def check(self, op_vals: Dict[str, int]) -> bool:
-        return op_vals[self.operand] <= self.value
+        return op_vals[self.operand] <= self.get_value(op_vals)
 
 
 class MultiTest(InsnInformationFlowTest):
@@ -617,7 +623,7 @@ def _parse_iflow_test(test_yml: object, what: str,
         raise ValueError(
             'Invalid information flow test format (expected "<operand> '
             '<comparison> <value>"): got {} (for {})'.format(test, what))
-    opname, comparison, value_str = test_split
+    opname, comparison, value = test_split
 
     opnames = [op.name for op in operands]
     if opname not in opnames:
@@ -626,11 +632,10 @@ def _parse_iflow_test(test_yml: object, what: str,
             'found in operands list: {}'.format(what, opname, opnames))
 
     try:
-        value = int(value_str, 0)
+        value = int(value, 0)  # type: ignore
     except ValueError:
-        raise ValueError(
-            'Value {} in test {} for {} must be an integer.'.format(
-                value_str, test, what))
+        # operand; ignore and keep as string
+        pass
 
     constructors = {
         '==': EqTest,
@@ -657,6 +662,9 @@ class InsnInformationFlowRule:
 
     def required_constants(self, op_vals: Dict[str, int]) -> Set[str]:
         '''Returns the names of regs that must be constant for `evaluate()`.'''
+        if not self.test.check(op_vals):
+            # Rule is not triggered
+            return set()
         out = set()
         for node in self.flows_to:
             out.update(node.required_constants(op_vals))

--- a/sw/acc/crypto/BUILD
+++ b/sw/acc/crypto/BUILD
@@ -17,6 +17,8 @@ acc_binary(
         ":p256_isoncurve",
         ":p256_sign",
         ":p256_verify",
+        ":trigger_fault_if_fg0_z",
+        ":trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -159,6 +161,8 @@ acc_binary(
         ":p256_shared_key",
         ":p256_sign",
         ":p256_verify",
+        ":trigger_fault_if_fg0_z",
+        ":trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -307,6 +311,7 @@ acc_binary(
         ":mul",
         ":primality",
         ":rsa_keygen",
+        ":trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -320,6 +325,8 @@ acc_binary(
         ":p256_isoncurve",
         ":p256_sign",
         ":p256_verify",
+        ":trigger_fault_if_fg0_z",
+        ":trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -331,6 +338,8 @@ acc_binary(
     deps = [
         ":p256_base",
         ":p256_isoncurve",
+        ":trigger_fault_if_fg0_z",
+        ":trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -342,6 +351,8 @@ acc_binary(
     deps = [
         ":p256_base",
         ":p256_isoncurve",
+        ":trigger_fault_if_fg0_z",
+        ":trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -356,6 +367,8 @@ acc_binary(
         ":p384_isoncurve",
         ":p384_modinv",
         ":p384_sign",
+        ":trigger_fault_if_fg0_z",
+        ":trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -378,6 +391,8 @@ acc_binary(
         ":p384_scalar_mult",
         ":p384_sign",
         ":p384_verify",
+        ":trigger_fault_if_fg0_z",
+        ":trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -440,6 +455,20 @@ acc_library(
     name = "sha3_shake",
     srcs = [
         "sha3_shake.s",
+    ],
+)
+
+acc_library(
+    name = "trigger_fault_if_fg0_z",
+    srcs = [
+        "trigger_fault_if_fg0_z.s",
+    ],
+)
+
+acc_library(
+    name = "trigger_fault_if_not_fg0_z",
+    srcs = [
+        "trigger_fault_if_not_fg0_z.s",
     ],
 )
 

--- a/sw/acc/crypto/boot.s
+++ b/sw/acc/crypto/boot.s
@@ -1,4 +1,5 @@
 /* Copyright lowRISC contributors (OpenTitan project). */
+/* Copyright zeroRISC Inc. */
 /* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
 /* SPDX-License-Identifier: Apache-2.0 */
 
@@ -168,7 +169,7 @@ attestation_keygen:
      The check fails if both sides are not equal.
      FG0.Z <= (y^2) mod p == (x^2 + ax + b) mod p */
   bn.cmp   w18, w19
-  jal      x1, trigger_fault_if_fg0_not_z
+  jal      x1, trigger_fault_if_not_fg0_z
 
   ecall
 

--- a/sw/acc/crypto/p256_base.s
+++ b/sw/acc/crypto/p256_base.s
@@ -17,8 +17,6 @@
 .globl p256_generate_random_key
 .globl p256_key_from_seed
 .globl p256_scalar_remask
-.globl trigger_fault_if_fg0_z
-.globl trigger_fault_if_fg0_not_z
 .globl mul_modp
 .globl setup_modp
 .globl mod_mul_256x256
@@ -32,88 +30,6 @@
 .globl proj_double
 
 .text
-
-/**
- * Trigger a fault if the FG0.Z flag is 1.
- *
- * If the flag is 1, then this routine will trigger an `ILLEGAL_INSN` error and
- * abort the ACC program. If the flag is 0, the routine will essentially do
- * nothing.
- *
- * NOTE: Be careful when calling this routine that the FG0.Z flag is not
- * sensitive; since aborting the program will be quicker than completing it,
- * the flag's value is likely clearly visible to an attacker through timing.
- *
- * @param[in]    w31: all-zero
- * @param[in]  FG0.Z: boolean indicating fault condition
- *
- * clobbered registers: x2
- * clobbered flag groups: none
- */
-trigger_fault_if_fg0_z:
-  /* Read the FG0.Z flag (position 3).
-       x2 <= FG0.Z */
-  csrrw     x2, FG0, x0
-  andi      x2, x2, 8
-  srli      x2, x2, 3
-
-  /* Subtract FG0.Z from 0.
-       x2 <= 0 - x2 = FG0.Z ? 2^32 - 1 : 0 */
-  sub       x2, x0, x2
-
-  /* The `bn.lid` instruction causes an `BAD_DATA_ADDR` error if the
-     memory address is out of bounds. Therefore, if FG0.Z is 1, this
-     instruction causes an error, but if FG0.Z is 0 it simply loads the word at
-     address 0 into w31. */
-  li         x3, 31
-  bn.lid     x3, 0(x2)
-
-  /* If we get here, the flag must have been 0. Restore w31 to zero and return.
-       w31 <= 0 */
-  bn.xor     w31, w31, w31
-
-  ret
-
-/**
- * Trigger a fault if the FG0.Z flag is 0.
- *
- * If the flag is 0, then this routine will trigger an `ILLEGAL_INSN` error and
- * abort the ACC program. If the flag is 1, the routine will essentially do
- * nothing.
- *
- * NOTE: Be careful when calling this routine that the FG0.Z flag is not
- * sensitive; since aborting the program will be quicker than completing it,
- * the flag's value is likely clearly visible to an attacker through timing.
- *
- * @param[in]    w31: all-zero
- * @param[in]  FG0.Z: boolean indicating (complement of) fault condition
- *
- * clobbered registers: x2
- * clobbered flag groups: none
- */
-trigger_fault_if_fg0_not_z:
-  /* Read the FG0.Z flag (position 3).
-       x2 <= FG0.Z */
-  csrrw     x2, FG0, x0
-  andi      x2, x2, 8
-  srli      x2, x2, 3
-
-  /* Subtract 1 from FG0.Z.
-       x2 <= x2 - 1 = FG0.Z ? 0 : 2^32 - 1 */
-  addi      x2, x2, -1
-
-  /* The `bn.lid` instruction causes an `BAD_DATA_ADDR` error if the
-     memory address is out of bounds. Therefore, if FG0.Z is 0, this
-     instruction causes an error, but if FG0.Z is 1 it simply loads the word at
-     address 0 into w31. */
-  li         x3, 31
-  bn.lid     x3, 0(x2)
-
-  /* If we get here, the flag must have been 1. Restore w31 to zero and return.
-       w31 <= 0 */
-  bn.xor     w31, w31, w31
-
-  ret
 
 /**
  * Reduce a 512-bit value by a 256-bit P-256 modulus (either n or p).
@@ -1599,7 +1515,7 @@ p256_base_mult:
      The check fails if both sides are not equal.
      FG0.Z <= (y^2) mod p == (x^2 + ax + b) mod p */
   bn.cmp   w18, w19
-  jal      x1, trigger_fault_if_fg0_not_z
+  jal      x1, trigger_fault_if_not_fg0_z
 
   ret
 

--- a/sw/acc/crypto/p256_shared_key.s
+++ b/sw/acc/crypto/p256_shared_key.s
@@ -86,7 +86,7 @@ p256_shared_key:
      The check fails if both sides are not equal.
      FG0.Z <= (y^2) mod p == (x^2 + ax + b) mod p */
   bn.cmp   w18, w19
-  jal      x1, trigger_fault_if_fg0_not_z
+  jal      x1, trigger_fault_if_not_fg0_z
 
   /* Arithmetic masking:
    1. Generate a random mask

--- a/sw/acc/crypto/p256_sign.s
+++ b/sw/acc/crypto/p256_sign.s
@@ -126,7 +126,7 @@ p256_sign:
      The check fails if both sides are not equal.
      FG0.Z <= (y^2) mod p == (x^2 + ax + b) mod p */
   bn.cmp   w18, w19
-  jal      x1, trigger_fault_if_fg0_not_z
+  jal      x1, trigger_fault_if_not_fg0_z
 
   /* setup modulus n (curve order) and Barrett constant
      MOD <= w29 <= n = dmem[p256_n]; w28 <= u_n = dmem[p256_u_n]  */

--- a/sw/acc/crypto/p384_internal_mult.s
+++ b/sw/acc/crypto/p384_internal_mult.s
@@ -166,7 +166,7 @@ store_proj_randomize:
 scalar_mult_int_p384:
 
   /* set regfile pointers to in/out regs of mulmod routine. Set here to avoid
-     resetting in very call to point addition routine */
+     resetting in every call to point addition routine */
   li        x22, 10
   li        x23, 11
   li        x24, 16

--- a/sw/acc/crypto/p384_isoncurve.s
+++ b/sw/acc/crypto/p384_isoncurve.s
@@ -18,48 +18,6 @@
  .section .text
 
 /**
- * Trigger a fault if the FG0.Z flag is 0.
- *
- * If the flag is 0, then this routine will trigger an `ILLEGAL_INSN` error and
- * abort the ACC program. If the flag is 1, the routine will essentially do
- * nothing.
- *
- * NOTE: Be careful when calling this routine that the FG0.Z flag is not
- * sensitive; since aborting the program will be quicker than completing it,
- * the flag's value is likely clearly visible to an attacker through timing.
- *
- * @param[in]    w31: all-zero
- * @param[in]  FG0.Z: boolean indicating (complement of) fault condition
- *
- * clobbered registers: x2, x3
- * clobbered flag groups: none
- */
- .globl trigger_fault_if_fg0_not_z
-trigger_fault_if_fg0_not_z:
-  /* Read the FG0.Z flag (position 3).
-       x2 <= FG0.Z */
-  csrrw     x2, FG0, x0
-  andi      x2, x2, 8
-  srli      x2, x2, 3
-
-  /* Subtract 1 from FG0.Z.
-       x2 <= x2 - 1 = FG0.Z ? 0 : 2^32 - 1 */
-  addi      x2, x2, -1
-
-  /* The `bn.lid` instruction causes an `BAD_DATA_ADDR` error if the
-     memory address is out of bounds. Therefore, if FG0.Z is 0, this
-     instruction causes an error, but if FG0.Z is 1 it simply loads the word at
-     address 0 into w31. */
-  li         x3, 31
-  bn.lid     x3, 0(x2)
-
-  /* If we get here, the flag must have been 1. Restore w31 to zero and return.
-       w31 <= 0 */
-  bn.xor     w31, w31, w31
-
-  ret
-
-/**
  * Checks if a point is a valid curve point on curve P-384
  *
  * Returns rhs = x^3 + ax + b  mod p
@@ -220,11 +178,11 @@ p384_isoncurve_check:
        FG0.Z <= (y^2) mod p == (x^2 + ax + b) mod p */
   bn.cmp    w4, w6
   /* Fail if FG0.Z is false. */
-  jal       x1, trigger_fault_if_fg0_not_z
+  jal       x1, trigger_fault_if_not_fg0_z
 
   bn.cmp    w5, w7
   /* Fail if FG0.Z is false. */
-  jal       x1, trigger_fault_if_fg0_not_z
+  jal       x1, trigger_fault_if_not_fg0_z
 
   ret
 

--- a/sw/acc/crypto/p384_isoncurve_proj.s
+++ b/sw/acc/crypto/p384_isoncurve_proj.s
@@ -54,11 +54,11 @@ p384_isoncurve_proj_check:
        FG0.Z <= (y^2) mod p == (x^2 + ax + b) mod p */
   bn.cmp    w4, w2
   /* Fail if FG0.Z is false. */
-  jal       x1, trigger_fault_if_fg0_not_z
+  jal       x1, trigger_fault_if_not_fg0_z
 
   bn.cmp    w5, w3
   /* Fail if FG0.Z is false. */
-  jal       x1, trigger_fault_if_fg0_not_z
+  jal       x1, trigger_fault_if_not_fg0_z
 
   ret
 

--- a/sw/acc/crypto/rsa_keygen.s
+++ b/sw/acc/crypto/rsa_keygen.s
@@ -1333,20 +1333,12 @@ modinv_f4:
   bn.addi    w23, w31, 1
   bn.cmp     w22, w23
 
-  /* Get the FG0.Z flag into a register.
-       x2 <= CSRs[FG0] & 8 = FG0.Z << 3 */
-  csrrs    x2, FG0, x0
-  andi     x2, x2, 8
-
-  /* If the flag is unset (x2 == 0) then u != 1; in this case GCD(65537, m) !=
+  /* If the flag is unset (FG0.Z == 0) then u != 1; in this case GCD(65537, m) !=
      1 and the modular inverse cannot be computed. This should never happen
      under normal operation, so panic and abort the program immediately. */
-  bne      x2, x0, _modinv_f4_u_ok
-  unimp
+  jal      x1, trigger_fault_if_not_fg0_z
 
-_modinv_f4_u_ok:
   /* Done; the modular inverse is stored in A. */
-
   ret
 
 /**

--- a/sw/acc/crypto/tests/BUILD
+++ b/sw/acc/crypto/tests/BUILD
@@ -330,6 +330,8 @@ acc_sim_test(
     deps = [
         "//sw/acc/crypto:p256_base",
         "//sw/acc/crypto:p256_isoncurve",
+        "//sw/acc/crypto:trigger_fault_if_fg0_z",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -342,6 +344,8 @@ acc_sim_test(
     deps = [
         "//sw/acc/crypto:p256_base",
         "//sw/acc/crypto:p256_isoncurve",
+        "//sw/acc/crypto:trigger_fault_if_fg0_z",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -378,6 +382,8 @@ acc_sim_test(
     deps = [
         "//sw/acc/crypto:p256_base",
         "//sw/acc/crypto:p256_isoncurve",
+        "//sw/acc/crypto:trigger_fault_if_fg0_z",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -390,6 +396,8 @@ acc_sim_test(
     deps = [
         "//sw/acc/crypto:p256_base",
         "//sw/acc/crypto:p256_isoncurve",
+        "//sw/acc/crypto:trigger_fault_if_fg0_z",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -433,6 +441,8 @@ acc_sim_test(
         "//sw/acc/crypto:p256_base",
         "//sw/acc/crypto:p256_isoncurve",
         "//sw/acc/crypto:p256_sign",
+        "//sw/acc/crypto:trigger_fault_if_fg0_z",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -446,6 +456,8 @@ acc_sim_test(
         "//sw/acc/crypto:p256_base",
         "//sw/acc/crypto:p256_isoncurve",
         "//sw/acc/crypto:p256_verify",
+        "//sw/acc/crypto:trigger_fault_if_fg0_z",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -458,6 +470,8 @@ acc_sim_test(
     deps = [
         "//sw/acc/crypto:p256_base",
         "//sw/acc/crypto:p256_isoncurve",
+        "//sw/acc/crypto:trigger_fault_if_fg0_z",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -471,6 +485,8 @@ acc_sim_test(
         "//sw/acc/crypto:p256_base",
         "//sw/acc/crypto:p256_isoncurve",
         "//sw/acc/crypto:p256_isoncurve_proj",
+        "//sw/acc/crypto:trigger_fault_if_fg0_z",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -483,6 +499,8 @@ acc_sim_test(
     deps = [
         "//sw/acc/crypto:p256_base",
         "//sw/acc/crypto:p256_isoncurve",
+        "//sw/acc/crypto:trigger_fault_if_fg0_z",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -495,6 +513,8 @@ acc_sim_test(
     deps = [
         "//sw/acc/crypto:p256_base",
         "//sw/acc/crypto:p256_isoncurve",
+        "//sw/acc/crypto:trigger_fault_if_fg0_z",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -507,6 +527,8 @@ acc_sim_test(
     deps = [
         "//sw/acc/crypto:p256_base",
         "//sw/acc/crypto:p256_isoncurve",
+        "//sw/acc/crypto:trigger_fault_if_fg0_z",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -521,6 +543,8 @@ acc_sim_test(
         "//sw/acc/crypto:p256_isoncurve",
         "//sw/acc/crypto:p256_isoncurve_proj",
         "//sw/acc/crypto:p256_shared_key",
+        "//sw/acc/crypto:trigger_fault_if_fg0_z",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -535,6 +559,8 @@ acc_sim_test(
         "//sw/acc/crypto:p256_isoncurve",
         "//sw/acc/crypto:p256_isoncurve_proj",
         "//sw/acc/crypto:p256_shared_key",
+        "//sw/acc/crypto:trigger_fault_if_fg0_z",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -549,6 +575,8 @@ acc_sim_test(
         "//sw/acc/crypto:p256_isoncurve",
         "//sw/acc/crypto:p256_isoncurve_proj",
         "//sw/acc/crypto:p256_shared_key",
+        "//sw/acc/crypto:trigger_fault_if_fg0_z",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -587,6 +615,8 @@ acc_sim_test(
         "//sw/acc/crypto:p384_base_mult",
         "//sw/acc/crypto:p384_internal_mult",
         "//sw/acc/crypto:p384_isoncurve",
+        "//sw/acc/crypto:trigger_fault_if_fg0_z",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -601,6 +631,8 @@ acc_sim_test(
         "//sw/acc/crypto:p384_base_mult",
         "//sw/acc/crypto:p384_internal_mult",
         "//sw/acc/crypto:p384_isoncurve",
+        "//sw/acc/crypto:trigger_fault_if_fg0_z",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -652,6 +684,8 @@ acc_sim_test(
         "//sw/acc/crypto:p384_isoncurve",
         "//sw/acc/crypto:p384_isoncurve_proj",
         "//sw/acc/crypto:p384_scalar_mult",
+        "//sw/acc/crypto:trigger_fault_if_fg0_z",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -667,6 +701,8 @@ acc_sim_test(
         "//sw/acc/crypto:p384_isoncurve",
         "//sw/acc/crypto:p384_modinv",
         "//sw/acc/crypto:p384_sign",
+        "//sw/acc/crypto:trigger_fault_if_fg0_z",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -681,6 +717,8 @@ acc_sim_test(
         "//sw/acc/crypto:p384_isoncurve",
         "//sw/acc/crypto:p384_modinv",
         "//sw/acc/crypto:p384_verify",
+        "//sw/acc/crypto:trigger_fault_if_fg0_z",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -693,6 +731,8 @@ acc_sim_test(
     deps = [
         "//sw/acc/crypto:p384_base",
         "//sw/acc/crypto:p384_isoncurve",
+        "//sw/acc/crypto:trigger_fault_if_fg0_z",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -706,6 +746,8 @@ acc_sim_test(
         "//sw/acc/crypto:p384_base",
         "//sw/acc/crypto:p384_isoncurve",
         "//sw/acc/crypto:p384_isoncurve_proj",
+        "//sw/acc/crypto:trigger_fault_if_fg0_z",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -718,6 +760,8 @@ acc_sim_test(
     deps = [
         "//sw/acc/crypto:p384_base",
         "//sw/acc/crypto:p384_isoncurve",
+        "//sw/acc/crypto:trigger_fault_if_fg0_z",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -780,6 +824,8 @@ acc_sim_test(
         "//sw/acc/crypto:p384_isoncurve",
         "//sw/acc/crypto:p384_isoncurve_proj",
         "//sw/acc/crypto:p384_scalar_mult",
+        "//sw/acc/crypto:trigger_fault_if_fg0_z",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -804,9 +850,6 @@ acc_consttime_test(
 
 acc_consttime_test(
     name = "p384_scalar_mult_consttime",
-    ignore = [
-        "trigger_fault_if_fg0_not_z",
-    ],
     subroutine = "p384_scalar_mult",
     deps = [
         ":p384_scalar_mult_test",
@@ -983,6 +1026,7 @@ acc_sim_test(
         "//sw/acc/crypto:mul",
         "//sw/acc/crypto:primality",
         "//sw/acc/crypto:rsa_keygen",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -1001,6 +1045,7 @@ acc_sim_test(
         "//sw/acc/crypto:mul",
         "//sw/acc/crypto:primality",
         "//sw/acc/crypto:rsa_keygen",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -1034,6 +1079,7 @@ acc_sim_test(
         "//sw/acc/crypto:mul",
         "//sw/acc/crypto:primality",
         "//sw/acc/crypto:rsa_keygen",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -1063,6 +1109,7 @@ acc_sim_test(
         "//sw/acc/crypto:mul",
         "//sw/acc/crypto:primality",
         "//sw/acc/crypto:rsa_keygen",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -1081,6 +1128,7 @@ acc_sim_test(
         "//sw/acc/crypto:mul",
         "//sw/acc/crypto:primality",
         "//sw/acc/crypto:rsa_keygen",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -1099,6 +1147,7 @@ acc_sim_test(
         "//sw/acc/crypto:mul",
         "//sw/acc/crypto:primality",
         "//sw/acc/crypto:rsa_keygen",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -1117,6 +1166,7 @@ acc_sim_test(
         "//sw/acc/crypto:mul",
         "//sw/acc/crypto:primality",
         "//sw/acc/crypto:rsa_keygen",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -1135,6 +1185,7 @@ acc_sim_test(
         "//sw/acc/crypto:mul",
         "//sw/acc/crypto:primality",
         "//sw/acc/crypto:rsa_keygen",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -1153,6 +1204,7 @@ acc_sim_test(
         "//sw/acc/crypto:mul",
         "//sw/acc/crypto:primality",
         "//sw/acc/crypto:rsa_keygen",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -1171,6 +1223,7 @@ acc_sim_test(
         "//sw/acc/crypto:mul",
         "//sw/acc/crypto:primality",
         "//sw/acc/crypto:rsa_keygen",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -1199,6 +1252,7 @@ acc_sim_test(
         "//sw/acc/crypto:mul",
         "//sw/acc/crypto:primality",
         "//sw/acc/crypto:rsa_keygen",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -1218,6 +1272,7 @@ acc_sim_test(
         "//sw/acc/crypto:montmul",
         "//sw/acc/crypto:mul",
         "//sw/acc/crypto:rsa_keygen",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -1238,6 +1293,7 @@ acc_sim_test(
         "//sw/acc/crypto:mul",
         "//sw/acc/crypto:primality",
         "//sw/acc/crypto:rsa_keygen",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -1259,6 +1315,7 @@ acc_sim_test(
         "//sw/acc/crypto:mul",
         "//sw/acc/crypto:primality",
         "//sw/acc/crypto:rsa_keygen",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -1279,6 +1336,7 @@ acc_sim_test(
         "//sw/acc/crypto:mul",
         "//sw/acc/crypto:primality",
         "//sw/acc/crypto:rsa_keygen",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -1298,6 +1356,7 @@ acc_sim_test(
         "//sw/acc/crypto:montmul",
         "//sw/acc/crypto:mul",
         "//sw/acc/crypto:rsa_keygen",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -1317,6 +1376,7 @@ acc_sim_test(
         "//sw/acc/crypto:montmul",
         "//sw/acc/crypto:mul",
         "//sw/acc/crypto:rsa_keygen",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 
@@ -1336,6 +1396,7 @@ acc_sim_test(
         "//sw/acc/crypto:mul",
         "//sw/acc/crypto:primality",
         "//sw/acc/crypto:rsa_keygen",
+        "//sw/acc/crypto:trigger_fault_if_not_fg0_z",
     ],
 )
 

--- a/sw/acc/crypto/trigger_fault_if_fg0_z.s
+++ b/sw/acc/crypto/trigger_fault_if_fg0_z.s
@@ -1,0 +1,33 @@
+/* Copyright lowRISC contributors (OpenTitan project). */
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Trigger a fault if the FG0.Z flag is 1.
+ *
+ * If the flag is 1, then this routine will trigger an `ILLEGAL_INSN` error and
+ * abort the ACC program. If the flag is 0, the routine will essentially do
+ * nothing.
+ *
+ * NOTE: Be careful when calling this routine that the FG0.Z flag is not
+ * sensitive; since aborting the program will be quicker than completing it,
+ * the flag's value is likely clearly visible to an attacker through timing.
+ *
+ * @param[in]  FG0.Z: boolean indicating fault condition
+ *
+ * clobbered registers: x2
+ * clobbered flag groups: none
+ */
+.globl trigger_fault_if_fg0_z
+trigger_fault_if_fg0_z:
+  /* Read the FG0.Z flag (position 3).
+       x2 <= FG0.Z << 3 */
+  csrrw     x2, FG0, x0
+  andi      x2, x2, 8
+
+  /* Causes an ILLEGAL_INSN error if x2 != 0; otherwise just does a no-op move
+     from w0 to w0. */
+  slli      x2, x2, 5
+  bn.movr   x2, x2
+  ret

--- a/sw/acc/crypto/trigger_fault_if_not_fg0_z.s
+++ b/sw/acc/crypto/trigger_fault_if_not_fg0_z.s
@@ -1,0 +1,33 @@
+/* Copyright lowRISC contributors (OpenTitan project). */
+/* Copyright zeroRISC Inc. */
+/* Licensed under the Apache License, Version 2.0, see LICENSE for details. */
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/**
+ * Trigger a fault if the FG0.Z flag is 0.
+ *
+ * If the flag is 0, then this routine will trigger an `ILLEGAL_INSN` error and
+ * abort the ACC program. If the flag is 1, the routine will essentially do
+ * nothing.
+ *
+ * NOTE: Be careful when calling this routine that the FG0.Z flag is not
+ * sensitive; since aborting the program will be quicker than completing it,
+ * the flag's value is likely clearly visible to an attacker through timing.
+ *
+ * @param[in]  FG0.Z: boolean indicating fault condition
+ *
+ * clobbered registers: x2
+ * clobbered flag groups: none
+ */
+.globl trigger_fault_if_not_fg0_z
+trigger_fault_if_not_fg0_z:
+  /* Read the FG0.Z flag (position 3).
+       x2 <= FG0.Z << 3 */
+  csrrw     x2, FG0, x0
+  andi      x2, x2, 8
+
+  /* Causes an ILLEGAL_INSN error if x2 == 0; otherwise just does a no-op move
+     from w0 to w0. */
+  addi      x2, x2, -8
+  bn.movr   x2, x2
+  ret


### PR DESCRIPTION
This PR:
- moves the `trigger_fault_if_fg0_z` and `trigger_fault_if_fg0_not_z` to separate files so P-256, P-384, and RSA keygen do not all maintain separate copies of this logic
- adjusts the information-flow backend rules to better detect certain special cases where operands being the same changes the information flow (`bn.xor`, `bn.sub`, `bn.movr`)
- changes the name of the complement routine to `trigger_fault_if_not_fg0_z`, because it makes more sense to me than `fg0_not_z`
- changes the mechanism for producing a fault to `bn.movr` with an invalid register instead of `bn.lid` with an invalid offset, for a few reasons:
  -  gives an `ILLEGAL_INSN` error instead of a `BAD_DATA_ADDR` area (I think that's a little bit clearer for debugging)
  - does not depend on DMEM size
  - plays more nicely with the information-flow checker given the no-op detection for `bn.movr`, so we don't have to exclude/ignore these paths
  - saves a few cycles (the new routines are 4 cycles each, compared to 8 each before)