### PR TITLE
[acc] Extend information-flow tools to track DMEM.

### DIFF
--- a/hw/ip/acc/data/base-insns.yml
+++ b/hw/ip/acc/data/base-insns.yml
@@ -289,7 +289,7 @@
     bytes: 4
   iflow:
     - to: [grd]
-      from: [dmem]
+      from: [dmem-grs1-4]
 
 - mnemonic: sw
   rv32i: true
@@ -320,7 +320,7 @@
     target: [offset, grs1]
     bytes: 4
   iflow:
-    - to: [dmem]
+    - to: [dmem-grs1-4]
       from: [grs2]
 
 - mnemonic: beq
@@ -444,41 +444,13 @@
     target: [csr]
   iflow:
     - to: [grd]
+      from: [csr]
+    - to: [csr]
+      from: [csr,grs1]
+    - test:
+        - csr == 0x7d9
+      to: [kmac_core]
       from: []
-    - test:
-        - csr == 0x7c0
-      to: [fg0-all]
-      from: [fg0-all, grs1]
-    - test:
-        - csr == 0x7c0
-      to: [grd]
-      from: [fg0-all]
-    - test:
-        - csr == 0x7c1
-      to: [fg1-all]
-      from: [fg1-all, grs1]
-    - test:
-        - csr == 0x7c1
-      to: [grd]
-      from: [fg1-all]
-    - test:
-        - csr == 0x7c8
-      to: [fg0-all, fg1-all]
-      from: [fg0-all, fg1-all, grs1]
-    - test:
-        - csr == 0x7c8
-      to: [grd]
-      from: [fg0-all, fg1-all]
-    - test:
-        - csr >= 0x7d0
-        - csr <= 0x7d8
-      to: [mod]
-      from: [mod, grs1]
-    - test:
-        - csr >= 0x7d0
-        - csr <= 0x7d8
-      to: [grd]
-      from: [mod]
 
 - mnemonic: csrrw
   rv32i: true
@@ -509,49 +481,13 @@
     target: [csr]
   iflow:
     - to: [grd]
+      from: [csr]
+    - to: [csr]
+      from: [grs1]
+    - test:
+        - csr == 0x7d9
+      to: [kmac_core]
       from: []
-    - test:
-        - grd != 0
-        - csr == 0x7c0
-      to: [fg0-all]
-      from: [grs1]
-    - test:
-        - grd != 0
-        - csr == 0x7c0
-      to: [grd]
-      from: [fg0-all]
-    - test:
-        - grd != 0
-        - csr == 0x7c1
-      to: [fg1-all]
-      from: [grs1]
-    - test:
-        - grd != 0
-        - csr == 0x7c1
-      to: [grd]
-      from: [fg1-all]
-    - test:
-        - grd != 0
-        - csr == 0x7c8
-      to: [fg0-all, fg1-all]
-      from: [grs1]
-    - test:
-        - grd != 0
-        - csr == 0x7c8
-      to: [grd]
-      from: [fg0-all, fg1-all]
-    - test:
-        - grd != 0
-        - csr >= 0x7d0
-        - csr <= 0x7d8
-      to: [mod]
-      from: [mod, grs1]
-    - test:
-        - grd != 0
-        - csr >= 0x7d0
-        - csr <= 0x7d8
-      to: [grd]
-      from: [mod]
 
 - mnemonic: ecall
   rv32i: true

--- a/hw/ip/acc/data/bignum-insns.yml
+++ b/hw/ip/acc/data/bignum-insns.yml
@@ -1020,7 +1020,7 @@
     - &data-addr A `BAD_DATA_ADDR` error if the computed address is not a valid DMEM address aligned to WLEN bits.
   iflow:
     - to: [wref-grd]
-      from: [dmem]
+      from: [dmem-grs1-32]
     - test:
         - grd_inc == 1
       to: [grd]
@@ -1093,7 +1093,7 @@
     target: [offset, grs1]
     bytes: 32
   iflow:
-    - to: [dmem]
+    - to: [dmem-grs1-32]
       from: [wref-grs2]
     - test:
         - grs1_inc == 1
@@ -1199,15 +1199,7 @@
     - &bad-wsr An `ILLEGAL_INSN` error if `wsr` doesn't name a valid WSR.
   iflow:
     - to: [wrd]
-      from: []
-    - test:
-        - wsr == 0x0
-      to: [wrd]
-      from: [mod]
-    - test:
-        - wsr == 0x3
-      to: [wrd]
-      from: [acc]
+      from: [wsr]
   encoding:
     scheme: wcsr
     mapping:
@@ -1233,16 +1225,16 @@
   errs:
     - *bad-wsr
   iflow:
-    - to: []
+    - to: [wsr]
+      from: [wrs]
+    - test:
+        - wsr == 0x8
+      to: [kmac_core]
       from: []
     - test:
-        - wsr == 0x0
-      to: [mod]
-      from: [wrs]
-    - test:
-        - wsr == 0x3
-      to: [acc]
-      from: [wrs]
+        - wsr == 0x9
+      to: [wsr]
+      from: [wsr]
   encoding:
     scheme: wcsr
     mapping:

--- a/hw/ip/acc/dv/accsim/sim/load_elf.py
+++ b/hw/ip/acc/dv/accsim/sim/load_elf.py
@@ -78,7 +78,7 @@ def load_elf(sim: ACCSim, path: str, dump_rtl_sim: bool = False) -> Optional[int
     Returns the expected end address, if set, otherwise None.
 
     '''
-    (imem_bytes, dmem_bytes, symbols) = read_elf(path)
+    (imem_bytes, dmem_bytes, symbols, _) = read_elf(path)
 
     # Collect imem bytes into 32-bit words and set the validity bit for each
     assert len(imem_bytes) & 3 == 0

--- a/hw/ip/acc/util/acc_sim_test.py
+++ b/hw/ip/acc/util/acc_sim_test.py
@@ -92,7 +92,7 @@ def main() -> int:
     if args.testcase and (args.expected_dmem or args.expected_regs):
         parser.error("Cannot specify --testcase together with --expected_dmem or --expected_regs.")
 
-    _, _, symbols = read_elf(args.elf)
+    _, _, symbols, _ = read_elf(args.elf)
 
     # Parse expected values.
     result = CheckResult()

--- a/hw/ip/acc/util/analyze_information_flow.py
+++ b/hw/ip/acc/util/analyze_information_flow.py
@@ -10,9 +10,11 @@ from shared.constants import parse_required_constants
 from shared.control_flow import program_control_graph, subroutine_control_graph
 from shared.decode import decode_elf
 from shared.information_flow import InformationFlowGraph
-from shared.information_flow_analysis import (get_program_iflow,
+from shared.information_flow_analysis import (get_dmem_symbols,
+                                              get_program_iflow,
                                               get_subroutine_iflow,
-                                              stringify_control_deps)
+                                              stringify_control_deps,
+                                              parse_information_flow_node)
 
 
 def main() -> int:
@@ -52,6 +54,13 @@ def main() -> int:
         help=(
             'Initially secret information-flow nodes. If provided, the final '
             'secrets will be printed.'))
+    parser.add_argument(
+        '--track-dmem',
+        action='store_true',
+        help=('Track data in a fine-grained way through DMEM, rather than '
+              'treating memory as a single information-flow node. This may '
+              'cause analysis to fail on programs with a dynamic pattern of '
+              'memory accesses.'))
     args = parser.parse_args()
     program = decode_elf(args.elf)
 
@@ -74,6 +83,9 @@ def main() -> int:
                     ', '.join(symbols)) if symbols else ''
                 print('{:#x}{}'.format(pc, label_str))
 
+    # Get the DMEM symbols from the program.
+    dmem_symbols = get_dmem_symbols(program)
+
     # Parse initial constants.
     if args.constants is None:
         constants = {}
@@ -82,17 +94,23 @@ def main() -> int:
             raise ValueError('Cannot require initial constants for a whole '
                              'program; use --subroutine to analyze a specific '
                              'subroutine.')
-        constants = parse_required_constants(args.constants)
+        constants = parse_required_constants(args.constants, dmem_symbols)
+
+    # Parse the secrets as information-flow nodes.
+    secret_nodes = set()
+    if args.secrets:
+        for secret in args.secrets:
+            secret_nodes.add(parse_information_flow_node(program, secret, not args.track_dmem))
 
     # Compute information-flow graph(s).
     if args.subroutine is None:
         what = 'program'
-        end_iflow, control_deps = get_program_iflow(program, graph)
+        end_iflow, control_deps = get_program_iflow(program, graph, not args.track_dmem)
         ret_iflow = InformationFlowGraph.nonexistent()
     else:
         what = 'subroutine'
         ret_iflow, end_iflow, control_deps = get_subroutine_iflow(
-            program, graph, args.subroutine, constants)
+            program, graph, args.subroutine, constants, not args.track_dmem)
 
     # If no secrets were given or the --verbose flag is set, then print the
     # full information-flow graphs.
@@ -100,13 +118,13 @@ def main() -> int:
         if ret_iflow.exists:
             print(
                 'Information flow for paths ending in a return to the caller:')
-            print(ret_iflow.pretty(indent=2))
+            print(ret_iflow.pretty(indent=2, dmem_symbols=dmem_symbols))
             if end_iflow.exists:
                 print('--------')
 
         if end_iflow.exists:
             print('Information flow for paths ending the program:')
-            print(end_iflow.pretty(indent=2))
+            print(end_iflow.pretty(indent=2, dmem_symbols=dmem_symbols))
 
     if args.clobbered:
         if ret_iflow.exists:
@@ -124,8 +142,9 @@ def main() -> int:
         # nodes could influence control flow.
         control_what = 'secrets'
         control_deps = {
-            name: pcs
-            for name, pcs in control_deps.items() if name in args.secrets
+            node: pcs
+            for node, pcs in control_deps.items()
+            if any([s.overlaps(node) for s in secret_nodes])
         }
 
     # Print any (secret) nodes that influence control flow, and the PCs of the
@@ -143,15 +162,15 @@ def main() -> int:
     if args.secrets is not None:
         if ret_iflow.exists:
             final_secrets = {
-                sink
-                for node in args.secrets for sink in ret_iflow.sinks(node)
+                sink.pretty(dmem_symbols)
+                for node in secret_nodes for sink in ret_iflow.sinks(node)
             }
             print('Final secrets for paths ending in a return to the caller:',
                   ', '.join(sorted(final_secrets)))
         if end_iflow.exists:
             final_secrets = {
-                sink
-                for node in args.secrets for sink in end_iflow.sinks(node)
+                sink.pretty(dmem_symbols)
+                for node in secret_nodes for sink in end_iflow.sinks(node)
             }
             print('Final secrets for paths ending the program:',
                   ', '.join(sorted(final_secrets)))

--- a/hw/ip/acc/util/check_const_time.py
+++ b/hw/ip/acc/util/check_const_time.py
@@ -10,10 +10,11 @@ from shared.check import CheckResult
 from shared.constants import parse_required_constants
 from shared.control_flow import program_control_graph, subroutine_control_graph
 from shared.decode import decode_elf
-from shared.information_flow_analysis import (get_program_iflow,
+from shared.information_flow_analysis import (get_dmem_symbols,
+                                              get_program_iflow,
                                               get_subroutine_iflow,
-                                              parse_information_flow_node,
-                                              stringify_control_deps)
+                                              stringify_control_deps,
+                                              parse_information_flow_node)
 
 
 def main() -> int:
@@ -51,7 +52,9 @@ def main() -> int:
         help=('Initial secret information-flow nodes. If not provided, '
               'assume everything is secret unless --public is specified; '
               'check that the subroutine or program has only one possible '
-              'control-flow path regardless of input.'))
+              'control-flow path regardless of input. Memory locations can '
+              'be specified in the form "dmem:<label>[:<length>]", for '
+              'example "dmem:foo[:32]".'))
     parser.add_argument(
         '--public',
         nargs='+',
@@ -60,10 +63,19 @@ def main() -> int:
         help=('Initially NOT secret information-flow nodes. If specified, '
               'assume everything else is secret. Cannot be specified at the '
               'same time as --secret.'))
+    parser.add_argument(
+        '--track-dmem',
+        action='store_true',
+        help=('Track data in a fine-grained way through DMEM, rather than '
+              'treating memory as a single information-flow node. This may '
+              'cause analysis to fail on programs with a dynamic pattern of '
+              'memory accesses.'))
     args = parser.parse_args()
 
     # Load the program.
     program = decode_elf(args.elf)
+
+    dmem_symbols = get_dmem_symbols(program)
 
     # Parse initial constants.
     if args.constants is None:
@@ -73,7 +85,9 @@ def main() -> int:
             raise ValueError('Cannot require initial constants for a whole '
                              'program; use --subroutine to analyze a specific '
                              'subroutine.')
-        constants = parse_required_constants(args.constants)
+        constants = parse_required_constants(args.constants, dmem_symbols)
+
+    coarse_dmem = not args.track_dmem
 
     if args.secret and args.public:
         raise ValueError('Cannot specify --secret and --public together.')
@@ -82,40 +96,46 @@ def main() -> int:
     secret_nodes = set()
     if args.secret:
         for secret in args.secret:
-            secret_nodes.add(parse_information_flow_node(secret))
+            secret_nodes.add(parse_information_flow_node(program, secret, coarse_dmem))
 
     # Parse the public values as information-flow nodes.
     public_nodes = set()
     if args.public:
         for public in args.public:
-            public_nodes.add(parse_information_flow_node(public))
+            if public.startswith('dmem:') and coarse_dmem:
+                raise ValueError('Cannot declassify specific DMEM ranges unless '
+                                 '--track-dmem is specified.')
+            public_nodes.add(parse_information_flow_node(program, public, coarse_dmem))
 
     # Compute control graph and get all nodes that influence control flow.
-    program = decode_elf(args.elf)
     if args.subroutine is None:
         graph = program_control_graph(program)
         to_analyze = 'entire program'
-        _, control_deps = get_program_iflow(program, graph)
+        _, control_deps = get_program_iflow(program, graph, coarse_dmem)
     else:
         graph = subroutine_control_graph(program, args.subroutine)
         to_analyze = 'subroutine {}'.format(args.subroutine)
         _, _, control_deps = get_subroutine_iflow(program, graph,
-                                                  args.subroutine, constants)
+                                                  args.subroutine,
+                                                  constants,
+                                                  coarse_dmem)
 
-    control_deps_ignore = {}
+    control_deps_ignore = set()
     if args.ignore is not None:
         for subroutine in args.ignore:
             graph = subroutine_control_graph(program, subroutine)
             _, _, control_deps_ignore_temp = get_subroutine_iflow(program, graph,
-                                                                  subroutine, {})
-            control_deps_ignore.update(control_deps_ignore_temp)
+                                                                  subroutine, {},
+                                                                  coarse_dmem)
+            for pcs in control_deps_ignore_temp.values():
+                control_deps_ignore |= pcs
 
     if args.secret is None:
         if args.public is not None:
             secret_control_deps = {
                 node: pcs
                 for node, pcs in control_deps.items()
-                if node not in public_nodes}
+                if not any([x.intersection(node) == x for x in public_nodes])}
         else:
             if args.verbose:
                 print(
@@ -130,11 +150,19 @@ def main() -> int:
         # nodes could influence control flow.
         secret_control_deps = {
             node: pcs
-            for node, pcs in control_deps.items() if node in args.secret
-        }
+            for node, pcs in control_deps.items()
+            if any([node.overlaps(secret) for secret in secret_nodes])}
 
-    secret_control_deps_filt = {k: v for k, v in secret_control_deps.items()
-                                if v not in control_deps_ignore.values()}
+    secret_control_deps_filt = {}
+    for node, pcs in secret_control_deps.items():
+        filtered_pcs = pcs - control_deps_ignore
+        has_overlap = any([node.overlaps(secret) for secret in secret_nodes])
+        if filtered_pcs != pcs and args.verbose and has_overlap:
+            ignored_pcs = pcs & control_deps_ignore
+            print('Control-flow dependencies on {} ignored at PCs: {}'
+                  .format(node.name, ', '.join([hex(pc) for pc in ignored_pcs])))
+        if filtered_pcs:
+            secret_control_deps_filt[node] = filtered_pcs
 
     out = CheckResult()
 

--- a/hw/ip/acc/util/shared/constants.py
+++ b/hw/ip/acc/util/shared/constants.py
@@ -132,7 +132,7 @@ class ConstantContext:
         elif insn.mnemonic == 'lui':
             grd_name = get_op_val_str(insn, op_vals, 'grd')
             new_values[grd_name] = op_vals['imm'] << 12
-        else:
+        elif insn.mnemonic in ['bn.lid', 'bn.sid', 'bn.movr']:
             # If the instruction has any op_vals ending in _inc,
             # assume we're incrementing the corresponding register
             for op in insn.operands:
@@ -140,16 +140,19 @@ class ConstantContext:
                     # If reg to be incremented is a constant, increment it
                     inc_op = op.name[:-(len('_inc'))]
                     inc_name = get_op_val_str(insn, op_vals, inc_op)
+                    inc_amount = 1
+                    if insn.mnemonic in ['bn.lid', 'bn.sid'] and op.name == 'grs1_inc':
+                        inc_amount = 32
                     if inc_name in self.values:
                         new_values[inc_name] = (self.values[inc_name] +
-                                                1) % (1 << 32)
+                                                inc_amount) % (1 << 32)
 
         # If the instruction's information-flow graph indicates that we updated
         # any constant register other than the ones handled above, the value of
         # that register can no longer be determined; remove it from the
         # constants dictionary.
-        iflow = insn.iflow.evaluate(op_vals, self.values)
-        self.removemany(iflow.all_sinks())
+        iflow = insn.iflow.evaluate(op_vals, self.values, True)
+        self.removemany([n.name for n in iflow.all_sinks()])
 
         self.values.update(new_values)
 
@@ -158,7 +161,8 @@ def is_gpr_name(name: str):
     return name in [f'x{i}' for i in range(32)]
 
 
-def parse_required_constants(constants: List[str]) -> Dict[str, int]:
+def parse_required_constants(constants: List[str],
+                             dmem_symbols: Dict[str, int]) -> Dict[str, int]:
     '''Parses required initial constants.
 
     Constants are expected to be provided in the form <reg>:<value>, e.g.
@@ -183,12 +187,14 @@ def parse_required_constants(constants: List[str]) -> Dict[str, int]:
         try:
             if value.startswith('0x'):
                 value = int(value, 16)
+            elif value in dmem_symbols:
+                value = dmem_symbols[value]
             else:
                 value = int(value)
         except ValueError:
             raise ValueError(
                 f'Cannot parse required constant {token}: {value} is not a '
-                'recognized numeric value.')
+                'recognized numeric value or DMEM label.')
         if value < 0 or value > GPR_MAX:
             raise ValueError(
                 f'Cannot parse required constant {token}: {value} is out of '

--- a/hw/ip/acc/util/shared/control_flow.py
+++ b/hw/ip/acc/util/shared/control_flow.py
@@ -197,12 +197,14 @@ class ControlGraph:
         '''
         return self.get_entry(pc)[1]
 
-    def get_cycle_starts(self) -> Set[int]:
+    def get_cycle_starts(self, skip_loops=False) -> Set[int]:
         '''Returns start PCs of all marked cycles in the graph.'''
         out = set()
         for pc, entry in self.graph.items():
             for edge in entry[1]:
                 if isinstance(edge, Cycle):
+                    if skip_loops and isinstance(edge, LoopEnd):
+                        continue
                     out.add(edge.pc)
         return out
 

--- a/hw/ip/acc/util/shared/decode.py
+++ b/hw/ip/acc/util/shared/decode.py
@@ -19,9 +19,10 @@ except RuntimeError as err:
 
 
 class ACCProgram:
-    def __init__(self, symbols: Dict[str, int], insns: Dict[int, int],
-                 data: Dict[int, int]):
+    def __init__(self, symbols: Dict[str, int], symbol_sections: Dict[int, str],
+                 insns: Dict[int, int], data: Dict[int, int]):
         self.symbols = symbols  # label -> PC
+        self.symbol_sections = symbol_sections  # label -> name of section (e.g. ".data")
         self.data = data  # addr -> data (32b word)
 
         self.insns = {}
@@ -74,9 +75,9 @@ def decode_elf(path: str) -> ACCProgram:
 
     Returns the ACCProgram instance representing the program in the ELF file.
     '''
-    (imem_bytes, dmem_bytes, symbols) = read_elf(path)
+    (imem_bytes, dmem_bytes, symbols, symbol_sections) = read_elf(path)
 
     insns = _decode_mem(0, imem_bytes)
     data = _decode_mem(0, dmem_bytes)
 
-    return ACCProgram(symbols, insns, data)
+    return ACCProgram(symbols, symbol_sections, insns, data)

--- a/hw/ip/acc/util/shared/elf.py
+++ b/hw/ip/acc/util/shared/elf.py
@@ -130,7 +130,8 @@ def _get_symtab(elf_file: ELFFile) -> Optional[SymbolTableSection]:
 
 def read_elf(path: str) -> Tuple[bytes,
                                  bytes,
-                                 Dict[str, int]]:
+                                 Dict[str, int],
+                                 Dict[str, str]]:
     '''Load the ELF file at path.
 
     Returns a tuple (imem_bytes, dmem_bytes, exp_end_addr, loop_warps). The
@@ -149,10 +150,14 @@ def read_elf(path: str) -> Tuple[bytes,
                                                    imem_desc, dmem_desc)
         symtab = _get_symtab(elf_file)
         symbols = {}
+        symbol_sections = {}
         if symtab is not None:
             for sym in symtab.iter_symbols():
                 assert isinstance(sym['st_value'], int)
                 symbols[sym.name] = sym['st_value']
+                index = sym['st_shndx']
+                if isinstance(index, int):
+                    symbol_sections[sym.name] = elf_file.get_section(index).name
 
     assert len(imem_bytes) <= imem_desc[1]
     if len(imem_bytes) & 3:
@@ -160,4 +165,4 @@ def read_elf(path: str) -> Tuple[bytes,
                            'not a multiple of 4.'
                            .format(path, len(imem_bytes)))
 
-    return (imem_bytes, dmem_bytes, symbols)
+    return (imem_bytes, dmem_bytes, symbols, symbol_sections)

--- a/hw/ip/acc/util/shared/information_flow.py
+++ b/hw/ip/acc/util/shared/information_flow.py
@@ -12,12 +12,158 @@ from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
 from serialize.parse_helpers import check_keys, check_list, check_str
 
-from .operand import Operand, RegOperandType
+from .isr import Isr
+from .operand import ImmOperandType, IsrOperandType, Operand, RegOperandType
 
 FLAG_NAMES = ['c', 'm', 'l', 'z']
 
+# Deliberately invalid CSR address used by unimp.
+UNIMP_CSR_ADDR = 3072
+
 # Registers that can be involved in information flow without being an operand
 SPECIAL_REG_NAMES = ['mod', 'acc', 'acch', 'kmac_core', 'rnd', 'urnd']
+
+# ISRs that should have different information-flow node(s) than their name
+ISR_REMAPPING = {
+    'fg0': ['fg0-' + x for x in FLAG_NAMES],
+    'fg1': ['fg1-' + x for x in FLAG_NAMES],
+    'flags': ['fg0-' + x for x in FLAG_NAMES] + ['fg1-' + x for x in FLAG_NAMES],
+    'mod0': ['mod'],
+    'mod1': ['mod'],
+    'mod2': ['mod'],
+    'mod3': ['mod'],
+    'mod4': ['mod'],
+    'mod5': ['mod'],
+    'mod6': ['mod'],
+    'mod7': ['mod'],
+    'kmac_msg': ['kmac_core'],
+    'kmac_digest': ['kmac_core'],
+}
+
+
+class InformationFlowNode:
+    '''Represents a node in the information flow graph.
+
+    A node is anything that can hold information; it can be a register, flag, or
+    memory location.
+    '''
+    def __init__(self, name: str):
+        self.name = name
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, InformationFlowNode):
+            return False
+        return self.name == other.name
+
+    def overlaps(self, other: 'InformationFlowNode') -> bool:
+        '''Returns true if self and other refer to the same underlying location.'''
+        return self == other
+
+    def intersection(self, other: 'InformationFlowNode') -> Optional['InformationFlowNode']:
+        '''Returns a new node which is the intersection of the two nodes.
+
+        Returns None if the nodes do not overlap.
+        '''
+        if not self.overlaps(other):
+            return None
+        return InformationFlowNode(self.name)
+
+    def subtract(self, other: 'InformationFlowNode') -> List['InformationFlowNode']:
+        '''Returns a new node with the intersection of self and other removed.
+
+        Returns self if self and other do not overlap and None if they are equal.
+        '''
+        if not self.overlaps(other):
+            return [self]
+        return []
+
+    def union(self, other: 'InformationFlowNode') -> Optional['InformationFlowNode']:
+        '''Try to merge self and other.'''
+        if self.overlaps(other):
+            return self
+        return None
+
+    def pretty(self, dmem_symbols: Dict[str, int]) -> List[str]:
+        '''Pretty-print the node. May return multiple names.'''
+        return [self.name]
+
+    def __hash__(self) -> int:
+        return hash(self.name)
+
+
+class DmemInformationFlowNode(InformationFlowNode):
+    '''Represents a memory range.'''
+    def __init__(self, start: int, end: int):
+        super().__init__(f'dmem:{start:#06x}-{end:#06x}')
+        assert start < end
+        self.start = start
+        self.end = end
+
+    def overlaps(self, other: InformationFlowNode) -> bool:
+        if not isinstance(other, DmemInformationFlowNode):
+            return False
+        if self.start <= other.start and self.end > other.start:
+            return True
+        return other.start <= self.start and other.end > self.start
+
+    def intersection(self, other: InformationFlowNode) -> Optional[InformationFlowNode]:
+        if not isinstance(other, DmemInformationFlowNode) or not self.overlaps(other):
+            return None
+        start = max(self.start, other.start)
+        end = min(self.end, other.end)
+        return DmemInformationFlowNode(start, end)
+
+    def subtract(self, other: InformationFlowNode) -> List[InformationFlowNode]:
+        if not isinstance(other, DmemInformationFlowNode) or not self.overlaps(other):
+            return [self]
+        out: List[InformationFlowNode] = []
+        if self.start < other.start:
+            out.append(DmemInformationFlowNode(self.start, other.start))
+        if other.end < self.end:
+            out.append(DmemInformationFlowNode(other.end, self.end))
+        return out
+
+    def union(self, other: 'InformationFlowNode') -> Optional['InformationFlowNode']:
+        '''Try to merge self and other.'''
+        if not isinstance(other, DmemInformationFlowNode):
+            return None
+        if other.start <= self.start <= other.end:
+            return DmemInformationFlowNode(other.start, max(self.end, other.end))
+        elif self.start <= other.start <= self.end:
+            return DmemInformationFlowNode(self.start, max(other.end, self.end))
+        return None
+
+    def pretty(self, dmem_symbols: Dict[str, int] = {}) -> List[str]:
+        labels = [([k], v) for k, v in dmem_symbols.items() if self.start <= v < self.end]
+        if not labels:
+            return [self.name]
+        labels.sort(key=lambda x: x[1])
+        lengths = []
+        i = 0
+        while i < len(labels):
+            names, start = labels[i]
+            if i + 1 < len(labels):
+                end = labels[i + 1][1]
+                if end == start:
+                    names.extend(labels[i + 1][0])
+                    del labels[i + 1]
+                    continue
+            else:
+                end = self.end
+            lengths.append(end - start)
+            i += 1
+        result = []
+        for i in range(len(labels)):
+            names = labels[i][0]
+            assert len(names) > 0
+            if len(names) > 1:
+                label_str = '(' + ','.join(names) + ')'
+            else:
+                label_str = names[0]
+            result.append(f'{label_str}[:{lengths[i]}]')
+        if labels[0][1] != self.start:
+            result.insert(0, DmemInformationFlowNode(self.start, labels[0][1]).name)
+        return result
 
 
 class InformationFlowGraph:
@@ -33,12 +179,15 @@ class InformationFlowGraph:
     means the sink is overwritten with a constant value, and information is not
     flowing to it from any nodes (including its own previous value).
     '''
-    def __init__(self, flow: Dict[str, Set[str]], exists: bool = True):
+    def __init__(self, flow: Dict[InformationFlowNode, Set[InformationFlowNode]],
+                 exists: bool = True):
         self.flow = flow
 
         # Should not be modified directly. See the nonexistent() method
         # documentation for details of what this flag means.
         self.exists = exists
+
+        self.simplify()
 
     @staticmethod
     def empty() -> 'InformationFlowGraph':
@@ -72,41 +221,46 @@ class InformationFlowGraph:
         '''
         return InformationFlowGraph({}, False)
 
-    def sources(self, sink: str) -> Set[str]:
+    def sources(self, sink: InformationFlowNode) -> Set[InformationFlowNode]:
         '''Returns all sources for the given sink.'''
-        # if the sink does not appear, it is unmodified, meaning its only
-        # source is itself
-        return self.flow.get(sink, {sink})
+        overlapping = [s for s in self.flow if s.overlaps(sink)]
+        if len(overlapping) == 0:
+            # if the sink does not appear, it is unmodified, meaning its only
+            # source is itself
+            return {sink}
+        out = set()
+        for s in overlapping:
+            out |= self.flow[s]
+        return out
 
-    def sinks(self, source: str) -> Set[str]:
+    def sinks(self, source: str) -> Set[InformationFlowNode]:
         '''Returns all sinks for the given source.'''
         out = set()
         for sink in self.flow:
-            if source in self.flow[sink]:
+            if [s for s in self.flow[sink] if s.name == source]:
                 out.add(sink)
-        if source not in self.flow:
+        if [s for s in self.flow if s.name == source]:
             # Implicitly, the source is unmodified and depends on itself
-            out.add(source)
+            out.add(InformationFlowNode(source))
         return out
 
-    def all_sources(self) -> Set[str]:
+    def all_sources(self) -> Set[InformationFlowNode]:
         '''Returns all sources in the graph.'''
-        out: Set[str] = set()
+        out: Set[InformationFlowNode] = set()
         return out.union(*self.flow.values())
 
-    def all_sinks(self) -> Set[str]:
+    def all_sinks(self) -> Set[InformationFlowNode]:
         '''Returns all sinks in the graph.'''
         return set(self.flow.keys())
 
-    def sources_for_any(self, sinks: Iterable[str]) -> Set[str]:
-        '''Returns all nodes that are a source for any of the given sinks.'''
-        out: Set[str] = set()
-        return out.union(*(self.sources(s) for s in sinks))
+    def sources_for_any(self, sinks: Iterable[str]) -> Set[InformationFlowNode]:
+        '''Returns all nodes that are a source for any of the given sinks.
 
-    def sinks_for_any(self, sinks: Iterable[str]) -> Set[str]:
-        '''Returns all nodes that are a sink for any of the given sources.'''
-        out: Set[str] = set()
-        return out.union(*(self.sinks(s) for s in sinks))
+        Important: this does not handle partial overlap of e.g. DMEM ranges! It
+        only returns sources for the sinks exactly.
+        '''
+        out: Set[InformationFlowNode] = set()
+        return out.union(*(self.sources(InformationFlowNode(s)) for s in sinks))
 
     def remove_source(self, node: str) -> None:
         '''Removes the node from the graph anywhere it appears as a source.
@@ -114,14 +268,40 @@ class InformationFlowGraph:
         If the node is not a source in the graph, does nothing.
         '''
         for sources in self.flow.values():
-            sources.discard(node)
+            for src in sources:
+                if src.name == node:
+                    sources.discard(src)
+                    break
 
     def remove_sink(self, node: str) -> None:
         '''Removes the node from the graph anywhere it appears as a sink.
 
         If the node is not a sink in the graph, does nothing.
         '''
-        self.flow.pop(node, None)
+        sink_nodes = [n for n in self.flow if n.name == node]
+        assert len(sink_nodes) <= 1
+        if sink_nodes:
+            self.flow.pop(sink_nodes[0], None)
+
+    def simplify(self) -> None:
+        '''Merge adjacent nodes in the graph (e.g. DMEM ranges).'''
+        for sink in self.flow.keys():
+            sources = list(self.flow[sink])
+            i = 0
+            while i < len(sources):
+                node1 = sources[i]
+                j = i + 1
+                while j < len(sources):
+                    node2 = sources[j]
+                    node12 = node1.union(node2)
+                    if node12 is not None:
+                        node1 = node12
+                        del sources[j]
+                    else:
+                        j += 1
+                sources[i] = node1
+                i += 1
+            self.flow[sink] = set(sources)
 
     def update(self, other: 'InformationFlowGraph') -> None:
         '''Updates self to include the information flow from other.
@@ -132,6 +312,12 @@ class InformationFlowGraph:
         union of their sources in the graph in which they appear and themselves
         (because a sink not appearing in a graph implicitly means the value is
         unchanged).
+
+        Sinks that overlap but are not equal will be split into up to 3 entries:
+        the overlapping portion and the portions covered by only one of the
+        sinks. The overlapping portion will depend on the union of the two
+        sources, while the non-overlapping portions will depend on the same
+        sources they did in self/other.
 
         Important note: updating with an empty graph will not be a no-op. An
         empty graph implies everything remains unmodified, so combining an
@@ -154,14 +340,56 @@ class InformationFlowGraph:
             self.exists = other.exists
             return
 
-        for sink, sources in other.flow.items():
-            if sink not in self.flow:
+        for sink1, sources1 in other.flow.items():
+            overlapping = [s for s in self.flow if s.overlaps(sink1)]
+            if not overlapping:
                 # implicitly, a non-updated value depends only on itself (NOT
                 # an empty set, which would indicate a value that is
                 # overwritten with a constant)
-                self.flow[sink] = {sink}
-            self.flow[sink].update(sources)
+                self.flow[sink1] = {sink1} | sources1
 
+            for sink2 in overlapping:
+                if sink1 == sink2:
+                    self.flow[sink1].update(sources1)
+                    continue
+                sources2 = self.flow[sink2]
+                self.flow.pop(sink2, None)
+                rem1 = sink1.subtract(sink2)
+                rem2 = sink2.subtract(sink1)
+                inter = sink1.intersection(sink2)
+                for node in rem1:
+                    self.flow[node] = deepcopy(sources1)
+                for node in rem2:
+                    self.flow[node] = deepcopy(sources2)
+                if inter is not None:
+                    self.flow[inter] = sources1 | sources2
+
+        self.simplify()
+
+        return
+
+    def combine(self, other: 'InformationFlowGraph') -> None:
+        '''Updates self to incorporate information flow from other.
+
+        The difference between combine() and update() is subtle and only
+        affects nodes that are sinks in one graph but not the other. In update(),
+        these nodes depend implicitly on themselves. In combine(), the graph
+        that mentions them takes precedence and if it indicates an overwrite,
+        then an overwrite will be present in the result.
+
+        In practical terms, the idea of update() is that self and other
+        represent two possible paths with different information flows that need
+        to be merged. The idea of combine() is that self and other are parts of
+        the same information flow dictionary.
+
+        Does not modify other.
+        '''
+        for sink1, sources1 in other.flow.items():
+            overlapping = [s for s in self.flow if s.overlaps(sink1)]
+            if not overlapping:
+                self.flow[sink1] = set()
+
+        self.update(other)
         return
 
     def seq(self, other: 'InformationFlowGraph') -> 'InformationFlowGraph':
@@ -193,8 +421,11 @@ class InformationFlowGraph:
         for sink, sources in other.flow.items():
             new_sources = set()
             for source in sources:
-                if source in self.flow:
-                    new_sources.update(self.flow[source])
+                overlapping = [s for s in self.flow if s.overlaps(source)]
+                if overlapping:
+                    for node in overlapping:
+                        # connect sink and source even for partial overlap
+                        new_sources.update(self.flow[node])
                 else:
                     # source is not a sink in self's flow; assume it stays
                     # constant
@@ -202,7 +433,16 @@ class InformationFlowGraph:
             flow[sink] = new_sources
 
         for sink, sources in self.flow.items():
-            if sink not in flow:
+            overlapping = [s for s in flow if s.overlaps(sink)]
+            if overlapping:
+                # if one of our original sinks partly overlaps with a new sink
+                # (partial overwrite), we should propagate only the
+                # non-overlapping part.
+                for node in overlapping:
+                    rem = sink.subtract(node)
+                    for n in rem:
+                        flow[n] = sources.copy()
+            else:
                 # sink is not updated in other's flow
                 flow[sink] = sources.copy()
 
@@ -297,20 +537,20 @@ class InformationFlowGraph:
         flag_groups = set()
         wregs = []
         xregs = []
-        for sink in sorted(self.flow.keys()):
-            if sink == 'dmem' or sink == 'x1':
+        for sink in self.flow:
+            if sink.name == 'x1':
                 # Not real registers or flags, ignore
                 continue
-            elif sink.startswith('w') and sink[1:].isdigit():
-                wregs.append(int(sink[1:]))
-            elif sink.startswith('x') and sink[1:].isdigit():
-                xregs.append(int(sink[1:]))
-            elif sink.startswith('fg0'):
+            elif sink.name.startswith('w') and sink.name[1:].isdigit():
+                wregs.append(int(sink.name[1:]))
+            elif sink.name.startswith('x') and sink.name[1:].isdigit():
+                xregs.append(int(sink.name[1:]))
+            elif sink.name.startswith('fg0'):
                 flag_groups.add('FG0')
-            elif sink.startswith('fg1'):
+            elif sink.name.startswith('fg1'):
                 flag_groups.add('FG1')
             else:
-                special.append(sink)
+                special.append(sink.name)
 
         # Combine the ranges.
         w_ranges = _combine_ranges(sorted(wregs))
@@ -325,24 +565,24 @@ class InformationFlowGraph:
         flags_line = '* clobbered flag groups: ' + flags_str
         return regs_line + '\n' + flags_line
 
-    def pretty(self, indent: int = 0) -> str:
+    def pretty(self, indent: int = 0, dmem_symbols: Dict[str, int] = {}) -> str:
         '''Return a human-readable representation of the graph.'''
-        if not self.exists:
-            return 'Nonexistent information-flow graph (no possible paths).'
-
         prefix = ' ' * indent
-        flow_strings = {
-            sink: ','.join(sorted(sources))
-            for sink, sources in self.flow.items()
-        }
-        max_source_chars = max([len(s) for s in flow_strings.values()],
-                               default=0)
+        if not self.exists:
+            return prefix + 'Nonexistent information-flow graph (no possible paths).'
+
+        flow_strings = {}
+        for sink in self.flow:
+            for sink_name in sink.pretty(dmem_symbols):
+                assert sink_name not in flow_strings
+                flow_strings[sink_name] = [x for s in self.flow[sink]
+                                           for x in s.pretty(dmem_symbols)]
+        max_sink_chars = max([len(s) for s in flow_strings.keys()], default=0)
         lines = []
-        for sink in sorted(self.flow.keys()):
-            sources_str = flow_strings[sink]
-            padding = ' ' * (max_source_chars - len(sources_str))
-            lines.append('{}{}{} -> {}'.format(prefix, sources_str, padding,
-                                               sink))
+        for sink_str in sorted(flow_strings.keys()):
+            sources_str = ', '.join(sorted(flow_strings[sink_str]))
+            padding = ' ' * (max_sink_chars - len(sink_str))
+            lines.append('{}{}{} <- {}'.format(prefix, sink_str, padding, sources_str))
         return '\n'.join(lines)
 
     def __eq__(self, other: object) -> bool:
@@ -359,17 +599,26 @@ class InformationFlowGraph:
 class InsnInformationFlowNode:
     '''Represents an information flow node whose value may depend on operands.
     '''
-    def required_constants(self, op_vals: Dict[str, int]) -> Set[str]:
+    def required_constants(self, op_vals: Dict[str, int],
+                           coarse_dmem: bool) -> Set[str]:
         '''Returns the names of regs that must be constant for `evaluate()`.
 
         For instance, for an indirect reference of a WDR via a GPR, the GPR's
         value must be constant for the node to be evaluated. Subclasses that
         require constants override this method.
+
+        When `coarse_dmem` is true, treat DMEM as a single information-flow
+        node rather than tracking values more precisely; in this case, for
+        example, addresses of DMEM loads would not be required constants.
         '''
         return set()
 
+    def is_read_only(self, op_vals: Dict[str, int]) -> bool:
+        return False
+
     def evaluate(self, op_vals: Dict[str, int],
-                 constant_regs: Dict[str, int]) -> str:
+                 constant_regs: Dict[str, int],
+                 coarse_dmem: bool) -> List[InformationFlowNode]:
         '''Determines information flow graph for the instruction.
 
         Evaluates the information-flow node according to the given operand
@@ -391,23 +640,121 @@ class InsnRegOperandNode(InsnInformationFlowNode):
         self.op = op
         self.is_wide = op.op_type.reg_type == 'wdr'
 
+    def _get_reg_name(self, op_vals: Dict[str, int]) -> str:
+        return self.op.op_type.op_val_to_str(op_vals[self.op.name], None)
+
+    def is_read_only(self, op_vals: Dict[str, int]) -> bool:
+        # x0 is the only read-only register
+        return self._get_reg_name(op_vals) == 'x0'
+
     def evaluate(self, op_vals: Dict[str, int],
-                 constant_regs: Dict[str, int]) -> str:
+                 constant_regs: Dict[str, int],
+                 coarse_dmem: bool) -> List[InformationFlowNode]:
         if self.op.name not in op_vals:
             raise ValueError(
                 'Operand {} not found in provided operand values: {}'.format(
                     self.op.name, op_vals.keys()))
-        return self.op.op_type.op_val_to_str(op_vals[self.op.name], None)
+        return [InformationFlowNode(self._get_reg_name(op_vals))]
 
 
-def _eval_indirect_wdr(gpr: str, constant_regs: Dict[str, int]) -> str:
+class InsnIsrOperandNode(InsnInformationFlowNode):
+    '''Represents an ISR operand for an instruction.'''
+    def __init__(self, op: Operand):
+        if not isinstance(op.op_type, IsrOperandType):
+            raise ValueError(
+                'Attempt to construct a register-operand information flow '
+                'node from a non-register operand {} of type {}'.format(
+                    op.name, op.op_type))
+        self.op = op
+
+    def _get_isr(self, op_vals: Dict[str, int]) -> Optional[Isr]:
+        addr = op_vals[self.op.name]
+        if addr == UNIMP_CSR_ADDR:
+            return None
+        return self.op.op_type.isrs.addr_to_isr[addr]  # type: ignore
+
+    def is_read_only(self, op_vals: Dict[str, int]) -> bool:
+        isr = self._get_isr(op_vals)
+        if isr is None:
+            return True
+        return isr.read_only
+
+    def evaluate(self, op_vals: Dict[str, int],
+                 constant_regs: Dict[str, int],
+                 coarse_dmem: bool) -> List[InformationFlowNode]:
+        if self.op.name not in op_vals:
+            raise ValueError(
+                'Operand {} not found in provided operand values: {}'.format(
+                    self.op.name, op_vals.keys()))
+        isr = self._get_isr(op_vals)
+        if isr is None:
+            return []
+        if isr.name in ISR_REMAPPING:
+            return [InformationFlowNode(name) for name in ISR_REMAPPING[isr.name]]
+        return [InformationFlowNode(isr.name)]
+
+
+class InsnDmemOperandNode(InsnInformationFlowNode):
+    '''Represents a specific dmem range for an instruction.
+
+    The dmem location consists of a GPR operand and an offset.
+    '''
+    def __init__(self, addr_op: Operand, offset_op: Operand, width: int):
+        if not isinstance(addr_op.op_type, RegOperandType):
+            raise ValueError(
+                'Attempt to construct a dmem information flow node from a '
+                'non-register address operand {} of type {}'.format(
+                    addr_op.name, addr_op.op_type))
+        if not isinstance(offset_op.op_type, ImmOperandType):
+            raise ValueError(
+                'Attempt to construct a dmem information flow node from a '
+                'non-immediate offset operand {} of type {}'.format(
+                    offset_op.name, offset_op.op_type))
+        self.addr_op = addr_op
+        self.offset_op = offset_op
+        self.width = width
+
+    def required_constants(self, op_vals: Dict[str, int], coarse_dmem: bool) -> Set[str]:
+        if coarse_dmem:
+            return set()
+        addr_reg_val = op_vals[self.addr_op.name]
+        addr_reg_name = self.addr_op.op_type.op_val_to_str(addr_reg_val, None)
+        return set([addr_reg_name])
+
+    def evaluate(self, op_vals: Dict[str, int],
+                 constant_regs: Dict[str, int],
+                 coarse_dmem: bool) -> List[InformationFlowNode]:
+        if coarse_dmem:
+            return [InformationFlowNode('dmem')]
+        if self.addr_op.name not in op_vals:
+            raise ValueError(
+                'Operand {} not found in provided operand values: {}'.format(
+                    self.addr_op.name, op_vals.keys()))
+        if self.offset_op.name not in op_vals:
+            raise ValueError(
+                'Operand {} not found in provided operand values: {}'.format(
+                    self.offset_op.name, op_vals.keys()))
+        addr_reg_val = op_vals[self.addr_op.name]
+        addr_reg_name = self.addr_op.op_type.op_val_to_str(addr_reg_val, None)
+        if addr_reg_name not in constant_regs:
+            raise RuntimeError(
+                'Cannot analyze information flow; cannot determine which '
+                'DMEM region is referenced by non-constant GPR {} (constant '
+                'regs are: {})'.format(addr_reg_name, constant_regs.keys()))
+        addr = constant_regs[addr_reg_name]
+        offset = op_vals[self.offset_op.name]
+        return [DmemInformationFlowNode(addr + offset, addr + offset + self.width)]
+
+
+def _eval_indirect_wdr(gpr: str, constant_regs: Dict[str, int]) -> InformationFlowNode:
     if gpr not in constant_regs:
         raise RuntimeError(
             'Cannot analyze information flow; cannot determine which '
             'WDR is referenced by non-constant GPR {} (constant regs '
             'are: {})'.format(gpr, constant_regs.keys()))
     wdr_idx = constant_regs[gpr]
-    return 'w{}'.format(wdr_idx)
+    wdr_name = 'w{}'.format(wdr_idx)
+    return InformationFlowNode(wdr_name)
 
 
 class InsnIndirectWDRNode(InsnInformationFlowNode):
@@ -432,13 +779,14 @@ class InsnIndirectWDRNode(InsnInformationFlowNode):
                     self.op.name, op_vals.keys()))
         return self.op.op_type.op_val_to_str(op_vals[self.op.name], None)
 
-    def required_constants(self, op_vals: Dict[str, int]) -> Set[str]:
+    def required_constants(self, op_vals: Dict[str, int], coarse_dmem: bool) -> Set[str]:
         return {self._get_gpr_name(op_vals)}
 
     def evaluate(self, op_vals: Dict[str, int],
-                 constant_regs: Dict[str, int]) -> str:
+                 constant_regs: Dict[str, int],
+                 coarse_dmem: bool) -> List[InformationFlowNode]:
         gpr = self._get_gpr_name(op_vals)
-        return _eval_indirect_wdr(gpr, constant_regs)
+        return [_eval_indirect_wdr(gpr, constant_regs)]
 
 
 class InsnGroupFlagNode(InsnInformationFlowNode):
@@ -453,23 +801,26 @@ class InsnGroupFlagNode(InsnInformationFlowNode):
         self.constant_dependent = False
 
     def evaluate(self, op_vals: Dict[str, int],
-                 constant_regs: Dict[str, int]) -> str:
+                 constant_regs: Dict[str, int],
+                 coarse_dmem: bool) -> List[InformationFlowNode]:
         if 'flag_group' not in op_vals:
             raise ValueError(
                 'Operand flag_group not found in provided operand values: {}'.
                 format(op_vals.keys()))
-        return 'fg{}-{}'.format(op_vals['flag_group'], self.flag)
+        flag_name = 'fg{}-{}'.format(op_vals['flag_group'], self.flag)
+        return [InformationFlowNode(flag_name)]
 
 
 class InsnConstantNode(InsnInformationFlowNode):
     '''Represents instruction node whose value does not depend on operands.'''
-    def __init__(self, node: str):
-        self.node = node
+    def __init__(self, name: str):
+        self.name = name
         self.constant_dependent = False
 
     def evaluate(self, op_vals: Dict[str, int],
-                 constant_regs: Dict[str, int]) -> str:
-        return self.node
+                 constant_regs: Dict[str, int],
+                 coarse_dmem: bool) -> List[InformationFlowNode]:
+        return [InformationFlowNode(self.name)]
 
 
 def _parse_iflow_nodes(
@@ -482,7 +833,10 @@ def _parse_iflow_nodes(
     - "wref-<reg operand name>" for instructions where a WDR is indirectly
       accessed via a GPR; in this case <reg operand name> is the GPR and must
       be in the operands list
-    - one of the special strings "dmem", "acc", or "mod"
+    - "dmem-<reg operand name>-<width>" for instructions where memory is
+      accessed via a GPR; in this case there must also be an immediate operand
+      called "offset" and <width> is the size of the access in bytes.
+    - one of the special strings "acch", "acc", or "mod"
     - a flag (represented as "<flag group>-<flag>", where <flag group> can
       be either "fg0", "fg1", or (if the instruction has a flag_group
       operand) simply "flags" to select the current flag group, and <flag>
@@ -495,6 +849,8 @@ def _parse_iflow_nodes(
     # Check if node is a register operand
     for op in operands:
         if node == op.name:
+            if isinstance(op.op_type, IsrOperandType):
+                return [InsnIsrOperandNode(op)]
             if not isinstance(op.op_type, RegOperandType):
                 raise RuntimeError(
                     'Information-flow node {} matches operand name, but '
@@ -520,8 +876,40 @@ def _parse_iflow_nodes(
             'indirect reference {}. Operand names: {}'.format(
                 gpr, node, ', '.join([op.name for op in operands])))
 
-    # Check if node is a special string
-    if node == 'dmem' or node in SPECIAL_REG_NAMES:
+    # Check if node is a DMEM reference.
+    if node.startswith('dmem-'):
+        fields = node.split('-')
+        if len(fields) != 3:
+            raise RuntimeError(
+                'Invalid dmem information-flow reference format: {}'.format(node))
+        _, gpr, width = fields
+        if not width.isnumeric():
+            raise RuntimeError(
+                'Invalid dmem write width {} in information-flow reference: {}'
+                .format(width, node))
+        width = int(width)  # type: ignore
+        offset = None
+        for op in operands:
+            if op.name == 'offset' and isinstance(op.op_type, ImmOperandType):
+                offset = op
+        if offset is None:
+            raise RuntimeError(
+                'No offset operand found for DMEM reference: {}'
+                .format(node))
+        for op in operands:
+            if gpr == op.name:
+                if not (isinstance(op.op_type, RegOperandType) and
+                        op.op_type.reg_type == 'gpr'):
+                    raise RuntimeError(
+                        'Operand {} in memory reference {} is not a GPR '
+                        '(type {}). Only GPRs can be memory references.'.
+                        format(gpr, node, type(op.op_type)))
+                return [InsnDmemOperandNode(op, offset, width)]  # type: ignore
+
+    # Check if node is a special string, indicating a special register that can
+    # be involved in an instruction's information flow *without* being one of
+    # the operands.
+    if node in SPECIAL_REG_NAMES:
         return [InsnConstantNode(node)]
 
     # Try to interpret node as a flag or set of flags
@@ -661,34 +1049,39 @@ class InsnInformationFlowRule:
         self.flows_from = flows_from
         self.test = test
 
-    def required_constants(self, op_vals: Dict[str, int]) -> Set[str]:
+    def required_constants(self, op_vals: Dict[str, int], coarse_dmem: bool) -> Set[str]:
         '''Returns the names of regs that must be constant for `evaluate()`.'''
         if not self.test.check(op_vals):
             # Rule is not triggered
             return set()
         out = set()
         for node in self.flows_to:
-            out.update(node.required_constants(op_vals))
+            out.update(node.required_constants(op_vals, coarse_dmem))
         for node in self.flows_from:
-            out.update(node.required_constants(op_vals))
+            out.update(node.required_constants(op_vals, coarse_dmem))
         return out
 
     def evaluate(self, op_vals: Dict[str, int],
-                 constant_regs: Dict[str, int]) -> InformationFlowGraph:
+                 constant_regs: Dict[str, int],
+                 coarse_dmem: bool) -> InformationFlowGraph:
         if not self.test.check(op_vals):
             # Rule is not triggered
             return InformationFlowGraph.nonexistent()
         sources = set()
-        for node in self.flows_from:
-            sources.add(node.evaluate(op_vals, constant_regs))
+        for insn_node in self.flows_from:
+            for node in insn_node.evaluate(op_vals, constant_regs, coarse_dmem):
+                sources.add(node)
         flow = {}
-        for node in self.flows_to:
-            dest = node.evaluate(op_vals, constant_regs)
-            if dest in ['x0']:
-                # No information will actually flow to this node, because it is
-                # not writeable; skip.
-                continue
-            flow[dest] = sources.copy()
+        for insn_node in self.flows_to:
+            for node in insn_node.evaluate(op_vals, constant_regs, coarse_dmem):
+                if not insn_node.is_read_only(op_vals):
+                    assert node not in flow
+                    flow[node] = sources.copy()
+            if coarse_dmem and isinstance(insn_node, InsnDmemOperandNode):
+                # if we are doing coarse dmem tracking, then the single "dmem"
+                # node should not get overwritten by writes; it should always
+                # inherit its own previous value as well.
+                flow[node].add(node)
         return InformationFlowGraph(flow)
 
     @staticmethod
@@ -729,20 +1122,21 @@ class InsnInformationFlow:
     def __init__(self, rules: List[InsnInformationFlowRule]) -> None:
         self.rules = rules
 
-    def required_constants(self, op_vals: Dict[str, int]) -> Set[str]:
+    def required_constants(self, op_vals: Dict[str, int], coarse_dmem: bool) -> Set[str]:
         '''Returns the names of regs that must be constant for `evaluate()`.'''
         return {
             const
             for rule in self.rules
-            for const in rule.required_constants(op_vals)
+            for const in rule.required_constants(op_vals, coarse_dmem)
         }
 
     def evaluate(self, op_vals: Dict[str, int],
-                 constant_regs: Dict[str, int]) -> InformationFlowGraph:
+                 constant_regs: Dict[str, int],
+                 coarse_dmem: bool) -> InformationFlowGraph:
         graph = InformationFlowGraph.nonexistent()
         for rule in self.rules:
-            rule_graph = rule.evaluate(op_vals, constant_regs)
-            graph.update(rule_graph)
+            rule_graph = rule.evaluate(op_vals, constant_regs, coarse_dmem)
+            graph.combine(rule_graph)
 
         return graph
 

--- a/hw/ip/acc/util/shared/information_flow_analysis.py
+++ b/hw/ip/acc/util/shared/information_flow_analysis.py
@@ -13,7 +13,10 @@ from .constants import ConstantContext, get_op_val_str
 from .control_flow import (ControlLoc, ControlGraph, Cycle, Ecall, ImemEnd,
                            LoopStart, Ret)
 from .decode import ACCProgram
-from .information_flow import InformationFlowGraph, SPECIAL_REG_NAMES
+from .information_flow import (InformationFlowGraph,
+                               InformationFlowNode,
+                               DmemInformationFlowNode,
+                               SPECIAL_REG_NAMES)
 from .insn_yaml import Insn
 
 # Calls to _get_iflow return results in the form of a tuple with entries:
@@ -42,7 +45,7 @@ from .insn_yaml import Insn
 #                   and whose values are those exact number of iterations
 IFlowResult = Tuple[Set[str], InformationFlowGraph, InformationFlowGraph,
                     Optional[ConstantContext], Dict[int, InformationFlowGraph],
-                    Dict[str, Set[int]], Dict[int, Set[int]]]
+                    Dict[InformationFlowNode, Set[int]], Dict[int, Set[int]]]
 
 
 class IFlowCacheEntry(CacheEntry[ConstantContext, IFlowResult]):
@@ -74,17 +77,17 @@ class IFlowCache(Cache[int, ConstantContext, IFlowResult]):
 # are a subset of the IFlowResult tuple entries; in particular, it has the form
 # (return iflow, end iflow, control deps).
 SubroutineIFlow = Tuple[InformationFlowGraph, InformationFlowGraph,
-                        Dict[str, Set[int]]]
+                        Dict[InformationFlowNode, Set[int]]]
 
 # The information flow of a full program is the same as for a subroutine,
 # except with no "return" information flow. Since the call stack is empty
 # at the start, we're not expecting any return paths!
-ProgramIFlow = Tuple[InformationFlowGraph, Dict[str, Set[int]]]
+ProgramIFlow = Tuple[InformationFlowGraph, Dict[InformationFlowNode, Set[int]]]
 
 
 def _build_iflow_insn(
         insn: Insn, op_vals: Dict[str, int], pc: int,
-        constants: ConstantContext) -> Tuple[Set[str], InformationFlowGraph]:
+        constants: ConstantContext, coarse_dmem: bool) -> Tuple[Set[str], InformationFlowGraph]:
     '''Constructs the information-flow graph for a single instruction.
 
     Raises a ValueError if the information-flow graph cannot be constructed
@@ -96,7 +99,7 @@ def _build_iflow_insn(
     be unchanged.
     '''
     # Check that the required-constant registers are constant here
-    constant_deps = insn.iflow.required_constants(op_vals)
+    constant_deps = insn.iflow.required_constants(op_vals, coarse_dmem)
     for const in constant_deps:
         if const not in constants:
             raise ValueError(
@@ -110,10 +113,10 @@ def _build_iflow_insn(
                                        insn.disassemble(pc, op_vals),
                                        list(constants.values.keys())))
 
-    return constant_deps, insn.iflow.evaluate(op_vals, constants.values)
+    return constant_deps, insn.iflow.evaluate(op_vals, constants.values, coarse_dmem)
 
 
-def _get_insn_control_deps(insn: Insn, op_vals: Dict[str, int]) -> Set[str]:
+def _get_insn_control_deps(insn: Insn, op_vals: Dict[str, int]) -> Set[InformationFlowNode]:
     '''Returns names of regs that influence control flow for instruction.
 
     The x1 (call stack) special register is not returned if it's used as the
@@ -125,17 +128,17 @@ def _get_insn_control_deps(insn: Insn, op_vals: Dict[str, int]) -> Set[str]:
         # both compared values influence control flow
         grs1_name = get_op_val_str(insn, op_vals, 'grs1')
         grs2_name = get_op_val_str(insn, op_vals, 'grs2')
-        return {grs1_name, grs2_name}
+        return {InformationFlowNode(grs1_name), InformationFlowNode(grs2_name)}
     elif insn.mnemonic == 'jalr':
         if op_vals['grs1'] == 1:
             return set()
         # jump destination register influences control flow
         grs1_name = get_op_val_str(insn, op_vals, 'grs1')
-        return {grs1_name}
+        return {InformationFlowNode(grs1_name)}
     elif insn.mnemonic == 'loop':
         # loop #iterations influences control flow
         grs_name = get_op_val_str(insn, op_vals, 'grs')
-        return {grs_name}
+        return {InformationFlowNode(grs_name)}
     elif insn.mnemonic in ['ecall', 'jal', 'loopi']:
         # these all rely only on immediates
         return set()
@@ -146,7 +149,7 @@ def _get_insn_control_deps(insn: Insn, op_vals: Dict[str, int]) -> Set[str]:
 
 def _build_iflow_straightline(
         program: ACCProgram, start_pc: int, end_pc: int,
-        constants: ConstantContext) -> Tuple[Set[str], InformationFlowGraph]:
+        constants: ConstantContext, coarse_dmem: bool) -> Tuple[Set[str], InformationFlowGraph]:
     '''Constructs the information-flow graph for a straightline code section.
 
     Returns two values:
@@ -167,8 +170,9 @@ def _build_iflow_straightline(
         assert insn.straight_line
 
         used_constants, insn_iflow = _build_iflow_insn(insn, op_vals, pc,
-                                                       constants)
-        constant_deps.update(iflow.sources_for_any(used_constants))
+                                                       constants, coarse_dmem)
+        constant_dep_nodes = iflow.sources_for_any(used_constants)
+        constant_deps.update([n.name for n in constant_dep_nodes])
 
         # Compose iflow with the information flow from this instruction
         iflow = iflow.seq(insn_iflow)
@@ -211,9 +215,9 @@ def _get_iflow_cache_update(pc: int, constants: ConstantContext,
     return
 
 
-def _update_control_deps(current_deps: Dict[str, Set[int]],
+def _update_control_deps(current_deps: Dict[InformationFlowNode, Set[int]],
                          iflow: InformationFlowGraph,
-                         new_deps: Dict[str, Set[int]]) -> None:
+                         new_deps: Dict[InformationFlowNode, Set[int]]) -> None:
     '''Update control-flow dependencies to include new data.
 
     The `current_deps` and `new_deps` dictionaries are assumed to hold
@@ -237,7 +241,7 @@ def _get_iflow_update_state(
         rec_result: IFlowResult, iflow: InformationFlowGraph,
         program_end_iflow: InformationFlowGraph, used_constants: Set[str],
         constants: ConstantContext, cycles: Dict[int, InformationFlowGraph],
-        control_deps: Dict[str, Set[int]],
+        control_deps: Dict[InformationFlowNode, Set[int]],
         loop_iters: Dict[int, Set[int]]) -> InformationFlowGraph:
     '''Update the internal state of _get_iflow after a recursive call.
 
@@ -261,7 +265,8 @@ def _get_iflow_update_state(
     rec_loop_iters = rec_result[6]
 
     # Update the used constants and control-flow dependencies
-    used_constants.update(iflow.sources_for_any(rec_used_constants))
+    used_constant_nodes = iflow.sources_for_any(rec_used_constants)
+    used_constants.update([n.name for n in used_constant_nodes])
     _update_control_deps(control_deps, iflow, rec_control_deps)
 
     # Update the cycles
@@ -278,7 +283,7 @@ def _get_iflow_update_state(
 
     # Update the constants to keep only those that are either unmodified in the
     # return-path information flow or returned by the recursive call.
-    constants.removemany(rec_return_iflow.all_sinks())
+    constants.removemany([n.name for n in rec_return_iflow.all_sinks()])
     if rec_constants is not None:
         constants.values.update(rec_constants.values)
 
@@ -288,9 +293,28 @@ def _get_iflow_update_state(
     return iflow.seq(rec_return_iflow)
 
 
+def simplify_control_deps(
+        control_deps: Dict[InformationFlowNode, Set[int]]) -> Dict[InformationFlowNode, Set[int]]:
+    '''Combine adjacent control-flow dependencies.'''
+    new_control_deps = {}
+    keys = list(control_deps.keys())
+    for i in range(len(keys)):
+        node1 = keys[i]
+        deps1 = control_deps[node1]
+        for node2 in keys[i + 1:]:
+            if deps1 != control_deps[node2] or node1.union(node2) is None:
+                continue
+            node1 = node1.union(node2)
+            if node1 in control_deps:
+                # This happens if the union already existed in the dictionary.
+                deps1 |= control_deps[node1]
+        new_control_deps[node1] = deps1
+    return new_control_deps
+
+
 def _get_iflow(program: ACCProgram, graph: ControlGraph, start_pc: int,
                start_constants: ConstantContext, loop_end_pc: Optional[int],
-               cache: IFlowCache) -> IFlowResult:
+               cache: IFlowCache, coarse_dmem: bool) -> IFlowResult:
     '''Gets the information-flow graphs for paths starting at start_pc.
 
     Returns None for the return and/or end iflow if there are no paths ending
@@ -321,7 +345,7 @@ def _get_iflow(program: ACCProgram, graph: ControlGraph, start_pc: int,
 
     # The control-flow nodes whose values at the start PC influence control
     # flow (and the PCs of the control-flow instructions they influence)
-    control_deps: Dict[str, Set[int]] = {}
+    control_deps: Dict[InformationFlowNode, Set[int]] = {}
 
     # Cycle starts that are accessible from this PC.
     cycles: Dict[int, InformationFlowGraph] = {}
@@ -329,14 +353,14 @@ def _get_iflow(program: ACCProgram, graph: ControlGraph, start_pc: int,
     # Possible loop iteration counts for loops accessible from this PC.
     loop_iters: Dict[int, Set[int]] = {}
 
-    # If this PC is the start of a cycle, then initialize the information flow
-    # for the cycle with an empty graph (since doing nothing is a valid
-    # traversal of the cycle).
-    if start_pc in graph.get_cycle_starts():
-        cycles[start_pc] = InformationFlowGraph.empty()
-
     section = graph.get_section(start_pc)
     edges = graph.get_edges(start_pc)
+
+    # If this PC is the start of a cycle, then initialize the information flow
+    # for the cycle with an empty graph (since doing nothing is a valid
+    # traversal of the cycle). Ensure we do not do this for loops.
+    if start_pc in graph.get_cycle_starts(skip_loops=True):
+        cycles[start_pc] = InformationFlowGraph.empty()
 
     # If we're crossing the loop end PC, we must do so at the end of the
     # section. In this case, we do not pass the end of the loop; we treat the
@@ -350,7 +374,7 @@ def _get_iflow(program: ACCProgram, graph: ControlGraph, start_pc: int,
     # _build_iflow_straightline updates the `constants` dictionary in-place.
     used_constants, iflow = _build_iflow_straightline(program, section.start,
                                                       section.end - 4,
-                                                      constants)
+                                                      constants, coarse_dmem)
 
     # Get the instruction/operands at the very end of the block (i.e. the
     # control-flow instruction) for special handling
@@ -358,11 +382,13 @@ def _get_iflow(program: ACCProgram, graph: ControlGraph, start_pc: int,
     last_op_vals = program.get_operands(section.end)
 
     last_insn_used_constants, last_insn_iflow = _build_iflow_insn(
-        last_insn, last_op_vals, section.end, constants)
+        last_insn, last_op_vals, section.end, constants, coarse_dmem)
 
     # Update used constants to include last instruction
-    used_constants.update(
-        last_insn_iflow.sources_for_any(last_insn_used_constants))
+    used_constant_nodes = iflow.sources_for_any(last_insn_used_constants)
+    used_constants.update([n.name for n in used_constant_nodes])
+
+    assert all([x in start_constants for x in used_constants])
 
     # Update control_deps to include last instruction
     last_insn_control_deps = {
@@ -396,7 +422,7 @@ def _get_iflow(program: ACCProgram, graph: ControlGraph, start_pc: int,
             for _ in range(iterations):
                 body_result = _get_iflow(program, graph,
                                          body_loc.loop_start_pc, constants,
-                                         body_loc.loop_end_pc, cache)
+                                         body_loc.loop_end_pc, cache, coarse_dmem)
 
                 iflow = _get_iflow_update_state(body_result, iflow,
                                                 program_end_iflow,
@@ -406,6 +432,10 @@ def _get_iflow(program: ACCProgram, graph: ControlGraph, start_pc: int,
 
             # Set the next edges to the instruction after the loop ends
             edges = [ControlLoc(body_loc.loop_end_pc + 4)]
+        else:
+            # If the number of loop iterations is not constant, fall back to
+            # treating this as a cycle.
+            cycles[start_pc] = InformationFlowGraph.empty()
 
     elif last_insn.mnemonic == 'jal' and last_op_vals['grd'] == 1:
         # Special handling for jumps; recursive call for jump destination, then
@@ -417,7 +447,7 @@ def _get_iflow(program: ACCProgram, graph: ControlGraph, start_pc: int,
         assert len(edges) == 1 and not edges[0].is_special()
         jump_loc = edges[0]
         jump_result = _get_iflow(program, graph, jump_loc.pc, constants, None,
-                                 cache)
+                                 cache, coarse_dmem)
         iflow = _get_iflow_update_state(jump_result, iflow, program_end_iflow,
                                         used_constants, constants, cycles,
                                         control_deps, loop_iters)
@@ -452,7 +482,7 @@ def _get_iflow(program: ACCProgram, graph: ControlGraph, start_pc: int,
 
             # update used_constants to reflect that we read the branch constants
             used_constant_nodes = iflow.sources_for_any([grs1, grs2])
-            used_constants.update(used_constant_nodes)
+            used_constants.update([n.name for n in used_constant_nodes])
     else:
         # Update the constants to include the last instruction
         constants.update_insn(last_insn, last_op_vals)
@@ -483,7 +513,7 @@ def _get_iflow(program: ACCProgram, graph: ControlGraph, start_pc: int,
         elif isinstance(loc, LoopStart) or not loc.is_special():
             # Just a normal PC; recurse
             result = _get_iflow(program, graph, loc.pc, constants, loop_end_pc,
-                                cache)
+                                cache, coarse_dmem)
 
             # Defensively copy constants so they don't cross between branches
             local_constants = deepcopy(constants)
@@ -513,8 +543,8 @@ def _get_iflow(program: ACCProgram, graph: ControlGraph, start_pc: int,
         # If there is no return branch, we would expect common_consts to be
         # None.
         assert return_iflow.exists
-        used_constants.update(
-            return_iflow.sources_for_any(common_consts.values.keys()))
+        used_constant_nodes = return_iflow.sources_for_any(common_consts.values.keys())
+        used_constants.update([n.name for n in used_constant_nodes])
 
     # If this PC is the start of one of the cycles we're currently processing,
     # see if it can be finalized.
@@ -525,14 +555,14 @@ def _get_iflow(program: ACCProgram, graph: ControlGraph, start_pc: int,
         # the cycle)
         stable_constants = ConstantContext.empty()
         for k, v in start_constants.values.items():
-            if k not in cycle_iflow.all_sinks():
+            if not any([s for s in cycle_iflow.all_sinks() if s.name == k]):
                 stable_constants.set(k, v)
 
         # If any start constants were modified during the cycle; do a recursive
         # call with only the unmodified constants, and return that.
         if not stable_constants.includes(start_constants):
             return _get_iflow(program, graph, start_pc, stable_constants,
-                              loop_end_pc, cache)
+                              loop_end_pc, cache, coarse_dmem)
 
         # If all starting constants were stable, just loop() the information
         # flow graph for this cycle to get the combined flow for all paths that
@@ -552,7 +582,7 @@ def _get_iflow(program: ACCProgram, graph: ControlGraph, start_pc: int,
 
         # Control-flow dependencies must also be updated to include the
         # dependencies stemming from any valid traversal of the cycle
-        new_control_deps: Dict[str, Set[int]] = {}
+        new_control_deps: Dict[InformationFlowNode, Set[int]] = {}
         _update_control_deps(new_control_deps, cycle_iflow, control_deps)
         control_deps = new_control_deps
 
@@ -564,7 +594,10 @@ def _get_iflow(program: ACCProgram, graph: ControlGraph, start_pc: int,
     return_iflow.remove_sink('x0')
     program_end_iflow.remove_source('x0')
     program_end_iflow.remove_sink('x0')
-    control_deps.pop('x0', None)
+    control_deps.pop(InformationFlowNode('x0'), None)
+
+    # Unify adjacent nodes in control dependencies.
+    control_deps = simplify_control_deps(control_deps)
 
     # Update the cache and return
     out = (used_constants, return_iflow, program_end_iflow, common_consts,
@@ -574,9 +607,23 @@ def _get_iflow(program: ACCProgram, graph: ControlGraph, start_pc: int,
     return out
 
 
+def get_dmem_symbols(program: ACCProgram) -> Dict[str, int]:
+    symbols = {}
+    for sym in program.symbols:
+        if sym.startswith('_'):
+            continue
+        if sym not in program.symbol_sections:
+            continue
+        if program.symbol_sections[sym] not in ['.data', '.bss', '.scratchpad']:
+            continue
+        symbols[sym] = program.symbols[sym]
+    return symbols
+
+
 def get_subroutine_iflow(program: ACCProgram, graph: ControlGraph,
                          subroutine_name: str,
-                         start_constants: Dict[str, int]) -> SubroutineIFlow:
+                         start_constants: Dict[str, int],
+                         coarse_dmem: bool) -> SubroutineIFlow:
     '''Gets the information-flow graphs for the subroutine.
 
     Returns three items:
@@ -595,7 +642,7 @@ def get_subroutine_iflow(program: ACCProgram, graph: ControlGraph,
     constants = ConstantContext(start_constants)
     start_pc = program.get_pc_at_symbol(subroutine_name)
     _, ret_iflow, end_iflow, _, cycles, control_deps, _ = _get_iflow(
-        program, graph, start_pc, constants, None, IFlowCache())
+        program, graph, start_pc, constants, None, IFlowCache(), coarse_dmem)
     if cycles:
         for pc in cycles:
             print(cycles[pc].pretty())
@@ -605,11 +652,13 @@ def get_subroutine_iflow(program: ACCProgram, graph: ControlGraph,
     if not (ret_iflow.exists or end_iflow.exists):
         raise ValueError('Could not find any complete control-flow paths when '
                          'analyzing subroutine.')
+    if not ret_iflow.exists:
+        print('WARNING: no paths in this subroutine appear to return to the caller.')
     return ret_iflow, end_iflow, control_deps
 
 
 def get_program_iflow(program: ACCProgram,
-                      graph: ControlGraph) -> ProgramIFlow:
+                      graph: ControlGraph, coarse_dmem: bool) -> ProgramIFlow:
     '''Gets the information-flow graph for the whole program.
 
     Returns two items:
@@ -620,7 +669,7 @@ def get_program_iflow(program: ACCProgram,
     '''
     _, ret_iflow, end_iflow, _, cycles, control_deps, _ = _get_iflow(
         program, graph, program.min_pc(), ConstantContext.empty(), None,
-        IFlowCache())
+        IFlowCache(), coarse_dmem)
     if cycles:
         raise RuntimeError('Unresolved cycles; start PCs: {}'.format(', '.join(
             ['{:#x}'.format(k) for k in cycles.keys()])))
@@ -634,7 +683,7 @@ def get_program_iflow(program: ACCProgram,
 
 def get_subroutine_loop_iters(
         program: ACCProgram, graph: ControlGraph, subroutine_name: str,
-        start_constants: Dict[str, int]) -> Dict[int, int]:
+        start_constants: Dict[str, int], coarse_dmem: bool) -> Dict[int, Set[int]]:
     '''Gets the loop iteration counts for the subroutine.
 
     Returns a dictionary which maps
@@ -650,7 +699,7 @@ def get_subroutine_loop_iters(
     constants = ConstantContext(start_constants)
     start_pc = program.get_pc_at_symbol(subroutine_name)
     _, ret_iflow, end_iflow, _, cycles, _, loop_iters = _get_iflow(
-        program, graph, start_pc, constants, None, IFlowCache())
+        program, graph, start_pc, constants, None, IFlowCache(), coarse_dmem)
     if cycles:
         for pc in cycles:
             print(cycles[pc].pretty())
@@ -664,7 +713,7 @@ def get_subroutine_loop_iters(
 
 
 def stringify_control_deps(program: ACCProgram,
-                           control_deps: Dict[str, Set[int]]) -> List[str]:
+                           control_deps: Dict[InformationFlowNode, Set[int]]) -> List[str]:
     '''Compute string representations of nodes that influence control flow.
 
     Returns a list of strings, each representing one node that influences
@@ -676,34 +725,61 @@ def stringify_control_deps(program: ACCProgram,
       input: {'x2' : {0x44, 0x55}, 'x3': {0x44}}
       output: ['x2 (via beq at 0x44, bne at 0x55)', 'x3 (via beq at 0x44)']
     '''
-    out = []
+    control_deps = simplify_control_deps(control_deps)
+    symbols = get_dmem_symbols(program)
+    # if any overlapping nodes affect control flow at the same PCs, unify them
+    dedup_control_deps = {}
     for node, pcs in control_deps.items():
+        if any([n.overlaps(node) and pcs == dedup_control_deps[n] for n in dedup_control_deps]):
+            # there is already an overlapping node with the same PCs, meaning
+            # we've already processed this node
+            continue
+        for other in control_deps:
+            if pcs == control_deps[other] and node.overlaps(other):
+                node = node.union(other)
+        dedup_control_deps[node] = pcs
+    out = []
+    for node, pcs in dedup_control_deps.items():
         pc_strings = []
         if len(pcs) == 0:
             continue
         for pc in pcs:
             insn = program.get_insn(pc)
             pc_strings.append('{} at PC {:#x}'.format(insn.mnemonic, pc))
-        out.append('{} (via {})'.format(node, ', '.join(pc_strings)))
+        out.append('{} (via {})'.format(','.join(node.pretty(symbols)), ', '.join(pc_strings)))
     return out
 
 
-def parse_information_flow_node(x: str) -> str:
+def parse_information_flow_node(program: ACCProgram,
+                                x: str, coarse_dmem: bool) -> InformationFlowNode:
     '''Parse a named information-flow node.
 
     Accepts:
-    - register names e.g. "x20", "w1"
-    - special strings like "dmem" and "mod"
+    - register names e.g. "x20", "w1", "mod"
+    - "dmem" (if coarse_dmem is True)
+    - dmem ranges with labels, e.g. "dmem:sk[32:64]" (if coarse_dmem is False)
     '''
     if x == 'dmem':
-        return x
+        if not coarse_dmem:
+            raise ValueError('{x} is not a valid node with fine-grained dmem tracking')
+        return InformationFlowNode(x)
     if x in SPECIAL_REG_NAMES:
-        return x
-    # try to match as a register
-    m = re.match(r'[wx]([0-9]+)', x)
+        return InformationFlowNode(x)
+    # try to match with the dmem location regex pattern
+    m = re.match(r'dmem:(.*)\[:([0-9]+)\]', x)
     if m is None:
-        raise ValueError(f'Malformatted node: {x}')
-    idx = int(m.group(1))
-    if not 0 <= idx < 32:
-        raise ValueError(f'Invalid register index: {x}')
-    return x
+        # try to match as a register
+        m = re.match(r'[wx]([0-9]+)', x)
+        if m is None:
+            raise ValueError(f'Malformatted node: {x}')
+        idx = int(m.group(1))
+        if not 0 <= idx < 32:
+            raise ValueError(f'Invalid register index: {x}')
+        return InformationFlowNode(x)
+    else:
+        if coarse_dmem:
+            return InformationFlowNode('dmem')
+        label = m.group(1)
+        length = int(m.group(2))
+        start = program.get_pc_at_symbol(label)
+        return DmemInformationFlowNode(start, start + length)

--- a/hw/ip/acc/util/shared/instruction_count_range.py
+++ b/hw/ip/acc/util/shared/instruction_count_range.py
@@ -199,7 +199,7 @@ def program_insn_count_range(program: ACCProgram,
     if thru_label is not None:
         subroutine_graph = subroutine_control_graph(program, thru_label)
         loop_iters = get_subroutine_loop_iters(program, subroutine_graph, thru_label,
-                                               {})
+                                               {}, coarse_dmem=True)
     else:
         loop_iters = {}
     program_graph = program_control_graph(program)

--- a/rules/acc.bzl
+++ b/rules/acc.bzl
@@ -297,6 +297,8 @@ def _acc_consttime_test_impl(ctx):
         script_content += " --public {}".format(" ".join(ctx.attr.public))
     if ctx.attr.initial_constants:
         script_content += " --constants {}".format(" ".join(ctx.attr.initial_constants))
+    if ctx.attr.track_dmem:
+        script_content += " --track-dmem"
     ctx.actions.write(
         output = ctx.outputs.executable,
         content = script_content,
@@ -576,6 +578,7 @@ acc_consttime_test = rule(
         "secret": attr.string_list(),
         "public": attr.string_list(),
         "initial_constants": attr.string_list(),
+        "track_dmem": attr.bool(default = False),
         "_checker": attr.label(
             default = "//hw/ip/acc/util:check_const_time",
             executable = True,


### PR DESCRIPTION
On top of https://github.com/zerorisc/expo/pull/246, draft until that is merged.

This commit reworks the information-flow backend to represent DMEM as well as just registers. Previously, registers were simply represented by their names. In theory we could represent every byte of DMEM this way, but in practice this is too slow; instead, we generalize everything to use "nodes" which can be either registers or DMEM ranges, and introduce the concept that nodes can overlap with one another and be merged or split.

This commit also makes a few small adjustments to how ISRs and loops are handled. These changes were necessary to handle P-256 and P-384 signing, which were previously outside the capabilities of the information-flow tools and which I was using as a test case.

Ideally the above fixups would be more separated out from the DMEM change but life is imperfect and so am I.