### PR TITLE
[acc] Expand constant-time coverage for ACC tests.

### DIFF
--- a/hw/ip/acc/util/shared/constants.py
+++ b/hw/ip/acc/util/shared/constants.py
@@ -4,9 +4,11 @@
 # Licensed under the Apache License, Version 2.0, see LICENSE for details.
 # SPDX-License-Identifier: Apache-2.0
 
+import re
 from copy import deepcopy
 from typing import Any, Dict, Iterable, List, Optional
 
+from .information_flow import DmemInformationFlowNode
 from .insn_yaml import Insn
 from .operand import RegOperandType
 
@@ -19,10 +21,10 @@ def get_op_val_str(insn: Insn, op_vals: Dict[str, int], opname: str) -> str:
 
 
 class ConstantContext:
-    '''Represents known-constant GPRs.
+    '''Represents known-constant GPRs and memory words.
 
     This datatype is used to track and evaluate GPR pointers for indirect
-    references.
+    references and memory offsets.
     '''
 
     def __init__(self, values: Dict[str, int]):
@@ -35,16 +37,16 @@ class ConstantContext:
         '''Represents a context with no known constants.'''
         return ConstantContext({'x0': 0})
 
-    def set(self, gpr: str, value: int) -> None:
-        '''Set the value of a GPR in the context.'''
-        if gpr == 'x0':
+    def set(self, key: str, value: int) -> None:
+        '''Set the value of a GPR or memory address in the context.'''
+        if key == 'x0':
             # Ignore writes to x0; it's read-only.
             return
-        self.values[gpr] = value
+        self.values[key] = value
 
-    def get(self, gpr: str) -> Optional[int]:
-        '''Get the value of a GPR in the context.'''
-        return self.values.get(gpr, None)
+    def get(self, key: str) -> Optional[int]:
+        '''Get the value of a GPR or memory address in the context.'''
+        return self.values.get(key, None)
 
     def __contains__(self, gpr: str) -> bool:
         return gpr in self.values
@@ -82,7 +84,7 @@ class ConstantContext:
             if reg != 'x0':
                 self.values.pop(reg, None)
 
-    def update_insn(self, insn: Insn, op_vals: Dict[str, int]) -> None:
+    def update_insn(self, insn: Insn, op_vals: Dict[str, int], coarse_dmem: bool) -> None:
         '''Updates to new known constant values GPRs after the instruction.
 
         Currently, this procedure supports only a limited set of instructions.
@@ -132,6 +134,21 @@ class ConstantContext:
         elif insn.mnemonic == 'lui':
             grd_name = get_op_val_str(insn, op_vals, 'grd')
             new_values[grd_name] = op_vals['imm'] << 12
+        elif insn.mnemonic == 'lw' and not coarse_dmem:
+            grd_name = get_op_val_str(insn, op_vals, 'grd')
+            grs1_name = get_op_val_str(insn, op_vals, 'grs1')
+            if grs1_name in self.values:
+                addr = (self.values[grs1_name] + op_vals['offset']) % (1 << 32)
+                src_name = DmemInformationFlowNode(addr, addr + 4).name
+                if src_name in self.values:
+                    new_values[grd_name] = self.values[src_name]
+        elif insn.mnemonic == 'sw' and not coarse_dmem:
+            grs1_name = get_op_val_str(insn, op_vals, 'grs1')
+            grs2_name = get_op_val_str(insn, op_vals, 'grs2')
+            if grs1_name in self.values and grs2_name in self.values:
+                addr = (self.values[grs1_name] + op_vals['offset']) % (1 << 32)
+                dest_name = DmemInformationFlowNode(addr, addr + 4).name
+                new_values[dest_name] = self.values[grs2_name]
         elif insn.mnemonic in ['bn.lid', 'bn.sid', 'bn.movr']:
             # If the instruction has any op_vals ending in _inc,
             # assume we're incrementing the corresponding register
@@ -157,8 +174,37 @@ class ConstantContext:
         self.values.update(new_values)
 
 
-def is_gpr_name(name: str):
+def _parse_constant(value: str, dmem_symbols: Dict[str, int]) -> int:
+    '''Interprets a value from a literal (decimal or hex) or DMEM symbol.'''
+    try:
+        if value.startswith('0x'):
+            return int(value, 16)
+        elif value in dmem_symbols:
+            return dmem_symbols[value]
+        return int(value)
+    except ValueError:
+        raise ValueError(
+            f'Cannot parse required constant: {value} is not a '
+            'recognized numeric value or DMEM label.')
+
+
+def is_gpr_name(name: str) -> bool:
     return name in [f'x{i}' for i in range(32)]
+
+
+def parse_dmem_slot(token: str, dmem_symbols: str) -> Optional[int]:
+    m = re.match(r'dmem:(.*)\[:([0-9]+)\]:(.*)', token)
+    if m is None:
+        raise ValueError(f'Cannot interpret constant: {token}')
+    label = m.group(1)
+    length = int(m.group(2))
+    if length != 4:
+        raise ValueError(f'Cannot interpret {token} as a constant: constant '
+                         'DMEM slots must be exactly 4 bytes.')
+    value = m.group(3)
+    start = _parse_constant(label, dmem_symbols)
+    value = _parse_constant(value, dmem_symbols)
+    return DmemInformationFlowNode(start, start + length).name, value
 
 
 def parse_required_constants(constants: List[str],
@@ -174,6 +220,11 @@ def parse_required_constants(constants: List[str],
 
     out = {}
     for token in constants:
+        if token.startswith('dmem'):
+            name, value = parse_dmem_slot(token, dmem_symbols)
+            out[name] = value
+            continue
+
         reg_and_value = token.split(':')
         if len(reg_and_value) != 2:
             raise ValueError(
@@ -183,18 +234,8 @@ def parse_required_constants(constants: List[str],
         if not is_gpr_name(reg):
             raise ValueError(
                 f'Cannot parse required constant {token}: {reg} is not a '
-                'valid GPR name.')
-        try:
-            if value.startswith('0x'):
-                value = int(value, 16)
-            elif value in dmem_symbols:
-                value = dmem_symbols[value]
-            else:
-                value = int(value)
-        except ValueError:
-            raise ValueError(
-                f'Cannot parse required constant {token}: {value} is not a '
-                'recognized numeric value or DMEM label.')
+                'valid GPR name or 4-byte DMEM slot.')
+        value = _parse_constant(value, dmem_symbols)
         if value < 0 or value > GPR_MAX:
             raise ValueError(
                 f'Cannot parse required constant {token}: {value} is out of '

--- a/hw/ip/acc/util/shared/information_flow_analysis.py
+++ b/hw/ip/acc/util/shared/information_flow_analysis.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import re
+import sys
 from copy import deepcopy
 from typing import Dict, List, Optional, Set, Tuple
 
@@ -102,8 +103,10 @@ def _build_iflow_insn(
     constant_deps = insn.iflow.required_constants(op_vals, coarse_dmem)
     for const in constant_deps:
         if const not in constants:
-            raise ValueError(
-                'Could not construct information flow because {} is '
+            # rather than raising an exception in this case, print and exit to
+            # avoid a messy stack trace that is not usually helpful
+            print(
+                'ERROR: Could not construct information flow because {} is '
                 'not a known constant at PC {:#x}:'
                 '\n{}'
                 '\n\nKnown constants: {}'
@@ -111,7 +114,8 @@ def _build_iflow_insn(
                 'need to add constant-tracking support for more '
                 'instructions.'.format(const, pc,
                                        insn.disassemble(pc, op_vals),
-                                       list(constants.values.keys())))
+                                       sorted(list(constants.values.keys()))))
+            sys.exit(1)
 
     return constant_deps, insn.iflow.evaluate(op_vals, constants.values, coarse_dmem)
 
@@ -178,7 +182,7 @@ def _build_iflow_straightline(
         iflow = iflow.seq(insn_iflow)
 
         # Update constants to their values after the instruction
-        constants.update_insn(insn, op_vals)
+        constants.update_insn(insn, op_vals, coarse_dmem)
 
     return constant_deps, iflow
 
@@ -411,7 +415,7 @@ def _get_iflow(program: ACCProgram, graph: ControlGraph, start_pc: int,
                                                    constants)
 
         # Update the constants to include the loop instruction
-        constants.update_insn(last_insn, last_op_vals)
+        constants.update_insn(last_insn, last_op_vals, coarse_dmem)
 
         if iterations is not None:
             # If the number of iterations is constant, perform recursive calls
@@ -440,7 +444,7 @@ def _get_iflow(program: ACCProgram, graph: ControlGraph, start_pc: int,
     elif last_insn.mnemonic == 'jal' and last_op_vals['grd'] == 1:
         # Special handling for jumps; recursive call for jump destination, then
         # continue at pc+4
-        constants.update_insn(last_insn, last_op_vals)
+        constants.update_insn(last_insn, last_op_vals, coarse_dmem)
 
         # Jumps should produce exactly one non-special edge; check that
         # assumption before we rely on it
@@ -485,7 +489,7 @@ def _get_iflow(program: ACCProgram, graph: ControlGraph, start_pc: int,
             used_constants.update([n.name for n in used_constant_nodes])
     else:
         # Update the constants to include the last instruction
-        constants.update_insn(last_insn, last_op_vals)
+        constants.update_insn(last_insn, last_op_vals, coarse_dmem)
 
     # We're only returning constants that are the same in all RET branches
     common_consts = None
@@ -667,8 +671,9 @@ def get_program_iflow(program: ACCProgram,
     2. The information-flow nodes whose values at the start of the subroutine
        influence its control flow.
     '''
+    start_constants = ConstantContext({'x0': 0})
     _, ret_iflow, end_iflow, _, cycles, control_deps, _ = _get_iflow(
-        program, graph, program.min_pc(), ConstantContext.empty(), None,
+        program, graph, program.min_pc(), start_constants, None,
         IFlowCache(), coarse_dmem)
     if cycles:
         raise RuntimeError('Unresolved cycles; start PCs: {}'.format(', '.join(

--- a/sw/acc/crypto/mlkem/mlkem_decap.s
+++ b/sw/acc/crypto/mlkem/mlkem_decap.s
@@ -365,6 +365,10 @@ crypto_kem_dec:
   bn.wsrr w8, 0xA /* KECCAK_DIGEST */
   bn.sid  t0, 0(a2++) /* Store into buffer */
 
+/* This label is an entrypoint for the consttime checker, to ensure that the
+ * ciphertext comparison timing does not depend on the provided ciphertext. */
+_decap_ciphertext_compare_label_for_consttime_check:
+
   /*** verify (constant-time): ct == cmp ? w4 = 0 : w4 = all-ones ***/
   li      t0, 0
   li      t1, 1

--- a/sw/acc/crypto/tests/BUILD
+++ b/sw/acc/crypto/tests/BUILD
@@ -417,19 +417,20 @@ acc_consttime_test(
     ],
 )
 
-# TODO: Add more fine-grained DMEM tracing to the constant-time checker. This
-# test fails because p256_sign branches based on some non-secret values from
-# DMEM. However, since there are also secret values in DMEM, it's not safe to
-# mark DMEM non-secret, and the constant-time checker doesn't currently have
-# the ability to track different DMEM regions separately.
-#
-# acc_consttime_test(
-#   name = "p256_sign_consttime",
-#   deps = [
-#       "//sw/acc/crypto:run_p256"
-#   ],
-#   subroutine = "p256_sign",
-# )
+acc_consttime_test(
+    name = "p256_sign_consttime",
+    secret = [
+        "dmem:k0[:64]",
+        "dmem:k1[:64]",
+        "dmem:d0[:64]",
+        "dmem:d1[:64]",
+    ],
+    subroutine = "p256_sign",
+    track_dmem = True,
+    deps = [
+        ":p256_ecdsa_sign_test",
+    ],
+)
 
 acc_sim_test(
     name = "p256_ecdsa_sign_test",
@@ -845,7 +846,7 @@ acc_consttime_test(
     secret = ["dmem"],
     subroutine = "p384_base_mult",
     deps = [
-        ":p384_base_mult_test",
+        "//sw/acc/crypto:run_p384",
     ],
 )
 
@@ -853,7 +854,7 @@ acc_consttime_test(
     name = "p384_scalar_mult_consttime",
     subroutine = "p384_scalar_mult",
     deps = [
-        ":p384_scalar_mult_test",
+        "//sw/acc/crypto:run_p384",
     ],
 )
 
@@ -861,7 +862,7 @@ acc_consttime_test(
     name = "p384_mulmod_p_consttime",
     subroutine = "p384_mulmod_p",
     deps = [
-        ":p384_ecdsa_sign_test",
+        "//sw/acc/crypto:run_p384",
     ],
 )
 
@@ -869,23 +870,24 @@ acc_consttime_test(
     name = "p384_mulmod_n_consttime",
     subroutine = "p384_mulmod_n",
     deps = [
-        ":p384_ecdsa_sign_test",
+        "//sw/acc/crypto:run_p384",
     ],
 )
 
-# TODO: Add more fine-grained DMEM tracing to the constant-time checker. This
-# test fails because p384_sign branches based on some non-secret values from
-# DMEM. However, since there are also secret values in DMEM, it's not safe to
-# mark DMEM non-secret, and the constant-time checker doesn't currently have
-# the ability to track different DMEM regions separately.
-#
-# acc_consttime_test(
-#   name = "p384_sign_consttime",
-#   deps = [
-#       ":p384_ecdsa_sign_test"
-#   ],
-#   subroutine = "p384_sign",
-# )
+acc_consttime_test(
+    name = "p384_sign_consttime",
+    secret = [
+        "dmem:k0[:64]",
+        "dmem:k1[:64]",
+        "dmem:d0[:64]",
+        "dmem:d1[:64]",
+    ],
+    subroutine = "p384_sign",
+    track_dmem = True,
+    deps = [
+        "//sw/acc/crypto:run_p384",
+    ],
+)
 
 acc_consttime_test(
     name = "proj_add_p384_consttime",
@@ -897,7 +899,7 @@ acc_consttime_test(
     ],
     subroutine = "proj_add_p384",
     deps = [
-        ":p384_ecdsa_sign_test",
+        "//sw/acc/crypto:run_p384",
     ],
 )
 

--- a/sw/acc/crypto/tests/mldsa/BUILD
+++ b/sw/acc/crypto/tests/mldsa/BUILD
@@ -217,3 +217,75 @@ acc_sim_test(
         "//sw/acc/crypto/mldsa:mldsa44_rounding",
     ],
 )
+
+SIGN_CONSTTIME_SUBROUTINES = [
+    "intt",
+    "ntt",
+    "poly_add",
+    "poly_chknorm",
+    "poly_decompose",
+    "poly_nonzero_encode",
+    "poly_reduce32",
+    "poly_sub",
+    "poly_pointwise",
+    "poly_pointwise_acc",
+    "poly_uniform_gamma_1",
+    "polyeta_unpack",
+    "polyt0_unpack",
+    "polyw1_pack",
+    "polyz_pack",
+    # The constant-time checker cannot handle the logic-dependent memory accesses
+    # of encode_h, make_hint, poly_challenge, poly_uniform, and poly_uniform_eta
+    # -- even though the logic does not depend on secret data, the information
+    # flow through DMEM cannot be constructed without knowing where the loads and
+    # stores are going. Luckily these routines don't handle secret data anyway
+    # (except for poly_unifom_eta).
+    #
+    # TODO: adding a capability to the information-flow analysis backend that can
+    # store the possible *range* of a GPR in a certain control-flow path, so that
+    # memory loads/stores can be conservatively mapped to the the whole range,
+    # would likely solve this.
+]
+
+[
+    acc_consttime_test(
+        name = params + "_" + subroutine + "_consttime",
+        subroutine = subroutine,
+        deps = [
+            ":" + params + "_sign_test0",
+        ],
+    )
+    for subroutine in SIGN_CONSTTIME_SUBROUTINES
+    for params in MLDSA_PARAMS
+]
+
+# keccak_send_message is special because the length argument affects control
+# flow, so we need to explicitly say the secrets are in dmem
+acc_consttime_test(
+    name = "keccak_send_message_consttime",
+    secret = ["dmem"],
+    subroutine = "keccak_send_message",
+    deps = [
+        ":mldsa44_sign_test0",
+    ],
+)
+
+# This list only contains subroutines that do not overlap with sign.
+KEYPAIR_CONSTTIME_SUBROUTINES = [
+    "poly_power2round",
+    "polyeta_pack",
+    "polyt0_pack",
+    "polyt1_pack",
+]
+
+[
+    acc_consttime_test(
+        name = params + "_" + subroutine + "_consttime",
+        subroutine = subroutine,
+        deps = [
+            ":" + params + "_keypair_test0",
+        ],
+    )
+    for subroutine in KEYPAIR_CONSTTIME_SUBROUTINES
+    for params in MLDSA_PARAMS
+]

--- a/sw/acc/crypto/tests/mlkem/BUILD
+++ b/sw/acc/crypto/tests/mlkem/BUILD
@@ -257,6 +257,15 @@ DECAP_CONSTTIME_SUBROUTINES = [
     for params in MODE_FOR_PARAMS
 ]
 
+# Special check to ensure the ciphertext comparison is constant-time.
+acc_consttime_test(
+    name = "decap_ciphertext_compare_consttime",
+    subroutine = "_decap_ciphertext_compare_label_for_consttime_check",
+    deps = [
+        ":mlkem512_decap_test0",
+    ],
+)
+
 # Includes only subroutines not shared with encap or decap.
 KEYPAIR_CONSTTIME_SUBROUTINES = [
     "pack_sk",

--- a/sw/acc/crypto/tests/mlkem/BUILD
+++ b/sw/acc/crypto/tests/mlkem/BUILD
@@ -185,3 +185,93 @@ py_binary(
     for i in range(NTESTS)
     for params in MODE_FOR_PARAMS
 ]
+
+ENCAP_CONSTTIME_SUBROUTINES = [
+    "basemul",
+    "basemul_acc",
+    "intt",
+    "ntt",
+    "pack_ciphertext",
+    "poly_add",
+    "poly_frommsg",
+    "poly_gen_matrix_init",
+    "poly_getnoise_eta_init",
+    "poly_getnoise_eta_1",
+    "poly_getnoise_eta_2",
+    "unpack_pk",
+
+    # The constant-time checker cannot handle the logic-dependent memory accesses
+    # of the following routines -- even though the logic does not depend on
+    # secret data, the information flow through DMEM cannot be constructed
+    # without knowing where the loads and stores are going.
+    #
+    # TODO: adding a capability to the information-flow analysis backend that can
+    # store the possible *range* of a GPR in a certain control-flow path, so that
+    # memory loads/stores can be conservatively mapped to the the whole range,
+    # would likely solve this.
+
+    # "poly_gen_matrix",
+]
+
+# keccak_send_message is special because the length argument affects control
+# flow, so we need to explicitly say the secrets are in dmem
+acc_consttime_test(
+    name = "keccak_send_message_consttime",
+    secret = ["dmem"],
+    subroutine = "keccak_send_message",
+    deps = [
+        ":mlkem512_encap_test0",
+    ],
+)
+
+[
+    acc_consttime_test(
+        name = params + "_" + subroutine + "_consttime",
+        subroutine = subroutine,
+        deps = [
+            ":" + params + "_encap_test0",
+        ],
+    )
+    for subroutine in ENCAP_CONSTTIME_SUBROUTINES
+    for params in MODE_FOR_PARAMS
+]
+
+# Includes only subroutines not shared with encap.
+DECAP_CONSTTIME_SUBROUTINES = [
+    "indcpa_dec",
+    "poly_sub",
+    "poly_tomsg",
+    "unpack_ciphertext",
+    "unpack_sk",
+]
+
+[
+    acc_consttime_test(
+        name = params + "_" + subroutine + "_consttime",
+        subroutine = subroutine,
+        deps = [
+            ":" + params + "_decap_test0",
+        ],
+    )
+    for subroutine in DECAP_CONSTTIME_SUBROUTINES
+    for params in MODE_FOR_PARAMS
+]
+
+# Includes only subroutines not shared with encap or decap.
+KEYPAIR_CONSTTIME_SUBROUTINES = [
+    "pack_sk",
+    "pack_pk",
+    "poly_tomont",
+]
+
+[
+    acc_consttime_test(
+        name = params + "_" + subroutine + "_consttime",
+        subroutine = subroutine,
+        deps = [
+            ":" + params + "_keypair_test0",
+        ],
+    )
+    for subroutine in KEYPAIR_CONSTTIME_SUBROUTINES
+    for params in MODE_FOR_PARAMS
+]


### PR DESCRIPTION
On top of https://github.com/zerorisc/expo/pull/247, draft until that is merged.

Using the recently improved capabilities of the constant-time checker from #246 and #247, add more checks to for ACC code for routines that were previously outside the checker's capabilities or otherwise not checked. This includes:
- P-256 and P-384 ECDSA signing
- various ML-KEM and ML-DSA subroutines

Unfortunately, we can't check full operations like sign or decaps for ML-KEM/ML-DSA because the checker struggles to reason about the memory access pattern of the matrix expansion -- because the pattern of writes depends on the SHAKE data, it can't statically tell what is getting written. We could consider fixes to this like extending the checker to consider the possible _range_ of addresses at a given index instead of requiring the addresses to be constant, or allowing some way for the user to assert that writes stay in a certain range. However, this would still not bring ML-DSA signing into scope; in an information-flow sense the number of iterations of the sign rejection loop does technically depend on the secret key, just not in an exploitable fashion.

For now, we check the PQC routines by just checking all the subroutines the checker can analyze (I searched for `jal` to find them) and in the case of ML-KEM adding a special label to check that the final comparison is constant-time relative to the ciphertext. I regression-tested that this check fails on an old non-constant-time version of the code.